### PR TITLE
feat: add aes_ecb_padded_size utility function

### DIFF
--- a/aes/aes.py
+++ b/aes/aes.py
@@ -26,6 +26,7 @@ __all__ = [
     "aes_ctr_decrypt",
     "aes_gcm_encrypt",
     "aes_gcm_decrypt",
+    "aes_ecb_padded_size",
     # Backward compatibility
     "aes128_ecb_encrypt",
     "aes128_ecb_decrypt",
@@ -289,6 +290,19 @@ def aes_ecb_decrypt(data: bytes, key: bytes) -> bytes:
 # Backward compatibility
 aes128_ecb_encrypt = aes_ecb_encrypt
 aes128_ecb_decrypt = aes_ecb_decrypt
+
+
+def aes_ecb_padded_size(plaintext_size: int) -> int:
+    """Calculate the ciphertext size after AES-ECB + PKCS7 padding.
+
+    Args:
+        plaintext_size: Size of the original data in bytes.
+
+    Returns:
+        Size of the encrypted output in bytes.
+    """
+    pad_len = 16 - (plaintext_size % 16)
+    return plaintext_size + pad_len
 
 
 # ── CBC Mode + PKCS7 Padding ───────────────────────────────────────────────

--- a/aes/aes_openssl.py
+++ b/aes/aes_openssl.py
@@ -32,6 +32,7 @@ __all__ = [
     "aes_ctr_decrypt",
     "aes_gcm_encrypt",
     "aes_gcm_decrypt",
+    "aes_ecb_padded_size",
     # Backward compatibility
     "aes128_ecb_encrypt",
     "aes128_ecb_decrypt",
@@ -278,6 +279,19 @@ def aes_ecb_decrypt(data: bytes, key: bytes) -> bytes:
 # Backward compatibility
 aes128_ecb_encrypt = aes_ecb_encrypt
 aes128_ecb_decrypt = aes_ecb_decrypt
+
+
+def aes_ecb_padded_size(plaintext_size: int) -> int:
+    """Calculate the ciphertext size after AES-ECB + PKCS7 padding.
+
+    Args:
+        plaintext_size: Size of the original data in bytes.
+
+    Returns:
+        Size of the encrypted output in bytes.
+    """
+    pad_len = 16 - (plaintext_size % 16)
+    return plaintext_size + pad_len
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `aes_ecb_padded_size(plaintext_size)` utility function to both `aes/aes.py` (pure-Python) and `aes/aes_openssl.py` (OpenSSL ctypes).
- This function calculates the ciphertext size after AES-ECB + PKCS7 padding without performing actual encryption.
- Export added to `__all__` in both modules.

## Motivation

Needed by `weilink` for CDN upload size calculation -- the upload protocol requires knowing the encrypted payload size before the actual encryption and upload, so a lightweight size-only computation avoids unnecessary work.

## Test plan

- [ ] Verify `aes_ecb_padded_size(0) == 16` (full block of padding)
- [ ] Verify `aes_ecb_padded_size(1) == 16`
- [ ] Verify `aes_ecb_padded_size(16) == 32` (PKCS7 always adds padding)
- [ ] Verify `aes_ecb_padded_size(31) == 32`
- [ ] Verify `aes_ecb_padded_size(32) == 48`
- [ ] Confirm function is importable from both `aes.aes` and `aes.aes_openssl`