### PR TITLE
style: modernize type annotations to PEP 604/585

### DIFF
--- a/a2a/a2a.py
+++ b/a2a/a2a.py
@@ -54,11 +54,7 @@ from dataclasses import dataclass, field, fields
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterator,
-    List,
-    Optional,
-    Tuple,
     Union,
 )
 
@@ -220,7 +216,7 @@ def _serialize(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return [_serialize(v) for v in obj]
     if hasattr(obj, "__dataclass_fields__"):
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         for f in fields(obj):
             val = getattr(obj, f.name)
             if val is None:
@@ -264,20 +260,20 @@ class Part:
         media_type: MIME type of the content.
     """
 
-    text: Optional[str] = None
-    raw: Optional[str] = None
-    url: Optional[str] = None
-    data: Optional[Any] = None
-    metadata: Optional[Dict[str, Any]] = None
-    filename: Optional[str] = None
-    media_type: Optional[str] = None
+    text: str | None = None
+    raw: str | None = None
+    url: str | None = None
+    data: Any | None = None
+    metadata: dict[str, Any] | None = None
+    filename: str | None = None
+    media_type: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "Part":
+    def from_dict(cls, d: dict[str, Any]) -> "Part":
         """Deserialize from a camelCase dictionary."""
         return cls(
             text=d.get("text"),
@@ -310,23 +306,23 @@ class Message:
 
     message_id: str = ""
     role: Role = Role.USER
-    parts: List[Part] = field(default_factory=list)
-    context_id: Optional[str] = None
-    task_id: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
-    extensions: Optional[List[str]] = None
-    reference_task_ids: Optional[List[str]] = None
+    parts: list[Part] = field(default_factory=list)
+    context_id: str | None = None
+    task_id: str | None = None
+    metadata: dict[str, Any] | None = None
+    extensions: list[str] | None = None
+    reference_task_ids: list[str] | None = None
 
     def __post_init__(self) -> None:
         if not self.message_id:
             self.message_id = str(uuid.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "Message":
+    def from_dict(cls, d: dict[str, Any]) -> "Message":
         """Deserialize from a camelCase dictionary."""
         role_val = d.get("role", "ROLE_USER")
         return cls(
@@ -358,22 +354,22 @@ class Artifact:
     """
 
     artifact_id: str = ""
-    parts: List[Part] = field(default_factory=list)
-    name: Optional[str] = None
-    description: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
-    extensions: Optional[List[str]] = None
+    parts: list[Part] = field(default_factory=list)
+    name: str | None = None
+    description: str | None = None
+    metadata: dict[str, Any] | None = None
+    extensions: list[str] | None = None
 
     def __post_init__(self) -> None:
         if not self.artifact_id:
             self.artifact_id = str(uuid.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "Artifact":
+    def from_dict(cls, d: dict[str, Any]) -> "Artifact":
         """Deserialize from a camelCase dictionary."""
         return cls(
             artifact_id=d.get("artifactId", ""),
@@ -399,19 +395,19 @@ class TaskStatus:
     """
 
     state: TaskState = TaskState.SUBMITTED
-    message: Optional[Message] = None
-    timestamp: Optional[str] = None
+    message: Message | None = None
+    timestamp: str | None = None
 
     def __post_init__(self) -> None:
         if self.timestamp is None:
             self.timestamp = _now_iso()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "TaskStatus":
+    def from_dict(cls, d: dict[str, Any]) -> "TaskStatus":
         """Deserialize from a camelCase dictionary."""
         msg = d.get("message")
         return cls(
@@ -439,21 +435,21 @@ class Task:
 
     id: str = ""
     status: TaskStatus = field(default_factory=TaskStatus)
-    context_id: Optional[str] = None
-    artifacts: Optional[List[Artifact]] = None
-    history: Optional[List[Message]] = None
-    metadata: Optional[Dict[str, Any]] = None
+    context_id: str | None = None
+    artifacts: list[Artifact] | None = None
+    history: list[Message] | None = None
+    metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if not self.id:
             self.id = str(uuid.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "Task":
+    def from_dict(cls, d: dict[str, Any]) -> "Task":
         """Deserialize from a camelCase dictionary."""
         artifacts_raw = d.get("artifacts")
         history_raw = d.get("history")
@@ -492,14 +488,14 @@ class TaskStatusUpdateEvent:
     task_id: str = ""
     context_id: str = ""
     status: TaskStatus = field(default_factory=TaskStatus)
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: dict[str, Any] | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "TaskStatusUpdateEvent":
+    def from_dict(cls, d: dict[str, Any]) -> "TaskStatusUpdateEvent":
         """Deserialize from a camelCase dictionary."""
         return cls(
             task_id=d.get("taskId", ""),
@@ -527,14 +523,14 @@ class TaskArtifactUpdateEvent:
     artifact: Artifact = field(default_factory=Artifact)
     append: bool = False
     last_chunk: bool = False
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: dict[str, Any] | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "TaskArtifactUpdateEvent":
+    def from_dict(cls, d: dict[str, Any]) -> "TaskArtifactUpdateEvent":
         """Deserialize from a camelCase dictionary."""
         return cls(
             task_id=d.get("taskId", ""),
@@ -559,12 +555,12 @@ class StreamResponse:
         artifact_update: A TaskArtifactUpdateEvent.
     """
 
-    task: Optional[Task] = None
-    message: Optional[Message] = None
-    status_update: Optional[TaskStatusUpdateEvent] = None
-    artifact_update: Optional[TaskArtifactUpdateEvent] = None
+    task: Task | None = None
+    message: Message | None = None
+    status_update: TaskStatusUpdateEvent | None = None
+    artifact_update: TaskArtifactUpdateEvent | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         if self.task is not None:
             return {"task": self.task.to_dict()}
@@ -577,7 +573,7 @@ class StreamResponse:
         return {}
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "StreamResponse":
+    def from_dict(cls, d: dict[str, Any]) -> "StreamResponse":
         """Deserialize from a camelCase dictionary."""
         task_d = d.get("task")
         msg_d = d.get("message")
@@ -604,14 +600,14 @@ class AuthenticationInfo:
     """
 
     scheme: str = "Bearer"
-    credentials: Optional[str] = None
+    credentials: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AuthenticationInfo":
+    def from_dict(cls, d: dict[str, Any]) -> "AuthenticationInfo":
         """Deserialize from a camelCase dictionary."""
         return cls(
             scheme=d.get("scheme", "Bearer"),
@@ -632,21 +628,21 @@ class PushNotificationConfig:
     """
 
     url: str = ""
-    id: Optional[str] = None
-    task_id: Optional[str] = None
-    token: Optional[str] = None
-    authentication: Optional[AuthenticationInfo] = None
+    id: str | None = None
+    task_id: str | None = None
+    token: str | None = None
+    authentication: AuthenticationInfo | None = None
 
     def __post_init__(self) -> None:
         if not self.id:
             self.id = str(uuid.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "PushNotificationConfig":
+    def from_dict(cls, d: dict[str, Any]) -> "PushNotificationConfig":
         """Deserialize from a camelCase dictionary."""
         auth = d.get("authentication")
         return cls(
@@ -669,17 +665,17 @@ class SendMessageConfiguration:
         return_immediately: If True, return without waiting for completion.
     """
 
-    accepted_output_modes: Optional[List[str]] = None
-    push_notification_config: Optional[PushNotificationConfig] = None
-    history_length: Optional[int] = None
+    accepted_output_modes: list[str] | None = None
+    push_notification_config: PushNotificationConfig | None = None
+    history_length: int | None = None
     return_immediately: bool = False
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "SendMessageConfiguration":
+    def from_dict(cls, d: dict[str, Any]) -> "SendMessageConfiguration":
         """Deserialize from a camelCase dictionary."""
         pnc = d.get("pushNotificationConfig") or d.get("taskPushNotificationConfig")
         return cls(
@@ -703,15 +699,15 @@ class SendMessageRequest:
     """
 
     message: Message = field(default_factory=Message)
-    configuration: Optional[SendMessageConfiguration] = None
-    metadata: Optional[Dict[str, Any]] = None
+    configuration: SendMessageConfiguration | None = None
+    metadata: dict[str, Any] | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "SendMessageRequest":
+    def from_dict(cls, d: dict[str, Any]) -> "SendMessageRequest":
         """Deserialize from a camelCase dictionary."""
         cfg = d.get("configuration")
         return cls(
@@ -730,10 +726,10 @@ class SendMessageResponse:
         message: A direct response message.
     """
 
-    task: Optional[Task] = None
-    message: Optional[Message] = None
+    task: Task | None = None
+    message: Message | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         if self.task is not None:
             return {"task": self.task.to_dict()}
@@ -742,7 +738,7 @@ class SendMessageResponse:
         return {}
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "SendMessageResponse":
+    def from_dict(cls, d: dict[str, Any]) -> "SendMessageResponse":
         """Deserialize from a camelCase dictionary."""
         task_d = d.get("task")
         msg_d = d.get("message")
@@ -767,12 +763,12 @@ class AgentProvider:
     organization: str = ""
     url: str = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AgentProvider":
+    def from_dict(cls, d: dict[str, Any]) -> "AgentProvider":
         """Deserialize from a camelCase dictionary."""
         return cls(
             organization=d.get("organization", ""),
@@ -792,16 +788,16 @@ class AgentExtension:
     """
 
     uri: str = ""
-    description: Optional[str] = None
+    description: str | None = None
     required: bool = False
-    params: Optional[Dict[str, Any]] = None
+    params: dict[str, Any] | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AgentExtension":
+    def from_dict(cls, d: dict[str, Any]) -> "AgentExtension":
         """Deserialize from a camelCase dictionary."""
         return cls(
             uri=d.get("uri", ""),
@@ -822,17 +818,17 @@ class AgentCapabilities:
         extended_agent_card: Whether an authenticated extended card is available.
     """
 
-    streaming: Optional[bool] = None
-    push_notifications: Optional[bool] = None
-    extensions: Optional[List[AgentExtension]] = None
-    extended_agent_card: Optional[bool] = None
+    streaming: bool | None = None
+    push_notifications: bool | None = None
+    extensions: list[AgentExtension] | None = None
+    extended_agent_card: bool | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AgentCapabilities":
+    def from_dict(cls, d: dict[str, Any]) -> "AgentCapabilities":
         """Deserialize from a camelCase dictionary."""
         exts = d.get("extensions")
         return cls(
@@ -860,17 +856,17 @@ class AgentSkill:
     id: str = ""
     name: str = ""
     description: str = ""
-    tags: List[str] = field(default_factory=list)
-    examples: Optional[List[str]] = None
-    input_modes: Optional[List[str]] = None
-    output_modes: Optional[List[str]] = None
+    tags: list[str] = field(default_factory=list)
+    examples: list[str] | None = None
+    input_modes: list[str] | None = None
+    output_modes: list[str] | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AgentSkill":
+    def from_dict(cls, d: dict[str, Any]) -> "AgentSkill":
         """Deserialize from a camelCase dictionary."""
         return cls(
             id=d.get("id", ""),
@@ -897,14 +893,14 @@ class AgentInterface:
     url: str = ""
     protocol_binding: str = "JSONRPC"
     protocol_version: str = "1.0"
-    tenant: Optional[str] = None
+    tenant: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AgentInterface":
+    def from_dict(cls, d: dict[str, Any]) -> "AgentInterface":
         """Deserialize from a camelCase dictionary."""
         return cls(
             url=d.get("url", ""),
@@ -937,23 +933,23 @@ class AgentCard:
     name: str = ""
     description: str = ""
     version: str = "1.0.0"
-    supported_interfaces: List[AgentInterface] = field(default_factory=list)
-    default_input_modes: List[str] = field(default_factory=lambda: ["text/plain"])
-    default_output_modes: List[str] = field(default_factory=lambda: ["text/plain"])
-    skills: List[AgentSkill] = field(default_factory=list)
-    capabilities: Optional[AgentCapabilities] = None
-    provider: Optional[AgentProvider] = None
-    documentation_url: Optional[str] = None
-    security_schemes: Optional[Dict[str, Any]] = None
-    security_requirements: Optional[List[Dict[str, Any]]] = None
-    icon_url: Optional[str] = None
+    supported_interfaces: list[AgentInterface] = field(default_factory=list)
+    default_input_modes: list[str] = field(default_factory=lambda: ["text/plain"])
+    default_output_modes: list[str] = field(default_factory=lambda: ["text/plain"])
+    skills: list[AgentSkill] = field(default_factory=list)
+    capabilities: AgentCapabilities | None = None
+    provider: AgentProvider | None = None
+    documentation_url: str | None = None
+    security_schemes: dict[str, Any] | None = None
+    security_requirements: list[dict[str, Any]] | None = None
+    icon_url: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to a camelCase dictionary."""
         return _serialize(self)
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "AgentCard":
+    def from_dict(cls, d: dict[str, Any]) -> "AgentCard":
         """Deserialize from a camelCase dictionary."""
         interfaces = d.get("supportedInterfaces", [])
         skills = d.get("skills", [])
@@ -987,7 +983,7 @@ class A2AError(JSONRPCException):
     code: int = INTERNAL_ERROR
     default_message: str = "Internal error"
 
-    def __init__(self, message: Optional[str] = None, data: Any = None):
+    def __init__(self, message: str | None = None, data: Any = None):
         self.rpc_message = message or self.default_message
         self.data = data
         super().__init__(
@@ -1057,7 +1053,7 @@ def sse_encode(data: Any) -> bytes:
 
 def sse_decode_stream(
     response: http.client.HTTPResponse,
-) -> Iterator[Dict[str, Any]]:
+) -> Iterator[dict[str, Any]]:
     """Parse an SSE stream from an ``http.client.HTTPResponse``.
 
     Reads lines from the response, extracts ``data:`` fields, and yields
@@ -1123,14 +1119,14 @@ class A2AClient:
 
     def __init__(
         self,
-        agent_card_url: Optional[str] = None,
-        base_url: Optional[str] = None,
-        headers: Optional[Dict[str, str]] = None,
+        agent_card_url: str | None = None,
+        base_url: str | None = None,
+        headers: dict[str, str] | None = None,
     ):
         self._base_url = base_url.rstrip("/") if base_url else None
         self._agent_card_url = agent_card_url
         self._headers = headers or {}
-        self._agent_card: Optional[AgentCard] = None
+        self._agent_card: AgentCard | None = None
 
     # --- Agent Card ---
 
@@ -1174,7 +1170,7 @@ class A2AClient:
     def _make_rpc_request(
         self,
         method: str,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         request_id: Union[str, int, None] = None,
     ) -> JSONRPCResponse:
         """Send a JSON-RPC request and return the parsed response.
@@ -1219,9 +1215,9 @@ class A2AClient:
     def _make_sse_request(
         self,
         method: str,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         request_id: Union[str, int, None] = None,
-    ) -> Iterator[Dict[str, Any]]:
+    ) -> Iterator[dict[str, Any]]:
         """Send a JSON-RPC request and stream SSE responses.
 
         Uses ``http.client`` for chunked/streaming reads.
@@ -1265,10 +1261,10 @@ class A2AClient:
         self,
         text: str,
         *,
-        task_id: Optional[str] = None,
-        context_id: Optional[str] = None,
-        configuration: Optional[SendMessageConfiguration] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        task_id: str | None = None,
+        context_id: str | None = None,
+        configuration: SendMessageConfiguration | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendMessageResponse:
         """Send a text message to the agent (blocking).
 
@@ -1302,10 +1298,10 @@ class A2AClient:
         self,
         text: str,
         *,
-        task_id: Optional[str] = None,
-        context_id: Optional[str] = None,
-        configuration: Optional[SendMessageConfiguration] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        task_id: str | None = None,
+        context_id: str | None = None,
+        configuration: SendMessageConfiguration | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> Iterator[StreamResponse]:
         """Send a text message and stream responses via SSE.
 
@@ -1339,7 +1335,7 @@ class A2AClient:
         self,
         task_id: str,
         *,
-        history_length: Optional[int] = None,
+        history_length: int | None = None,
     ) -> Task:
         """Retrieve the current state of a task.
 
@@ -1350,7 +1346,7 @@ class A2AClient:
         Returns:
             The current ``Task`` object.
         """
-        params: Dict[str, Any] = {"id": task_id}
+        params: dict[str, Any] = {"id": task_id}
         if history_length is not None:
             params["historyLength"] = history_length
         rpc_resp = self._make_rpc_request("GetTask", params)
@@ -1361,11 +1357,11 @@ class A2AClient:
     def list_tasks(
         self,
         *,
-        context_id: Optional[str] = None,
-        status: Optional[TaskState] = None,
-        page_size: Optional[int] = None,
-        page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        context_id: str | None = None,
+        status: TaskState | None = None,
+        page_size: int | None = None,
+        page_token: str | None = None,
+    ) -> dict[str, Any]:
         """List tasks with optional filtering.
 
         Args:
@@ -1377,7 +1373,7 @@ class A2AClient:
         Returns:
             Raw result dictionary with ``tasks``, ``nextPageToken``, etc.
         """
-        params: Dict[str, Any] = {}
+        params: dict[str, Any] = {}
         if context_id:
             params["contextId"] = context_id
         if status:
@@ -1485,7 +1481,7 @@ class A2ARequestHandler(http.server.BaseHTTPRequestHandler):
             else:
                 # Collect all into a list and return as a single JSON-RPC
                 # response with the last item.
-                last: Optional[JSONRPCResponse] = None
+                last: JSONRPCResponse | None = None
                 for item in stream:
                     last = item
                 if last is not None:
@@ -1585,14 +1581,14 @@ class A2AServer:
         self,
         host: str = "0.0.0.0",
         port: int = 8000,
-        agent_card: Optional[AgentCard] = None,
+        agent_card: AgentCard | None = None,
     ):
         self.host = host
         self.port = port
         self.dispatcher = JSONRPCDispatcher()
         self.agent_card = agent_card or AgentCard()
-        self._httpd: Optional[http.server.HTTPServer] = None
-        self._thread: Optional[threading.Thread] = None
+        self._httpd: http.server.HTTPServer | None = None
+        self._thread: threading.Thread | None = None
 
     def _create_server(self) -> http.server.HTTPServer:
         """Create and configure the HTTP server instance."""
@@ -1657,7 +1653,7 @@ class TaskStore:
     """
 
     def __init__(self) -> None:
-        self._tasks: Dict[str, Task] = {}
+        self._tasks: dict[str, Task] = {}
         self._lock = threading.Lock()
 
     def save(self, task: Task) -> None:
@@ -1669,7 +1665,7 @@ class TaskStore:
         with self._lock:
             self._tasks[task.id] = copy.deepcopy(task)
 
-    def get(self, task_id: str) -> Optional[Task]:
+    def get(self, task_id: str) -> Task | None:
         """Retrieve a task by ID.
 
         Args:
@@ -1697,11 +1693,11 @@ class TaskStore:
     def list_tasks(
         self,
         *,
-        context_id: Optional[str] = None,
-        status: Optional[TaskState] = None,
+        context_id: str | None = None,
+        status: TaskState | None = None,
         page_size: int = 50,
-        page_token: Optional[str] = None,
-    ) -> Tuple[List[Task], str, int]:
+        page_token: str | None = None,
+    ) -> tuple[list[Task], str, int]:
         """List tasks with optional filtering and pagination.
 
         Args:
@@ -1765,7 +1761,7 @@ class TaskManager:
     """
 
     # Valid state transitions (from -> set of allowed to-states)
-    _TRANSITIONS: Dict[TaskState, set] = {
+    _TRANSITIONS: dict[TaskState, set] = {
         TaskState.UNSPECIFIED: {TaskState.SUBMITTED},
         TaskState.SUBMITTED: {
             TaskState.WORKING,
@@ -1800,16 +1796,16 @@ class TaskManager:
         TaskState.REJECTED: set(),
     }
 
-    def __init__(self, store: Optional[TaskStore] = None):
+    def __init__(self, store: TaskStore | None = None):
         self.store = store or TaskStore()
-        self._listeners: Dict[str, List[Callable[[StreamResponse], None]]] = {}
+        self._listeners: dict[str, list[Callable[[StreamResponse], None]]] = {}
         self._lock = threading.Lock()
 
     def create_task(
         self,
         message: Message,
         *,
-        context_id: Optional[str] = None,
+        context_id: str | None = None,
     ) -> Task:
         """Create a new task from an incoming message.
 
@@ -1851,7 +1847,7 @@ class TaskManager:
         task_id: str,
         state: TaskState,
         *,
-        status_message: Optional[Message] = None,
+        status_message: Message | None = None,
     ) -> Task:
         """Transition a task to a new state.
 
@@ -2038,7 +2034,7 @@ if __name__ == "__main__":
     task_manager = TaskManager()
 
     @server.dispatcher.register("SendMessage")
-    def handle_send_message(params: Dict[str, Any]) -> Dict[str, Any]:
+    def handle_send_message(params: dict[str, Any]) -> dict[str, Any]:
         """Handle a SendMessage request by echoing the input."""
         req = SendMessageRequest.from_dict(params)
         text = ""
@@ -2060,8 +2056,8 @@ if __name__ == "__main__":
 
     @server.dispatcher.register("SendStreamingMessage")
     def handle_stream_message(
-        params: Dict[str, Any],
-    ) -> Iterator[Dict[str, Any]]:
+        params: dict[str, Any],
+    ) -> Iterator[dict[str, Any]]:
         """Handle a SendStreamingMessage by streaming token-by-token."""
         req = SendMessageRequest.from_dict(params)
         text = ""
@@ -2108,14 +2104,14 @@ if __name__ == "__main__":
         ).to_dict()
 
     @server.dispatcher.register("GetTask")
-    def handle_get_task(params: Dict[str, Any]) -> Dict[str, Any]:
+    def handle_get_task(params: dict[str, Any]) -> dict[str, Any]:
         """Handle a GetTask request."""
         task_id = params.get("id", "")
         task = task_manager.get_task(task_id)
         return task.to_dict()
 
     @server.dispatcher.register("CancelTask")
-    def handle_cancel_task(params: Dict[str, Any]) -> Dict[str, Any]:
+    def handle_cancel_task(params: dict[str, Any]) -> dict[str, Any]:
         """Handle a CancelTask request."""
         task_id = params.get("id", "")
         task = task_manager.cancel_task(task_id)

--- a/acp/acp.py
+++ b/acp/acp.py
@@ -85,7 +85,6 @@ from typing import (
     Any,
     AsyncIterator,
     Callable,
-    Optional,
     Union,
 )
 
@@ -395,7 +394,7 @@ class _TextResource:
 
     uri: str
     text: str
-    mime_type: Optional[str] = None
+    mime_type: str | None = None
 
 
 @dataclass
@@ -427,10 +426,10 @@ class ResourceLinkContent:
 
     uri: str
     name: str
-    mime_type: Optional[str] = None
-    title: Optional[str] = None
-    description: Optional[str] = None
-    size: Optional[int] = None
+    mime_type: str | None = None
+    title: str | None = None
+    description: str | None = None
+    size: int | None = None
     type: str = "resource_link"
 
 
@@ -491,7 +490,7 @@ class ImplementationInfo:
 
     name: str
     version: str = ""
-    title: Optional[str] = None
+    title: str | None = None
 
 
 @dataclass
@@ -516,7 +515,7 @@ class ClientCapabilities:
         terminal: Whether all ``terminal/*`` methods are available.
     """
 
-    fs: Optional[FsCapabilities] = None
+    fs: FsCapabilities | None = None
     terminal: bool = False
 
 
@@ -563,7 +562,7 @@ class SessionCapabilities:
         list: If present, ``session/list`` is supported.
     """
 
-    list: Optional[SessionListCapability] = None
+    list: SessionListCapability | None = None
 
 
 @dataclass
@@ -578,9 +577,9 @@ class AgentCapabilities:
     """
 
     load_session: bool = False
-    prompt_capabilities: Optional[PromptCapabilities] = None
-    mcp_capabilities: Optional[McpCapabilities] = None
-    session_capabilities: Optional[SessionCapabilities] = None
+    prompt_capabilities: PromptCapabilities | None = None
+    mcp_capabilities: McpCapabilities | None = None
+    session_capabilities: SessionCapabilities | None = None
 
 
 @dataclass
@@ -595,7 +594,7 @@ class AuthMethod:
 
     id: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 @dataclass
@@ -609,8 +608,8 @@ class InitializeParams:
     """
 
     protocol_version: int = 1
-    client_capabilities: Optional[ClientCapabilities] = None
-    client_info: Optional[ImplementationInfo] = None
+    client_capabilities: ClientCapabilities | None = None
+    client_info: ImplementationInfo | None = None
 
 
 @dataclass
@@ -625,9 +624,9 @@ class InitializeResult:
     """
 
     protocol_version: int = 1
-    agent_capabilities: Optional[AgentCapabilities] = None
-    agent_info: Optional[ImplementationInfo] = None
-    auth_methods: Optional[list[AuthMethod]] = None
+    agent_capabilities: AgentCapabilities | None = None
+    agent_info: ImplementationInfo | None = None
+    auth_methods: list[AuthMethod] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -662,7 +661,7 @@ class McpServerStdio:
     name: str
     command: str
     args: list[str] = field(default_factory=list)
-    env: Optional[list[EnvVariable]] = None
+    env: list[EnvVariable] | None = None
 
 
 @dataclass
@@ -708,7 +707,7 @@ class NewSessionParams:
     """
 
     cwd: str
-    mcp_servers: Optional[list[dict[str, Any]]] = None
+    mcp_servers: list[dict[str, Any]] | None = None
 
 
 @dataclass
@@ -723,7 +722,7 @@ class SessionMode:
 
     id: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 @dataclass
@@ -751,7 +750,7 @@ class ConfigOptionValue:
 
     value: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 @dataclass
@@ -773,8 +772,8 @@ class ConfigOption:
     type: str
     current_value: str
     options: list[ConfigOptionValue] = field(default_factory=list)
-    description: Optional[str] = None
-    category: Optional[str] = None
+    description: str | None = None
+    category: str | None = None
 
 
 @dataclass
@@ -788,8 +787,8 @@ class NewSessionResult:
     """
 
     session_id: str
-    modes: Optional[SessionModeState] = None
-    config_options: Optional[list[ConfigOption]] = None
+    modes: SessionModeState | None = None
+    config_options: list[ConfigOption] | None = None
 
 
 @dataclass
@@ -804,7 +803,7 @@ class LoadSessionParams:
 
     session_id: str
     cwd: str
-    mcp_servers: Optional[list[dict[str, Any]]] = None
+    mcp_servers: list[dict[str, Any]] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -905,8 +904,8 @@ class ListSessionsParams:
         cursor: Optional pagination cursor.
     """
 
-    cwd: Optional[str] = None
-    cursor: Optional[str] = None
+    cwd: str | None = None
+    cursor: str | None = None
 
 
 @dataclass
@@ -922,8 +921,8 @@ class SessionInfo:
 
     session_id: str
     cwd: str
-    title: Optional[str] = None
-    updated_at: Optional[str] = None
+    title: str | None = None
+    updated_at: str | None = None
 
 
 @dataclass
@@ -936,7 +935,7 @@ class ListSessionsResult:
     """
 
     sessions: list[SessionInfo] = field(default_factory=list)
-    next_cursor: Optional[str] = None
+    next_cursor: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -954,7 +953,7 @@ class ToolCallLocation:
     """
 
     path: str
-    line: Optional[int] = None
+    line: int | None = None
 
 
 @dataclass
@@ -970,7 +969,7 @@ class DiffContent:
 
     path: str
     new_text: str
-    old_text: Optional[str] = None
+    old_text: str | None = None
     type: str = "diff"
 
 
@@ -1028,7 +1027,7 @@ class PermissionOutcome:
     """
 
     outcome: str
-    option_id: Optional[str] = None
+    option_id: str | None = None
 
 
 @dataclass
@@ -1105,7 +1104,7 @@ class AvailableCommand:
 
     name: str
     description: str
-    input: Optional[AvailableCommandInput] = None
+    input: AvailableCommandInput | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1126,8 +1125,8 @@ class ReadTextFileParams:
 
     session_id: str
     path: str
-    line: Optional[int] = None
-    limit: Optional[int] = None
+    line: int | None = None
+    limit: int | None = None
 
 
 @dataclass
@@ -1176,10 +1175,10 @@ class CreateTerminalParams:
 
     session_id: str
     command: str
-    args: Optional[list[str]] = None
-    env: Optional[list[EnvVariable]] = None
-    cwd: Optional[str] = None
-    output_byte_limit: Optional[int] = None
+    args: list[str] | None = None
+    env: list[EnvVariable] | None = None
+    cwd: str | None = None
+    output_byte_limit: int | None = None
 
 
 @dataclass
@@ -1215,8 +1214,8 @@ class TerminalExitStatus:
         signal: Termination signal (may be ``None``).
     """
 
-    exit_code: Optional[int] = None
-    signal: Optional[str] = None
+    exit_code: int | None = None
+    signal: str | None = None
 
 
 @dataclass
@@ -1231,7 +1230,7 @@ class TerminalOutputResult:
 
     output: str = ""
     truncated: bool = False
-    exit_status: Optional[TerminalExitStatus] = None
+    exit_status: TerminalExitStatus | None = None
 
 
 @dataclass
@@ -1337,10 +1336,10 @@ class ToolCallUpdate:
     title: str
     kind: ToolKind = ToolKind.OTHER
     status: ToolCallStatus = ToolCallStatus.PENDING
-    content: Optional[list[ToolCallContent]] = None
-    locations: Optional[list[ToolCallLocation]] = None
-    raw_input: Optional[dict[str, Any]] = None
-    raw_output: Optional[dict[str, Any]] = None
+    content: list[ToolCallContent] | None = None
+    locations: list[ToolCallLocation] | None = None
+    raw_input: dict[str, Any] | None = None
+    raw_output: dict[str, Any] | None = None
     session_update: str = "tool_call"
 
 
@@ -1358,10 +1357,10 @@ class ToolCallStatusUpdate:
     """
 
     tool_call_id: str
-    status: Optional[ToolCallStatus] = None
-    content: Optional[list[ToolCallContent]] = None
-    title: Optional[str] = None
-    locations: Optional[list[ToolCallLocation]] = None
+    status: ToolCallStatus | None = None
+    content: list[ToolCallContent] | None = None
+    title: str | None = None
+    locations: list[ToolCallLocation] | None = None
     session_update: str = "tool_call_update"
 
 
@@ -1427,8 +1426,8 @@ class SessionInfoUpdate:
         session_update: Discriminator.
     """
 
-    title: Optional[str] = None
-    updated_at: Optional[str] = None
+    title: str | None = None
+    updated_at: str | None = None
     session_update: str = "session_info_update"
 
 
@@ -1472,17 +1471,17 @@ class ACPClient:
     def __init__(
         self,
         command: list[str],
-        env: Optional[dict[str, str]] = None,
+        env: dict[str, str] | None = None,
     ) -> None:
         self._command = command
         self._env = env
-        self._process: Optional[asyncio.subprocess.Process] = None
-        self._transport: Optional[JSONRPCTransport] = None
+        self._process: asyncio.subprocess.Process | None = None
+        self._transport: JSONRPCTransport | None = None
         self._pending: dict[Union[int, str], asyncio.Future[dict[str, Any]]] = {}
         self._notification_handlers: dict[str, Callable[..., Any]] = {}
-        self._update_queue: asyncio.Queue[Optional[dict[str, Any]]] = asyncio.Queue()
-        self._reader_task: Optional[asyncio.Task[None]] = None
-        self._request_handler: Optional[Callable[[str, dict[str, Any]], Any]] = None
+        self._update_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+        self._reader_task: asyncio.Task[None] | None = None
+        self._request_handler: Callable[[str, dict[str, Any]], Any] | None = None
 
     async def start(self) -> None:
         """Launch the agent subprocess and begin reading messages."""
@@ -1620,7 +1619,7 @@ class ACPClient:
 
     async def initialize(
         self,
-        params: Optional[InitializeParams] = None,
+        params: InitializeParams | None = None,
     ) -> InitializeResult:
         """Perform the ``initialize`` handshake with the agent.
 
@@ -1651,7 +1650,7 @@ class ACPClient:
     async def new_session(
         self,
         cwd: str,
-        mcp_servers: Optional[list[dict[str, Any]]] = None,
+        mcp_servers: list[dict[str, Any]] | None = None,
     ) -> NewSessionResult:
         """Create a new conversation session.
 
@@ -1674,7 +1673,7 @@ class ACPClient:
         self,
         session_id: str,
         cwd: str,
-        mcp_servers: Optional[list[dict[str, Any]]] = None,
+        mcp_servers: list[dict[str, Any]] | None = None,
     ) -> None:
         """Load (resume) an existing session.
 
@@ -1695,7 +1694,7 @@ class ACPClient:
         self,
         session_id: str,
         text: str,
-        extra_content: Optional[list[ContentBlock]] = None,
+        extra_content: list[ContentBlock] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Send a prompt and yield ``session/update`` notifications.
 
@@ -1803,8 +1802,8 @@ class ACPClient:
 
     async def list_sessions(
         self,
-        cwd: Optional[str] = None,
-        cursor: Optional[str] = None,
+        cwd: str | None = None,
+        cursor: str | None = None,
     ) -> ListSessionsResult:
         """List sessions known to the agent.
 
@@ -1864,7 +1863,7 @@ class ACPAgent(ABC):
     """
 
     def __init__(self) -> None:
-        self._transport: Optional[JSONRPCTransport] = None
+        self._transport: JSONRPCTransport | None = None
         self._running = False
 
     # -- Handler methods (override these) -----------------------------------
@@ -2020,8 +2019,8 @@ class ACPAgent(ABC):
         session_id: str,
         path: str,
         *,
-        line: Optional[int] = None,
-        limit: Optional[int] = None,
+        line: int | None = None,
+        limit: int | None = None,
     ) -> str:
         """Read a text file via the client's ``fs/read_text_file`` method.
 
@@ -2072,8 +2071,8 @@ class ACPAgent(ABC):
         session_id: str,
         command: str,
         *,
-        args: Optional[list[str]] = None,
-        cwd: Optional[str] = None,
+        args: list[str] | None = None,
+        cwd: str | None = None,
     ) -> str:
         """Create a terminal via the client's ``terminal/create`` method.
 
@@ -2186,9 +2185,7 @@ class ACPAgent(ABC):
                     JSONRPCError(code=INTERNAL_ERROR, message=str(exc)),
                 )
 
-    async def _handle_method(
-        self, method: Optional[str], params: dict[str, Any]
-    ) -> Any:
+    async def _handle_method(self, method: str | None, params: dict[str, Any]) -> Any:
         """Dispatch a method call to the correct handler."""
         if method == "initialize":
             rp = from_raw(params)

--- a/jsonrpc/jsonrpc.py
+++ b/jsonrpc/jsonrpc.py
@@ -38,7 +38,6 @@ from typing import (
     Any,
     Callable,
     Iterator,
-    Optional,
     Union,
 )
 
@@ -129,7 +128,7 @@ class JSONRPCRequest:
     """
 
     method: str = ""
-    params: Optional[dict[str, Any]] = None
+    params: dict[str, Any] | None = None
     id: Union[str, int, None] = None
     jsonrpc: str = JSONRPC_VERSION
 
@@ -173,7 +172,7 @@ class JSONRPCResponse:
 
     id: Union[str, int, None] = None
     result: Any = None
-    error: Optional[JSONRPCError] = None
+    error: JSONRPCError | None = None
     jsonrpc: str = JSONRPC_VERSION
 
     def to_dict(self) -> dict[str, Any]:
@@ -373,7 +372,7 @@ class JSONRPCTransport:
         self.writer = writer
         self._closed = False
 
-    async def read_message(self) -> Optional[dict[str, Any]]:
+    async def read_message(self) -> dict[str, Any] | None:
         """Read the next JSON-RPC message.
 
         Returns:


### PR DESCRIPTION
## Summary

Closes #4

- Replace `Optional[X]` → `X | None` in a2a, acp, jsonrpc
- Replace `Dict[K,V]` → `dict[K,V]`, `List[T]` → `list[T]`, `Tuple` → `tuple` in a2a
- Clean up unused typing imports
- validate/validate.py already used modern style, no changes needed

## Test plan

- [x] `ruff check --fix` and `ruff format` pass
- [x] All 128 tests pass (`pytest a2a/ acp/ jsonrpc/ validate/`)