### PR TITLE
style: standardize test file docstring format

### DIFF
--- a/config/test_config_correctness.py
+++ b/config/test_config_correctness.py
@@ -1,10 +1,4 @@
-"""Correctness tests for zerodep config module.
-
-Covers: env vars, .env files, config files (JSON/YAML/TOML/INI),
-type coercion (bool/int/float/list/tuple), Csv, Choices, prefix,
-nested keys, priority override, UndefinedValueError, and comparison
-with python-decouple where applicable.
-"""
+"""Correctness tests: zerodep config."""
 
 from __future__ import annotations
 

--- a/jsonrpc/test_jsonrpc_correctness.py
+++ b/jsonrpc/test_jsonrpc_correctness.py
@@ -1,14 +1,4 @@
-"""Correctness tests for the jsonrpc module.
-
-Covers:
-    - JSONRPCError: construction, to_dict, from_dict, defaults
-    - JSONRPCRequest: construction, to_dict, from_dict, is_notification
-    - JSONRPCResponse: construction, to_dict, from_dict, success, from_error
-    - JSONRPCException: wrapping, message propagation
-    - next_id: monotonic incrementing
-    - JSONRPCDispatcher: register, dispatch, error handling, streaming
-    - JSONRPCTransport: read/write over async streams (unit-level)
-"""
+"""Correctness tests: zerodep jsonrpc."""
 
 from __future__ import annotations
 

--- a/prompt/test_prompt_correctness.py
+++ b/prompt/test_prompt_correctness.py
@@ -1,4 +1,4 @@
-"""Correctness tests for zerodep prompt module."""
+"""Correctness tests: zerodep prompt."""
 
 import io
 import os

--- a/scheduler/test_scheduler_correctness.py
+++ b/scheduler/test_scheduler_correctness.py
@@ -1,4 +1,4 @@
-"""Correctness tests for zerodep scheduler."""
+"""Correctness tests: zerodep scheduler."""
 
 import os
 import sys

--- a/search/test_sparse_search_correctness.py
+++ b/search/test_sparse_search_correctness.py
@@ -1,4 +1,4 @@
-"""Correctness tests for sparse_search module."""
+"""Correctness tests: zerodep sparse_search."""
 
 from __future__ import annotations
 

--- a/skills/test_skills_correctness.py
+++ b/skills/test_skills_correctness.py
@@ -1,4 +1,4 @@
-"""Correctness tests for the zerodep skills module."""
+"""Correctness tests: zerodep skills."""
 
 import os
 import sys

--- a/sse/test_sse_correctness.py
+++ b/sse/test_sse_correctness.py
@@ -1,4 +1,4 @@
-"""Correctness tests for zerodep SSE client."""
+"""Correctness tests: zerodep sse."""
 
 import asyncio
 import http.server

--- a/vcs/test_vcs_correctness.py
+++ b/vcs/test_vcs_correctness.py
@@ -1,4 +1,4 @@
-"""Correctness tests: zerodep vcs module."""
+"""Correctness tests: zerodep vcs."""
 
 import os
 import shutil


### PR DESCRIPTION
## Summary

Closes #9

Standardized 8 test file docstrings to the format `"Correctness tests: zerodep {MODULE}."`:

- config, jsonrpc, prompt, scheduler, sse, vcs, search, skills

runner already had the correct format.

## Test plan

- [x] `ruff check --fix` and `ruff format` pass
- [x] Changes are purely cosmetic (docstrings only)