### PR TITLE
style: add __all__ exports to all modules

### DIFF
--- a/ansi/ansi.py
+++ b/ansi/ansi.py
@@ -44,6 +44,44 @@ import re
 import sys
 from typing import Any
 
+__all__ = [
+    # Text attributes
+    "RESET",
+    "BOLD",
+    "DIM",
+    "ITALIC",
+    "UNDERLINE",
+    "BLINK",
+    "REVERSE",
+    "HIDDEN",
+    "STRIKETHROUGH",
+    # Cursor control
+    "CURSOR_UP",
+    "CURSOR_DOWN",
+    "CURSOR_FORWARD",
+    "CURSOR_BACK",
+    "CURSOR_HIDE",
+    "CURSOR_SHOW",
+    "CLEAR_LINE",
+    "CLEAR_SCREEN",
+    "CURSOR_HOME",
+    # Named color tables
+    "NAMED_COLORS",
+    "BRIGHT_COLORS",
+    # Color constructors
+    "fg",
+    "bg",
+    # High-level styling
+    "style",
+    # Terminal detection
+    "supports_color",
+    "color_depth",
+    # Utilities
+    "strip_ansi",
+    "visible_len",
+    "cursor_move",
+]
+
 # ── Text Attributes ─────────────────────────────────────────────────
 
 RESET = "\033[0m"

--- a/config/config.py
+++ b/config/config.py
@@ -38,6 +38,22 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
+__all__ = [
+    # Sentinels
+    "MISSING",
+    # Exceptions
+    "ConfigError",
+    "UndefinedValueError",
+    # Type coercion helpers
+    "Csv",
+    "Choices",
+    # Main class
+    "Config",
+    # Module-level convenience
+    "setup",
+    "config",
+]
+
 
 def _ensure_sibling_path(name: str) -> str:
     """Return the sibling module directory and prepend it to ``sys.path``."""

--- a/diff/diff.py
+++ b/diff/diff.py
@@ -45,6 +45,27 @@ import difflib
 import re
 from collections.abc import Sequence
 
+__all__ = [
+    # Exceptions
+    "DiffError",
+    "PatchParseError",
+    "PatchApplyError",
+    # Data structures
+    "Hunk",
+    "PatchedFile",
+    "Patch",
+    "ConflictRegion",
+    "MergeResult",
+    # Diff generation
+    "make_diff",
+    # Patch operations
+    "parse_patch",
+    "apply_patch",
+    "reverse_patch",
+    # Three-way merge
+    "merge3",
+]
+
 # ── Exceptions ──────────────────────────────────────────────────────
 
 

--- a/dotenv/dotenv.py
+++ b/dotenv/dotenv.py
@@ -28,6 +28,15 @@ import sys
 from pathlib import Path
 from typing import IO, Iterator, Mapping
 
+__all__ = [
+    "find_dotenv",
+    "get_key",
+    "set_key",
+    "unset_key",
+    "dotenv_values",
+    "load_dotenv",
+]
+
 # ── Constants / Regex ──────────────────────────────────────────────────────────
 
 _ESCAPE_MAP = {

--- a/frontmatter/frontmatter.py
+++ b/frontmatter/frontmatter.py
@@ -55,6 +55,22 @@ import sys
 from pathlib import Path
 from typing import IO, Any
 
+__all__ = [
+    # Exceptions
+    "FrontmatterError",
+    "HandlerError",
+    # Data class
+    "Document",
+    # Detection
+    "detect_handler",
+    "check",
+    # Public API
+    "loads",
+    "load",
+    "dumps",
+    "dump",
+]
+
 # ── Sibling yaml import (guarded) ──
 
 try:

--- a/httpclient/httpclient.py
+++ b/httpclient/httpclient.py
@@ -52,6 +52,47 @@ from collections.abc import AsyncIterator, Iterator
 from typing import IO, Any
 from urllib.parse import quote, urlencode, urlparse
 
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_MAX_REDIRECTS",
+    "DEFAULT_USER_AGENT",
+    "DEFAULT_POOL_SIZE",
+    "DEFAULT_POOL_IDLE_TIMEOUT",
+    # Exceptions
+    "HttpClientError",
+    "HTTPError",
+    "TooManyRedirects",
+    "HttpConnectionError",
+    "HttpTimeoutError",
+    # Response classes
+    "Response",
+    "StreamingResponse",
+    # Auth
+    "Auth",
+    "BasicAuth",
+    "DigestAuth",
+    # Sync convenience functions
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    # Async convenience functions
+    "async_get",
+    "async_post",
+    "async_put",
+    "async_patch",
+    "async_delete",
+    "async_head",
+    "async_options",
+    # Client classes
+    "Client",
+    "AsyncClient",
+]
+
 # ── Constants / Defaults ──
 
 logger = logging.getLogger(__name__)

