### PR TITLE
style: add slots=True to frozen dataclasses

### DIFF
--- a/runner/runner.py
+++ b/runner/runner.py
@@ -152,7 +152,7 @@ class CommandBlockedError(RunnerError):
 # ── Data Models (RunResult) ───────────────────────────────────────────
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class RunResult:
     """Result of a completed command execution.
 

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -47,7 +47,7 @@ from typing import Any, Callable, Union, get_type_hints
 # ── Constraint Annotations ──
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Gt:
     """Value must be strictly greater than *val*."""
 
@@ -63,7 +63,7 @@ class Gt:
         return f"> {self.val}"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Ge:
     """Value must be greater than or equal to *val*."""
 
@@ -79,7 +79,7 @@ class Ge:
         return f">= {self.val}"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Lt:
     """Value must be strictly less than *val*."""
 
@@ -95,7 +95,7 @@ class Lt:
         return f"< {self.val}"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Le:
     """Value must be less than or equal to *val*."""
 
@@ -111,7 +111,7 @@ class Le:
         return f"<= {self.val}"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class MinLen:
     """Length must be at least *val*."""
 
@@ -132,7 +132,7 @@ class MinLen:
         return f"len >= {self.val}"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class MaxLen:
     """Length must be at most *val*."""
 
@@ -151,7 +151,7 @@ class MaxLen:
         return f"len <= {self.val}"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Match:
     """Value must match *pattern* (via ``re.fullmatch``)."""
 
@@ -167,7 +167,7 @@ class Match:
         return f"match({self.pattern!r})"
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Predicate:
     """Value must satisfy a custom predicate function.
 

--- a/vcs/vcs.py
+++ b/vcs/vcs.py
@@ -146,7 +146,7 @@ class NotARepoError(VCSError):
 # ── Data Structures ──────────────────────────────────────────────────
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class FileStatus:
     """Status of a single file in the working tree.
 
@@ -162,7 +162,7 @@ class FileStatus:
     original_path: str | None = None
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class Commit:
     """Metadata for a single commit.
 
@@ -181,7 +181,7 @@ class Commit:
     message: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class BlameLine:
     """Annotation for a single source line.
 
@@ -200,7 +200,7 @@ class BlameLine:
     content: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class WorkspaceInfo:
     """Information about a workspace (Git worktree / Jujutsu workspace).
 


### PR DESCRIPTION
## Summary

Closes #7

Added `slots=True` to 13 frozen dataclasses across 3 modules:

- `vcs/vcs.py`: FileStatus, Commit, BlameLine, WorkspaceInfo (4)
- `validate/validate.py`: Gt, Ge, Lt, Le, MinLen, MaxLen, Match, Predicate (8)
- `runner/runner.py`: RunResult (1)

Skipped modules where dataclasses don't have `frozen=True` (search, skills, acp, a2a, jsonrpc, structlog, retry, diff, toon, frontmatter). All modified dataclasses are standalone (no inheritance), so adding slots is safe.

## Test plan

- [x] `ruff check --fix` and `ruff format` pass
- [x] All 227 tests pass across vcs, validate, runner