### PR TITLE
feat: add cross-platform filelock module

### DIFF
--- a/filelock/filelock.py
+++ b/filelock/filelock.py
@@ -1,0 +1,210 @@
+# /// zerodep
+# version = "0.2.2"
+# deps = []
+# tier = "simple"
+# category = "utility"
+# ///
+
+"""Cross-process file locking (Unix ``fcntl`` / Windows ``msvcrt``).
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+A cross-platform, context-manager-based advisory file lock using only the
+Python standard library.  On Unix/macOS it delegates to ``fcntl.flock``;
+on Windows it uses ``msvcrt.locking`` with exponential-backoff polling for
+blocking semantics.
+
+Usage::
+
+    from filelock import FileLock
+    from pathlib import Path
+
+    lock = FileLock(Path("/tmp/.my.lock"))
+
+    # Blocking acquire
+    with lock:
+        ...  # exclusive access
+
+    # Non-blocking try
+    if lock.try_lock():
+        try:
+            ...
+        finally:
+            lock.unlock()
+
+Requirements:
+    Python >= 3.10, no third-party packages.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+__all__ = [
+    "FileLock",
+]
+
+# ── Platform detection ────────────────────────────────────────────────
+
+_IS_WIN32 = sys.platform == "win32"
+
+if _IS_WIN32:
+    import msvcrt
+else:
+    import fcntl
+
+
+# ── FileLock ──────────────────────────────────────────────────────────
+
+
+class FileLock:
+    """Advisory file lock backed by ``fcntl.flock`` (Unix) or
+    ``msvcrt.locking`` (Windows).
+
+    The lock is *advisory* — it coordinates only among processes that
+    voluntarily use the same lock file.  It is **not** reentrant within a
+    single OS thread (locking twice from the same ``FileLock`` instance
+    without an intermediate unlock is safe because ``fcntl.flock`` /
+    ``msvcrt.locking`` silently succeed, but two *different* ``FileLock``
+    objects pointing at the same path will deadlock on Unix).
+
+    Args:
+        path: Path to the lock file (created automatically if missing,
+            along with any intermediate parent directories).
+
+    Attributes:
+        path: The lock-file path supplied at construction time.
+    """
+
+    # msvcrt.locking requires a byte-range length; we lock the first byte.
+    _LOCK_LEN = 1
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._fd: int | None = None
+
+    # ── Properties ────────────────────────────────────────────────────
+
+    @property
+    def path(self) -> Path:
+        """The lock-file path."""
+        return self._path
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    def lock(self) -> None:
+        """Acquire the lock, blocking until available."""
+        self._ensure_fd()
+        assert self._fd is not None
+        if _IS_WIN32:
+            self._win_lock_blocking()
+        else:
+            fcntl.flock(self._fd, fcntl.LOCK_EX)
+
+    def try_lock(self) -> bool:
+        """Try to acquire the lock without blocking.
+
+        Returns:
+            ``True`` if the lock was acquired, ``False`` if another
+            process holds it.
+        """
+        self._ensure_fd()
+        assert self._fd is not None
+        if _IS_WIN32:
+            return self._win_try_lock()
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def unlock(self) -> None:
+        """Release the lock (no-op if not held)."""
+        if self._fd is None:
+            return
+        if _IS_WIN32:
+            self._win_unlock()
+        else:
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+
+    def close(self) -> None:
+        """Release the lock and close the underlying file descriptor."""
+        if self._fd is not None:
+            try:
+                self.unlock()
+            except OSError:
+                pass
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+
+    # ── Context manager ───────────────────────────────────────────────
+
+    def __enter__(self) -> FileLock:
+        self.lock()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.unlock()
+
+    # ── Internals ─────────────────────────────────────────────────────
+
+    def _ensure_fd(self) -> None:
+        """Open (or create) the lock file if not already open."""
+        if self._fd is not None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(
+            str(self._path),
+            os.O_RDWR | os.O_CREAT,
+            0o644,
+        )
+        if _IS_WIN32:
+            # Ensure the file has at least 1 byte so msvcrt.locking works.
+            if os.fstat(self._fd).st_size == 0:
+                os.write(self._fd, b"\x00")
+            os.lseek(self._fd, 0, os.SEEK_SET)
+
+    # ── Windows helpers ───────────────────────────────────────────────
+
+    def _win_try_lock(self) -> bool:
+        """Non-blocking lock via ``msvcrt.LK_NBLCK``."""
+        assert self._fd is not None
+        os.lseek(self._fd, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(self._fd, msvcrt.LK_NBLCK, self._LOCK_LEN)
+            return True
+        except OSError:
+            return False
+
+    def _win_lock_blocking(self) -> None:
+        """Blocking lock via polling ``msvcrt.LK_NBLCK``.
+
+        ``msvcrt.LK_LOCK`` retries internally but only for ~1 s.
+        We spin with back-off for robust blocking semantics.
+        """
+        assert self._fd is not None
+        delay = 0.01
+        while True:
+            if self._win_try_lock():
+                return
+            time.sleep(delay)
+            delay = min(delay * 2, 0.5)
+
+    def _win_unlock(self) -> None:
+        """Unlock via ``msvcrt.LK_UNLCK``."""
+        assert self._fd is not None
+        os.lseek(self._fd, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(self._fd, msvcrt.LK_UNLCK, self._LOCK_LEN)
+        except OSError:
+            pass

--- a/filelock/test_filelock_correctness.py
+++ b/filelock/test_filelock_correctness.py
@@ -1,0 +1,164 @@
+"""Correctness tests: zerodep filelock."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+from filelock import FileLock
+
+
+class TestBasicLocking:
+    """Basic lock/unlock semantics."""
+
+    def test_lock_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            lock.lock()
+            assert lock_path.exists()
+            lock.unlock()
+            lock.close()
+
+    def test_context_manager(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            with lock:
+                assert lock_path.exists()
+            lock.close()
+
+    def test_try_lock_succeeds_when_free(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            assert lock.try_lock() is True
+            lock.unlock()
+            lock.close()
+
+    def test_path_property(self):
+        p = Path("/tmp/.test.lock")
+        lock = FileLock(p)
+        assert lock.path == p
+
+    def test_accepts_str_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = os.path.join(tmpdir, ".lock")
+            lock = FileLock(lock_path)
+            lock.lock()
+            assert Path(lock_path).exists()
+            lock.unlock()
+            lock.close()
+
+
+class TestContention:
+    """Two FileLock instances competing for the same file."""
+
+    def test_try_lock_fails_when_held(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            holder_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+
+            if sys.platform == "win32":
+                import msvcrt
+
+                os.write(holder_fd, b"\x00")
+                os.lseek(holder_fd, 0, os.SEEK_SET)
+                msvcrt.locking(holder_fd, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(holder_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+            try:
+                lock = FileLock(lock_path)
+                assert lock.try_lock() is False
+                lock.close()
+            finally:
+                if sys.platform == "win32":
+                    os.lseek(holder_fd, 0, os.SEEK_SET)
+                    msvcrt.locking(holder_fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(holder_fd, fcntl.LOCK_UN)
+                os.close(holder_fd)
+
+    def test_unlock_releases_for_others(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock_a = FileLock(lock_path)
+            lock_b = FileLock(lock_path)
+
+            lock_a.lock()
+            assert lock_b.try_lock() is False
+
+            lock_a.unlock()
+            assert lock_b.try_lock() is True
+
+            lock_b.unlock()
+            lock_a.close()
+            lock_b.close()
+
+    def test_close_releases_lock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock_a = FileLock(lock_path)
+            lock_b = FileLock(lock_path)
+
+            lock_a.lock()
+            assert lock_b.try_lock() is False
+
+            lock_a.close()
+            assert lock_b.try_lock() is True
+
+            lock_b.unlock()
+            lock_b.close()
+
+
+class TestEdgeCases:
+    """Edge-case and safety tests."""
+
+    def test_creates_parent_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "sub" / "dir" / ".lock"
+            lock = FileLock(lock_path)
+            lock.lock()
+            assert lock_path.exists()
+            lock.unlock()
+            lock.close()
+
+    def test_double_close_is_safe(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            lock.lock()
+            lock.close()
+            lock.close()  # should not raise
+
+    def test_unlock_without_lock_is_safe(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            lock.unlock()  # no fd yet, should not raise
+
+    def test_reacquire_after_unlock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            lock.lock()
+            lock.unlock()
+            lock.lock()  # re-acquire same lock
+            lock.unlock()
+            lock.close()
+
+    def test_reacquire_after_close(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / ".lock"
+            lock = FileLock(lock_path)
+            lock.lock()
+            lock.close()
+            lock.lock()  # re-open fd and acquire
+            lock.unlock()
+            lock.close()

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-03-31T16:59:31.167079+00:00",
+  "generated": "2026-04-01T07:27:33.001906+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -90,6 +90,16 @@
       "deps": [],
       "tier": "simple",
       "category": "data"
+    },
+    "filelock": {
+      "description": "Cross-process file locking (Unix ``fcntl`` / Windows ``msvcrt``)",
+      "files": [
+        "filelock/filelock.py"
+      ],
+      "version": "0.2.2",
+      "deps": [],
+      "tier": "simple",
+      "category": "utility"
     },
     "frontmatter": {
       "description": "Frontmatter parser and serializer — zero dependencies, stdlib only, Python 3.10+",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock"]
 
 [tool.ruff]
 target-version = "py310"
@@ -154,4 +154,5 @@ extra-paths = [
     "./a2a",
     "./acp",
     "./skills",
+    "./filelock",
 ]


### PR DESCRIPTION
## Summary

New `filelock` module — cross-platform advisory file lock using only stdlib.

- **Unix/macOS**: `fcntl.flock()` (blocking + non-blocking)
- **Windows**: `msvcrt.locking()` with exponential-backoff polling
- Context manager support, auto parent-dir creation
- 13 correctness tests

## Test plan

- [x] `pytest filelock/ -x -q` — 13 passed
- [x] Deployed to weilink project and all 16 tests pass
- [ ] Windows CI verification (msvcrt path)