--- a/jsonc/jsonc.py
+++ b/jsonc/jsonc.py
@@ -32,6 +32,14 @@ import json
 import re
 from typing import IO, Any
 
+__all__ = [
+    "JSONCDecodeError",
+    "loads",
+    "load",
+    "dumps",
+    "dump",
+]
+
 # ── Comment stripping ─────────────────────────────────────────────────────────
 
 # Matches (in priority order):

--- a/markdown/markdown.py
+++ b/markdown/markdown.py
@@ -40,6 +40,10 @@ from __future__ import annotations
 import html
 import re
 
+__all__ = [
+    "render",
+]
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 _ESCAPED_CHARS = r"\\!\"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~"

--- a/qr/qr.py
+++ b/qr/qr.py
@@ -23,6 +23,13 @@ import re
 from collections.abc import Sequence
 from typing import Union
 
+__all__ = [
+    "QrCode",
+    "QrSegment",
+    "DataTooLongError",
+    "print_qr_terminal",
+]
+
 # ---- QR Code symbol class ----
 
 

--- a/retry/retry.py
+++ b/retry/retry.py
@@ -48,6 +48,25 @@ import random
 import time
 from typing import Any, Callable
 
+__all__ = [
+    # Constants
+    "DEFAULT_MAX_RETRIES",
+    "DEFAULT_BASE_DELAY",
+    "DEFAULT_MAX_DELAY",
+    "DEFAULT_BACKOFF_FACTOR",
+    # Exceptions
+    "RetryError",
+    # Data classes
+    "RetryState",
+    # Predicates
+    "retry_if_exception",
+    "retry_if_result",
+    "retry_if_status",
+    # Main API
+    "retry",
+    "retry_call",
+]
+
 # ── Defaults ──
 
 DEFAULT_MAX_RETRIES = 3

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -57,6 +57,36 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
+__all__ = [
+    # Constants
+    "DEFAULT_MISFIRE_GRACE_TIME",
+    "DEFAULT_TICK_INTERVAL",
+    # Exceptions
+    "SchedulerError",
+    "SchedulerAlreadyRunning",
+    "SchedulerNotRunning",
+    "JobNotFound",
+    "InvalidCronExpression",
+    # Cron
+    "CronSpec",
+    "parse_cron",
+    # Triggers
+    "IntervalTrigger",
+    "CronTrigger",
+    "OnceTrigger",
+    "every",
+    "cron",
+    "once",
+    # Enums
+    "JobStatus",
+    "EventType",
+    # Data classes
+    "JobEvent",
+    "Job",
+    # Scheduler
+    "Scheduler",
+]
+
 logger = logging.getLogger(__name__)
 
 # ── Constants ──

--- a/search/sparse_search.py
+++ b/search/sparse_search.py
@@ -47,6 +47,11 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+__all__ = [
+    "Result",
+    "SparseIndex",
+]
+
 _VERSION = "0.1.0"
 
 # ---------------------------------------------------------------------------

--- a/skills/skills.py
+++ b/skills/skills.py
@@ -54,6 +54,30 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Protocol, runtime_checkable
 
+__all__ = [
+    # Exceptions
+    "SkillError",
+    "ParseError",
+    "ValidationError",
+    # Data classes
+    "SkillProperties",
+    "Skill",
+    "SelectionResult",
+    # Selector protocol and implementations
+    "Selector",
+    "KeywordSelector",
+    "BM25Selector",
+    # Registry
+    "SkillRegistry",
+    # Public API functions
+    "validate",
+    "to_catalog",
+    "compose",
+    "load",
+    "loads",
+    "discover",
+]
+
 # ---------------------------------------------------------------------------
 # Sibling imports (guarded)
 # ---------------------------------------------------------------------------

--- a/soup/soup.py
+++ b/soup/soup.py
@@ -32,6 +32,12 @@ import re
 from html.parser import HTMLParser
 from typing import Any
 
