### PR TITLE
feat: add persistdict module with pluggable backends

### DIFF
--- a/persistdict/persistdict.py
+++ b/persistdict/persistdict.py
@@ -1,0 +1,496 @@
+# /// zerodep
+# version = "0.3.0"
+# deps = []
+# tier = "medium"
+# category = "data"
+# ///
+"""Persistent dictionary with pluggable backends.
+
+Zero dependencies, stdlib only, Python 3.10+.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+A MutableMapping that persists key-value pairs to disk.  Supports JSON file
+and SQLite backends with pluggable serialization.  Thread-safe by default.
+
+Example::
+
+    from persistdict import open
+
+    # Auto-detect backend from file extension
+    with open("data.json") as d:
+        d["name"] = "Alice"
+        d["scores"] = [95, 87, 92]
+
+    # Reopen -- data persists
+    with open("data.json") as d:
+        print(d["name"])      # "Alice"
+        print(len(d))         # 2
+
+    # SQLite backend for larger datasets
+    with open("data.db") as d:
+        for i in range(10000):
+            d[f"key_{i}"] = {"index": i}
+
+    # Explicit backend and custom table
+    with open("app.db", backend="sqlite", table="users") as users:
+        users["alice"] = {"email": "alice@example.com"}
+
+    # Direct class usage with custom serializer
+    from persistdict import PersistDict, SqliteBackend
+
+    backend = SqliteBackend("mydata.db", table="config")
+    d = PersistDict(backend)
+    d["debug"] = True
+    d.close()
+
+Requirements:
+    Python >= 3.10, no third-party packages.
+"""
+
+from __future__ import annotations
+
+import collections.abc
+import json
+import os
+import re
+import sqlite3
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+__all__ = [
+    # Main class
+    "PersistDict",
+    # Backends
+    "Backend",
+    "JsonFileBackend",
+    "SqliteBackend",
+    # Serialization
+    "Serializer",
+    "JsonSerializer",
+    # Factory
+    "open",
+]
+
+
+# ── Serializer ────────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class Serializer(Protocol):
+    """Protocol for value serialization."""
+
+    def dumps(self, obj: Any) -> str: ...
+    def loads(self, s: str) -> Any: ...
+
+
+class JsonSerializer:
+    """JSON serializer (default).
+
+    Args:
+        ensure_ascii: Passed to ``json.dumps``.  Defaults to ``False`` so
+            non-ASCII data is preserved without escaping.
+        **kwargs: Extra keyword arguments forwarded to ``json.dumps``.
+    """
+
+    def __init__(self, *, ensure_ascii: bool = False, **kwargs: Any) -> None:
+        self._dump_kw: dict[str, Any] = {"ensure_ascii": ensure_ascii, **kwargs}
+
+    def dumps(self, obj: Any) -> str:
+        """Serialize *obj* to a JSON string."""
+        return json.dumps(obj, **self._dump_kw)
+
+    def loads(self, s: str) -> Any:
+        """Deserialize a JSON string back to a Python object."""
+        return json.loads(s)
+
+
+# ── Backend Protocol ──────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class Backend(Protocol):
+    """Protocol that storage backends must satisfy."""
+
+    def get(self, key: str) -> str: ...
+    def set(self, key: str, value: str) -> None: ...
+    def delete(self, key: str) -> None: ...
+    def contains(self, key: str) -> bool: ...
+    def keys(self) -> Iterator[str]: ...
+    def __len__(self) -> int: ...
+    def clear(self) -> None: ...
+    def flush(self) -> None: ...
+    def close(self) -> None: ...
+
+
+# ── JSON File Backend ─────────────────────────────────────────────────────
+
+_EMPTY_MARKERS = {b"", b"{}"}
+
+
+class JsonFileBackend:
+    """Fully-buffered JSON file backend.
+
+    The entire file is loaded into memory on open.  Mutations happen
+    in-memory and are written atomically (temp file + ``os.replace``) on
+    :meth:`flush` or :meth:`close`.
+
+    Args:
+        path: Path to the JSON file.  Created on first flush if missing.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self._path = Path(path)
+        self._closed = False
+        self._data: dict[str, str] = {}
+        if self._path.exists():
+            raw = self._path.read_bytes().strip()
+            if raw and raw not in _EMPTY_MARKERS:
+                try:
+                    loaded = json.loads(raw)
+                except (json.JSONDecodeError, ValueError) as exc:
+                    raise ValueError(f"corrupt JSON file: {self._path}") from exc
+                if not isinstance(loaded, dict):
+                    raise ValueError(
+                        f"expected JSON object, got {type(loaded).__name__}: "
+                        f"{self._path}"
+                    )
+                self._data = loaded
+
+    # -- Backend interface -------------------------------------------------
+
+    def get(self, key: str) -> str:
+        return self._data[key]
+
+    def set(self, key: str, value: str) -> None:
+        self._data[key] = value
+
+    def delete(self, key: str) -> None:
+        del self._data[key]
+
+    def contains(self, key: str) -> bool:
+        return key in self._data
+
+    def keys(self) -> Iterator[str]:
+        return iter(list(self._data))
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    def flush(self) -> None:
+        """Write the current state to disk atomically."""
+        if self._closed:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(self._path.parent),
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, ensure_ascii=False)
+            os.replace(tmp, str(self._path))
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def close(self) -> None:
+        """Flush and mark as closed."""
+        if self._closed:
+            return
+        self.flush()
+        self._closed = True
+
+    def __repr__(self) -> str:
+        return f"JsonFileBackend({str(self._path)!r})"
+
+
+# ── SQLite Backend ────────────────────────────────────────────────────────
+
+_TABLE_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class SqliteBackend:
+    """Write-through SQLite backend.
+
+    Each :meth:`set` / :meth:`delete` / :meth:`clear` is committed
+    immediately.  Uses WAL journal mode for concurrency.
+
+    Args:
+        path: Path to the SQLite database file.
+        table: Table name for storage (default ``"items"``).  Must be a
+            valid SQL identifier (letters, digits, underscores).
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        table: str = "items",
+    ) -> None:
+        if not _TABLE_NAME_RE.fullmatch(table):
+            raise ValueError(
+                f"invalid table name {table!r}: must match [A-Za-z_][A-Za-z0-9_]*"
+            )
+        self._path = Path(path)
+        self._table = table
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {table} "
+            "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        self._conn.commit()
+
+    # -- Backend interface -------------------------------------------------
+
+    def get(self, key: str) -> str:
+        row = self._conn.execute(
+            f"SELECT value FROM {self._table} WHERE key = ?", (key,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(key)
+        return row[0]
+
+    def set(self, key: str, value: str) -> None:
+        self._conn.execute(
+            f"INSERT OR REPLACE INTO {self._table} (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+        self._conn.commit()
+
+    def delete(self, key: str) -> None:
+        cur = self._conn.execute(f"DELETE FROM {self._table} WHERE key = ?", (key,))
+        self._conn.commit()
+        if cur.rowcount == 0:
+            raise KeyError(key)
+
+    def contains(self, key: str) -> bool:
+        row = self._conn.execute(
+            f"SELECT 1 FROM {self._table} WHERE key = ? LIMIT 1", (key,)
+        ).fetchone()
+        return row is not None
+
+    def keys(self) -> Iterator[str]:
+        rows = self._conn.execute(f"SELECT key FROM {self._table}").fetchall()
+        return iter([r[0] for r in rows])
+
+    def __len__(self) -> int:
+        row = self._conn.execute(f"SELECT COUNT(*) FROM {self._table}").fetchone()
+        assert row is not None
+        return row[0]
+
+    def clear(self) -> None:
+        self._conn.execute(f"DELETE FROM {self._table}")
+        self._conn.commit()
+
+    def flush(self) -> None:
+        """Commit any pending transaction (no-op in write-through mode)."""
+        self._conn.commit()
+
+    def close(self) -> None:
+        """Close the database connection."""
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def __repr__(self) -> str:
+        return f"SqliteBackend({str(self._path)!r}, table={self._table!r})"
+
+
+# ── PersistDict ───────────────────────────────────────────────────────────
+
+
+class PersistDict(collections.abc.MutableMapping):
+    """Persistent dictionary backed by a pluggable storage backend.
+
+    Implements :class:`collections.abc.MutableMapping` so it can be used
+    as a drop-in replacement for ``dict`` wherever persistence is needed.
+
+    Args:
+        backend: Storage backend (e.g. :class:`JsonFileBackend` or
+            :class:`SqliteBackend`).
+        serializer: Value serializer.  Defaults to :class:`JsonSerializer`.
+        lock: Thread-safety control.  ``True`` (default) creates a new
+            ``threading.Lock``; ``False`` disables locking; a
+            ``threading.Lock`` instance is used as-is.
+    """
+
+    def __init__(
+        self,
+        backend: Backend,
+        *,
+        serializer: Serializer | None = None,
+        lock: threading.Lock | bool = True,
+    ) -> None:
+        self._backend = backend
+        self._serializer: Serializer = serializer or JsonSerializer()
+        if lock is True:
+            self._lock: threading.Lock | None = threading.Lock()
+        elif lock is False:
+            self._lock = None
+        else:
+            self._lock = lock
+        self._closed = False
+
+    # -- Helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _check_key(key: Any) -> str:
+        if not isinstance(key, str):
+            raise TypeError(f"keys must be str, got {type(key).__name__}")
+        return key
+
+    # -- MutableMapping interface ------------------------------------------
+
+    def __getitem__(self, key: Any) -> Any:
+        k = self._check_key(key)
+        if self._lock:
+            with self._lock:
+                raw = self._backend.get(k)
+        else:
+            raw = self._backend.get(k)
+        return self._serializer.loads(raw)
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        k = self._check_key(key)
+        raw = self._serializer.dumps(value)
+        if self._lock:
+            with self._lock:
+                self._backend.set(k, raw)
+        else:
+            self._backend.set(k, raw)
+
+    def __delitem__(self, key: Any) -> None:
+        k = self._check_key(key)
+        if self._lock:
+            with self._lock:
+                self._backend.delete(k)
+        else:
+            self._backend.delete(k)
+
+    def __iter__(self) -> Iterator[str]:
+        if self._lock:
+            with self._lock:
+                return self._backend.keys()
+        return self._backend.keys()
+
+    def __len__(self) -> int:
+        if self._lock:
+            with self._lock:
+                return len(self._backend)
+        return len(self._backend)
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        if self._lock:
+            with self._lock:
+                return self._backend.contains(key)
+        return self._backend.contains(key)
+
+    # -- Extra public API --------------------------------------------------
+
+    def flush(self) -> None:
+        """Flush pending writes to the underlying storage."""
+        if self._lock:
+            with self._lock:
+                self._backend.flush()
+        else:
+            self._backend.flush()
+
+    def close(self) -> None:
+        """Flush and close the backend."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._lock:
+            with self._lock:
+                self._backend.close()
+        else:
+            self._backend.close()
+
+    # -- Context manager ---------------------------------------------------
+
+    def __enter__(self) -> PersistDict:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # -- Representation ----------------------------------------------------
+
+    def __repr__(self) -> str:
+        return f"PersistDict({self._backend!r})"
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+# ── Factory ───────────────────────────────────────────────────────────────
+
+_EXT_TO_BACKEND: dict[str, str] = {
+    ".json": "json",
+    ".db": "sqlite",
+    ".sqlite": "sqlite",
+    ".sqlite3": "sqlite",
+}
+
+
+def open(
+    path: str | os.PathLike[str],
+    *,
+    backend: str = "auto",
+    serializer: Serializer | None = None,
+    lock: threading.Lock | bool = True,
+    table: str = "items",
+) -> PersistDict:
+    """Open a persistent dictionary.
+
+    Args:
+        path: File path for storage.
+        backend: ``"auto"`` (detect from extension), ``"json"``, or
+            ``"sqlite"``.
+        serializer: Value serializer.  Defaults to :class:`JsonSerializer`.
+        lock: Thread-safety control (see :class:`PersistDict`).
+        table: Table name for SQLite backend (ignored for JSON).
+
+    Returns:
+        A :class:`PersistDict` instance backed by the chosen storage.
+
+    Raises:
+        ValueError: If *backend* is ``"auto"`` and the file extension is
+            not recognised, or if *backend* is not a known name.
+    """
+    p = Path(path)
+    kind = backend
+    if kind == "auto":
+        ext = p.suffix.lower()
+        kind = _EXT_TO_BACKEND.get(ext, "")
+        if not kind:
+            raise ValueError(
+                f"cannot auto-detect backend for extension {ext!r}; "
+                "use backend='json' or backend='sqlite'"
+            )
+
+    if kind == "json":
+        be: Backend = JsonFileBackend(p)
+    elif kind == "sqlite":
+        be = SqliteBackend(p, table=table)
+    else:
+        raise ValueError(f"unknown backend {backend!r}")
+
+    return PersistDict(be, serializer=serializer, lock=lock)

--- a/persistdict/test_persistdict_correctness.py
+++ b/persistdict/test_persistdict_correctness.py
@@ -1,0 +1,617 @@
+"""Correctness tests: zerodep persistdict."""
+
+import os
+import sys
+import tempfile
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from persistdict import (
+    Backend,
+    JsonFileBackend,
+    JsonSerializer,
+    Serializer,
+    SqliteBackend,
+    open,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture(params=["json", "sqlite"], ids=["json-backend", "sqlite-backend"])
+def persist_dict(request, tmp_dir):
+    """Parametrized fixture yielding PersistDict with each backend."""
+    if request.param == "json":
+        path = os.path.join(tmp_dir, "test.json")
+    else:
+        path = os.path.join(tmp_dir, "test.db")
+    d = open(path)
+    yield d
+    d.close()
+
+
+@pytest.fixture(params=["json", "sqlite"], ids=["json-backend", "sqlite-backend"])
+def backend_path(request, tmp_dir):
+    """Return (backend_type, path) tuple."""
+    if request.param == "json":
+        return ("json", os.path.join(tmp_dir, "test.json"))
+    return ("sqlite", os.path.join(tmp_dir, "test.db"))
+
+
+# ── TestJsonSerializer ────────────────────────────────────────────────────
+
+
+class TestJsonSerializer:
+    def test_round_trip_primitives(self):
+        s = JsonSerializer()
+        for val in ("hello", 42, 3.14, True, False, None):
+            assert s.loads(s.dumps(val)) == val
+
+    def test_round_trip_collections(self):
+        s = JsonSerializer()
+        data = {"a": [1, 2, {"nested": True}], "b": None}
+        assert s.loads(s.dumps(data)) == data
+
+    def test_non_serializable_raises(self):
+        s = JsonSerializer()
+        with pytest.raises(TypeError):
+            s.dumps(object())
+
+    def test_custom_kwargs(self):
+        s = JsonSerializer(sort_keys=True, indent=2)
+        result = s.dumps({"b": 1, "a": 2})
+        assert result.index('"a"') < result.index('"b"')
+        assert "\n" in result
+
+    def test_ensure_ascii_default(self):
+        s = JsonSerializer()
+        result = s.dumps("你好")
+        assert "你好" in result
+
+    def test_ensure_ascii_true(self):
+        s = JsonSerializer(ensure_ascii=True)
+        result = s.dumps("你好")
+        assert "\\u" in result
+
+    def test_protocol_compliance(self):
+        assert isinstance(JsonSerializer(), Serializer)
+
+
+# ── TestJsonFileBackend ───────────────────────────────────────────────────
+
+
+class TestJsonFileBackend:
+    def test_create_new(self, tmp_dir):
+        path = os.path.join(tmp_dir, "new.json")
+        be = JsonFileBackend(path)
+        assert len(be) == 0
+        be.close()
+
+    def test_set_get(self, tmp_dir):
+        path = os.path.join(tmp_dir, "test.json")
+        be = JsonFileBackend(path)
+        be.set("k", '"v"')
+        assert be.get("k") == '"v"'
+        be.close()
+
+    def test_get_missing_raises(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        with pytest.raises(KeyError):
+            be.get("missing")
+        be.close()
+
+    def test_delete(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        be.set("k", "1")
+        be.delete("k")
+        assert not be.contains("k")
+        be.close()
+
+    def test_delete_missing_raises(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        with pytest.raises(KeyError):
+            be.delete("nope")
+        be.close()
+
+    def test_contains(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        be.set("k", "1")
+        assert be.contains("k")
+        assert not be.contains("other")
+        be.close()
+
+    def test_keys_and_len(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        be.set("a", "1")
+        be.set("b", "2")
+        assert sorted(be.keys()) == ["a", "b"]
+        assert len(be) == 2
+        be.close()
+
+    def test_clear(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        be.set("a", "1")
+        be.set("b", "2")
+        be.clear()
+        assert len(be) == 0
+        be.close()
+
+    def test_persistence(self, tmp_dir):
+        path = os.path.join(tmp_dir, "test.json")
+        be = JsonFileBackend(path)
+        be.set("key", '"value"')
+        be.close()
+        be2 = JsonFileBackend(path)
+        assert be2.get("key") == '"value"'
+        be2.close()
+
+    def test_atomic_flush(self, tmp_dir):
+        path = os.path.join(tmp_dir, "test.json")
+        be = JsonFileBackend(path)
+        be.set("k", "1")
+        be.flush()
+        assert os.path.exists(path)
+        be.close()
+
+    def test_corrupt_file_raises(self, tmp_dir):
+        path = os.path.join(tmp_dir, "bad.json")
+        with builtins_open(path, "w") as f:
+            f.write("{invalid json")
+        with pytest.raises(ValueError, match="corrupt JSON"):
+            JsonFileBackend(path)
+
+    def test_empty_file(self, tmp_dir):
+        path = os.path.join(tmp_dir, "empty.json")
+        with builtins_open(path, "w") as f:
+            f.write("")
+        be = JsonFileBackend(path)
+        assert len(be) == 0
+        be.close()
+
+    def test_empty_object_file(self, tmp_dir):
+        path = os.path.join(tmp_dir, "empty_obj.json")
+        with builtins_open(path, "w") as f:
+            f.write("{}")
+        be = JsonFileBackend(path)
+        assert len(be) == 0
+        be.close()
+
+    def test_non_object_file_raises(self, tmp_dir):
+        path = os.path.join(tmp_dir, "list.json")
+        with builtins_open(path, "w") as f:
+            f.write("[1, 2, 3]")
+        with pytest.raises(ValueError, match="expected JSON object"):
+            JsonFileBackend(path)
+
+    def test_parent_dir_creation(self, tmp_dir):
+        path = os.path.join(tmp_dir, "sub", "dir", "test.json")
+        be = JsonFileBackend(path)
+        be.set("k", "1")
+        be.flush()
+        assert os.path.exists(path)
+        be.close()
+
+    def test_protocol_compliance(self, tmp_dir):
+        be = JsonFileBackend(os.path.join(tmp_dir, "test.json"))
+        assert isinstance(be, Backend)
+        be.close()
+
+
+# ── TestSqliteBackend ─────────────────────────────────────────────────────
+
+
+class TestSqliteBackend:
+    def test_create_new(self, tmp_dir):
+        path = os.path.join(tmp_dir, "new.db")
+        be = SqliteBackend(path)
+        assert len(be) == 0
+        be.close()
+
+    def test_set_get(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        be.set("k", '"v"')
+        assert be.get("k") == '"v"'
+        be.close()
+
+    def test_get_missing_raises(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        with pytest.raises(KeyError):
+            be.get("missing")
+        be.close()
+
+    def test_delete(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        be.set("k", "1")
+        be.delete("k")
+        assert not be.contains("k")
+        be.close()
+
+    def test_delete_missing_raises(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        with pytest.raises(KeyError):
+            be.delete("nope")
+        be.close()
+
+    def test_contains(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        be.set("k", "1")
+        assert be.contains("k")
+        assert not be.contains("other")
+        be.close()
+
+    def test_keys_and_len(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        be.set("a", "1")
+        be.set("b", "2")
+        assert sorted(be.keys()) == ["a", "b"]
+        assert len(be) == 2
+        be.close()
+
+    def test_clear(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        be.set("a", "1")
+        be.set("b", "2")
+        be.clear()
+        assert len(be) == 0
+        be.close()
+
+    def test_persistence(self, tmp_dir):
+        path = os.path.join(tmp_dir, "test.db")
+        be = SqliteBackend(path)
+        be.set("key", '"value"')
+        be.close()
+        be2 = SqliteBackend(path)
+        assert be2.get("key") == '"value"'
+        be2.close()
+
+    def test_wal_mode(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        mode = be._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode == "wal"
+        be.close()
+
+    def test_invalid_table_name(self, tmp_dir):
+        with pytest.raises(ValueError, match="invalid table name"):
+            SqliteBackend(os.path.join(tmp_dir, "test.db"), table="drop table;")
+
+    def test_invalid_table_name_digit_start(self, tmp_dir):
+        with pytest.raises(ValueError, match="invalid table name"):
+            SqliteBackend(os.path.join(tmp_dir, "test.db"), table="123bad")
+
+    def test_multi_table(self, tmp_dir):
+        path = os.path.join(tmp_dir, "multi.db")
+        be1 = SqliteBackend(path, table="users")
+        be2 = SqliteBackend(path, table="config")
+        be1.set("alice", "1")
+        be2.set("debug", "true")
+        assert be1.contains("alice")
+        assert not be1.contains("debug")
+        assert be2.contains("debug")
+        assert not be2.contains("alice")
+        be1.close()
+        be2.close()
+
+    def test_parent_dir_creation(self, tmp_dir):
+        path = os.path.join(tmp_dir, "sub", "dir", "test.db")
+        be = SqliteBackend(path)
+        be.set("k", "1")
+        assert os.path.exists(path)
+        be.close()
+
+    def test_protocol_compliance(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        assert isinstance(be, Backend)
+        be.close()
+
+    def test_upsert(self, tmp_dir):
+        be = SqliteBackend(os.path.join(tmp_dir, "test.db"))
+        be.set("k", "old")
+        be.set("k", "new")
+        assert be.get("k") == "new"
+        assert len(be) == 1
+        be.close()
+
+
+# ── TestPersistDict ───────────────────────────────────────────────────────
+
+
+class TestPersistDict:
+    def test_getitem_setitem(self, persist_dict):
+        persist_dict["name"] = "Alice"
+        assert persist_dict["name"] == "Alice"
+
+    def test_getitem_missing_raises(self, persist_dict):
+        with pytest.raises(KeyError):
+            persist_dict["missing"]
+
+    def test_delitem(self, persist_dict):
+        persist_dict["k"] = 1
+        del persist_dict["k"]
+        assert "k" not in persist_dict
+
+    def test_delitem_missing_raises(self, persist_dict):
+        with pytest.raises(KeyError):
+            del persist_dict["nope"]
+
+    def test_iter(self, persist_dict):
+        persist_dict["a"] = 1
+        persist_dict["b"] = 2
+        assert sorted(persist_dict) == ["a", "b"]
+
+    def test_len(self, persist_dict):
+        assert len(persist_dict) == 0
+        persist_dict["x"] = 1
+        assert len(persist_dict) == 1
+
+    def test_contains(self, persist_dict):
+        persist_dict["k"] = 1
+        assert "k" in persist_dict
+        assert "other" not in persist_dict
+
+    def test_contains_non_str(self, persist_dict):
+        assert 42 not in persist_dict
+
+    def test_get_default(self, persist_dict):
+        assert persist_dict.get("missing") is None
+        assert persist_dict.get("missing", 99) == 99
+
+    def test_pop(self, persist_dict):
+        persist_dict["k"] = "v"
+        assert persist_dict.pop("k") == "v"
+        assert "k" not in persist_dict
+
+    def test_pop_default(self, persist_dict):
+        assert persist_dict.pop("nope", "default") == "default"
+
+    def test_popitem(self, persist_dict):
+        persist_dict["only"] = 1
+        k, v = persist_dict.popitem()
+        assert k == "only"
+        assert v == 1
+        assert len(persist_dict) == 0
+
+    def test_clear(self, persist_dict):
+        persist_dict["a"] = 1
+        persist_dict["b"] = 2
+        persist_dict.clear()
+        assert len(persist_dict) == 0
+
+    def test_update(self, persist_dict):
+        persist_dict.update({"a": 1, "b": 2})
+        assert persist_dict["a"] == 1
+        assert persist_dict["b"] == 2
+
+    def test_setdefault(self, persist_dict):
+        persist_dict.setdefault("k", 42)
+        assert persist_dict["k"] == 42
+        persist_dict.setdefault("k", 99)
+        assert persist_dict["k"] == 42
+
+    def test_keys_values_items(self, persist_dict):
+        persist_dict["a"] = 1
+        persist_dict["b"] = 2
+        assert sorted(persist_dict.keys()) == ["a", "b"]
+        assert sorted(persist_dict.values()) == [1, 2]
+        assert sorted(persist_dict.items()) == [("a", 1), ("b", 2)]
+
+    def test_key_type_validation(self, persist_dict):
+        with pytest.raises(TypeError, match="keys must be str"):
+            persist_dict[123] = "value"
+        with pytest.raises(TypeError, match="keys must be str"):
+            _ = persist_dict[123]
+        with pytest.raises(TypeError, match="keys must be str"):
+            del persist_dict[123]
+
+    def test_complex_values(self, persist_dict):
+        data = {"nested": {"list": [1, 2, 3], "flag": True, "null": None}}
+        persist_dict["complex"] = data
+        assert persist_dict["complex"] == data
+
+    def test_repr(self, persist_dict):
+        r = repr(persist_dict)
+        assert r.startswith("PersistDict(")
+
+
+class TestPersistDictPersistence:
+    def test_json_round_trip(self, tmp_dir):
+        path = os.path.join(tmp_dir, "rt.json")
+        with open(path) as d:
+            d["name"] = "Alice"
+            d["scores"] = [95, 87]
+        with open(path) as d:
+            assert d["name"] == "Alice"
+            assert d["scores"] == [95, 87]
+            assert len(d) == 2
+
+    def test_sqlite_round_trip(self, tmp_dir):
+        path = os.path.join(tmp_dir, "rt.db")
+        with open(path) as d:
+            d["name"] = "Alice"
+            d["scores"] = [95, 87]
+        with open(path) as d:
+            assert d["name"] == "Alice"
+            assert d["scores"] == [95, 87]
+            assert len(d) == 2
+
+
+class TestPersistDictCustomSerializer:
+    def test_custom_serializer(self, tmp_dir):
+        class UpperSerializer:
+            def dumps(self, obj):
+                return str(obj).upper()
+
+            def loads(self, s):
+                return s.lower()
+
+        path = os.path.join(tmp_dir, "custom.db")
+        d = open(path, serializer=UpperSerializer())
+        d["k"] = "hello"
+        assert d["k"] == "hello"
+        d.close()
+
+
+# ── TestPersistDictContextManager ─────────────────────────────────────────
+
+
+class TestPersistDictContextManager:
+    def test_context_manager(self, tmp_dir):
+        path = os.path.join(tmp_dir, "ctx.json")
+        with open(path) as d:
+            d["k"] = "v"
+        with open(path) as d:
+            assert d["k"] == "v"
+
+    def test_close_idempotent(self, tmp_dir):
+        path = os.path.join(tmp_dir, "ctx.json")
+        d = open(path)
+        d["k"] = 1
+        d.close()
+        d.close()  # should not raise
+
+
+# ── TestPersistDictThreadSafety ───────────────────────────────────────────
+
+
+class TestPersistDictThreadSafety:
+    def test_concurrent_writes(self, backend_path):
+        kind, path = backend_path
+        d = open(path, backend=kind)
+        errors: list[Exception] = []
+
+        def writer(start: int) -> None:
+            try:
+                for i in range(100):
+                    d[f"key_{start + i}"] = start + i
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(i * 100,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+        assert len(d) == 400
+        d.close()
+
+    def test_concurrent_read_write(self, backend_path):
+        kind, path = backend_path
+        d = open(path, backend=kind)
+        d["shared"] = 0
+        errors: list[Exception] = []
+
+        def writer() -> None:
+            try:
+                for i in range(200):
+                    d["shared"] = i
+            except Exception as exc:
+                errors.append(exc)
+
+        def reader() -> None:
+            try:
+                for _ in range(200):
+                    _ = d["shared"]
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer),
+            threading.Thread(target=reader),
+            threading.Thread(target=reader),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+        d.close()
+
+    def test_no_lock(self, tmp_dir):
+        path = os.path.join(tmp_dir, "nolock.db")
+        d = open(path, lock=False)
+        d["k"] = 1
+        assert d["k"] == 1
+        d.close()
+
+
+# ── TestOpenFactory ───────────────────────────────────────────────────────
+
+
+class TestOpenFactory:
+    def test_auto_json(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.json")
+        d = open(path)
+        assert isinstance(d._backend, JsonFileBackend)
+        d.close()
+
+    def test_auto_db(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.db")
+        d = open(path)
+        assert isinstance(d._backend, SqliteBackend)
+        d.close()
+
+    def test_auto_sqlite(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.sqlite")
+        d = open(path)
+        assert isinstance(d._backend, SqliteBackend)
+        d.close()
+
+    def test_auto_sqlite3(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.sqlite3")
+        d = open(path)
+        assert isinstance(d._backend, SqliteBackend)
+        d.close()
+
+    def test_explicit_json(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.dat")
+        d = open(path, backend="json")
+        assert isinstance(d._backend, JsonFileBackend)
+        d.close()
+
+    def test_explicit_sqlite(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.dat")
+        d = open(path, backend="sqlite")
+        assert isinstance(d._backend, SqliteBackend)
+        d.close()
+
+    def test_unknown_extension_raises(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.xyz")
+        with pytest.raises(ValueError, match="cannot auto-detect"):
+            open(path)
+
+    def test_unknown_backend_raises(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.json")
+        with pytest.raises(ValueError, match="unknown backend"):
+            open(path, backend="redis")
+
+    def test_table_forwarded(self, tmp_dir):
+        path = os.path.join(tmp_dir, "data.db")
+        d = open(path, table="custom")
+        assert d._backend._table == "custom"
+        d.close()
+
+    def test_context_manager_via_factory(self, tmp_dir):
+        path = os.path.join(tmp_dir, "ctx.json")
+        with open(path) as d:
+            d["k"] = "v"
+        with open(path) as d:
+            assert d["k"] == "v"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+# Alias to avoid shadowing by persistdict.open
+builtins_open = (  # type: ignore[index]
+    __builtins__["open"] if isinstance(__builtins__, dict) else __builtins__.open
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict"]
 
 [tool.ruff]
 target-version = "py310"
@@ -176,4 +176,5 @@ extra-paths = [
     "./acp",
     "./skills",
     "./filelock",
+    "./persistdict",
 ]


### PR DESCRIPTION
## Summary

- New `persistdict` module: `MutableMapping`-based persistent dictionary with pluggable backends (JSON file + SQLite) and pluggable serialization (JSON by default, no pickle)
- Thread-safe by default, atomic writes, namespace support via SQLite tables
- Factory function `open()` auto-detects backend from file extension (`.json` → JSON, `.db`/`.sqlite` → SQLite)
- 97 correctness tests covering serializer, backends, MutableMapping compliance, thread safety, and factory

Closes #33

## Test plan

- [x] 97 tests pass (`pytest persistdict/ -v`)
- [x] `ruff check` and `ruff format` clean
- [x] `ty check` clean
- [x] CI across Python 3.10-3.13