+__all__ = [
+    "SELF_CLOSING_TAGS",
+    "Tag",
+    "Soup",
+]
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 SELF_CLOSING_TAGS = frozenset(

--- a/sse/sse.py
+++ b/sse/sse.py
@@ -54,6 +54,27 @@ import time
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from typing import Any, Callable
 
+__all__ = [
+    # Constants
+    "DEFAULT_RETRY_INTERVAL",
+    "DEFAULT_TIMEOUT",
+    # Data classes
+    "SSEEvent",
+    # Low-level parsers
+    "EventSource",
+    "AsyncEventSource",
+    # Exceptions
+    "SSEError",
+    "SSEConnectionError",
+    "SSEHTTPError",
+    # High-level clients
+    "SSEClient",
+    "AsyncSSEClient",
+    # Convenience functions
+    "connect",
+    "async_connect",
+]
+
 
 def _ensure_sibling_path(name: str) -> str:
     """Return the sibling module directory and prepend it to ``sys.path``."""

--- a/structlog/structlog.py
+++ b/structlog/structlog.py
@@ -50,6 +50,41 @@ import sys
 import traceback
 from typing import IO, Any, Callable
 
+__all__ = [
+    # Type aliases
+    "EventDict",
+    "Processor",
+    "LoggerFactory",
+    # Exceptions
+    "DropEvent",
+    # Logger factories
+    "PrintLogger",
+    "PrintLoggerFactory",
+    "StdlibLoggerFactory",
+    # Processors
+    "add_log_level",
+    "add_logger_name",
+    "TimeStamper",
+    "format_exc_info",
+    # Renderers
+    "KeyValueRenderer",
+    "JSONRenderer",
+    "ConsoleRenderer",
+    # Bound logger
+    "BoundLogger",
+    # Configuration
+    "configure",
+    "reset_defaults",
+    "get_config",
+    "get_logger",
+    "wrap_logger",
+    # Setup helper
+    "setup_logging",
+    # Utilities
+    "truncate_string",
+    "truncate_base64",
+]
+
 # ── Type Aliases ─────────────────────────────────────────────────────────────
 
 EventDict = dict[str, Any]

--- a/toon/toon.py
+++ b/toon/toon.py
@@ -35,6 +35,22 @@ from decimal import Decimal
 from pathlib import PurePath
 from typing import Any, Literal, TypedDict, TypeGuard, Union
 
+__all__ = [
+    # Type aliases
+    "JsonPrimitive",
+    "JsonObject",
+    "JsonArray",
+    "JsonValue",
+    # Options
+    "EncodeOptions",
+    "DecodeOptions",
+    # Exceptions
+    "ToonDecodeError",
+    # Public API
+    "encode",
+    "decode",
+]
+
 # ── Types ─────────────────────────────────────────────────────────────────────
 
 JsonPrimitive = Union[str, int, float, bool, None]

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -44,6 +44,24 @@ import re
 import typing
 from typing import Any, Callable, Union, get_type_hints
 
+__all__ = [
+    # Constraint annotations
+    "Gt",
+    "Ge",
+    "Lt",
+    "Le",
+    "MinLen",
+    "MaxLen",
+    "Match",
+    "Predicate",
+    # Error types
+    "ErrorDetail",
+    "ValidationError",
+    # Public API
+    "validate",
+    "json_schema",
+]
+
 # ── Constraint Annotations ──
 
 

--- a/vcs/vcs.py
+++ b/vcs/vcs.py
@@ -38,6 +38,27 @@ import sys
 import tempfile
 from typing import Any, Callable, Protocol, runtime_checkable
 
+__all__ = [
+    # Exceptions
+    "VCSError",
+    "BinaryNotFoundError",
+    "CommandError",
+    "NotARepoError",
+    # Data classes
+    "FileStatus",
+    "Commit",
+    "BlameLine",
+    "WorkspaceInfo",
+    # Backend protocol
+    "VCSBackend",
+    # Backend implementations
+    "Git",
+    "Mercurial",
+    "Jujutsu",
+    # Detection
+    "detect",
+]
+
 # ── Sentinel for injection parameters ──────────────────────────────────────
 
 

--- a/xml/xml.py
+++ b/xml/xml.py
@@ -78,6 +78,18 @@ import io  # noqa: E402
 import re  # noqa: E402
 from typing import IO, Any, Callable  # noqa: E402
 
+__all__ = [
+    # Exceptions
+    "XMLError",
+    "ParsingInterrupted",
+    # Data classes
+    "ExtractedTag",
+    # Public API
+    "parse",
+    "unparse",
+    "extract_tags",
+]
+
 # ── Exceptions ────────────────────────────────────────────────────────────────
 
 

--- a/yaml/yaml.py
+++ b/yaml/yaml.py
@@ -31,6 +31,14 @@ import math
 import re
 from typing import IO, Any, Iterator, overload
 
+__all__ = [
+    "YAMLError",
+    "load",
+    "load_all",
+    "dump",
+    "dump_all",
+]
+
 # ── Exceptions ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #5

Added `__all__` exports to 21 modules that were missing them: ansi, config, diff, dotenv, frontmatter, httpclient, jsonc, markdown, qr, retry, scheduler, search, skills, soup, sse, structlog, toon, validate, vcs, xml, yaml.

Each `__all__` is placed after imports, before the first implementation code, listing only public API symbols.

## Test plan

- [x] `ruff check --fix` and `ruff format` pass
- [x] All 748 tests pass across all affected modules