### PR TITLE
perf: cache get_type_hints in validate module

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-04-09T14:51:46.523881+00:00",
+  "generated": "2026-04-10T08:37:08.549244+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -383,12 +383,12 @@
       "files": [
         "validate/validate.py"
       ],
-      "version": "0.4.0",
+      "version": "0.4.1",
       "deps": [],
       "tier": "medium",
       "category": "data",
       "last_updated": "2026-04-09T22:14:17+08:00",
-      "content_hash": "2bbd23088920dad933f1e9c38cc974c3d6b0531630d6bf0d80f1b338469b0f20"
+      "content_hash": "95c75e3a8c306ba50580cab4fdc5e83d40a2ce93b9ae16bd34ffedb1d70360e4"
     },
     "vcs": {
       "description": "VCS CLI wrapper — zero dependencies, stdlib only, Python 3.10+",

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.0"
+# version = "0.4.1"
 # deps = []
 # tier = "medium"
 # category = "data"
@@ -40,6 +40,7 @@ Annotated constraints::
 from __future__ import annotations
 
 import dataclasses
+import functools
 import re
 import typing
 from typing import Any, Callable, Union, get_type_hints
@@ -279,8 +280,12 @@ def _is_dataclass_type(tp: Any) -> bool:
     return isinstance(tp, type) and dataclasses.is_dataclass(tp)
 
 
+@functools.lru_cache(maxsize=None)
 def _typeddict_fields(td: type) -> dict[str, tuple[Any, bool]]:
     """Get fields of a TypedDict with their types and required status.
+
+    Results are cached because TypedDict type structures are static at
+    runtime, and ``get_type_hints()`` is expensive on Python 3.10-3.12.
 
     Returns:
         Dict mapping field name to ``(type_hint, is_required)``.
@@ -300,8 +305,12 @@ def _typeddict_fields(td: type) -> dict[str, tuple[Any, bool]]:
     return result
 
 
+@functools.lru_cache(maxsize=None)
 def _dataclass_fields(dc: type) -> dict[str, tuple[Any, bool]]:
     """Get fields of a dataclass with their types and required status.
+
+    Results are cached because dataclass type structures are static at
+    runtime, and ``get_type_hints()`` is expensive on Python 3.10-3.12.
 
     Returns:
         Dict mapping field name to ``(type_hint, is_required)``.
@@ -351,20 +360,23 @@ def _type_name(tp: Any) -> str:
     return str(tp)
 
 
+@functools.lru_cache(maxsize=None)
 def _find_discriminator(union_args: tuple[Any, ...]) -> str | None:
     """Find a shared Literal field that can discriminate union members.
 
     Checks all TypedDict members for a common field whose type is
     ``Literal[...]``.  Returns the field name if found, else None.
+
+    Results are cached because union type structures are static.
     """
     td_args = [a for a in union_args if _is_typeddict(a)]
     if len(td_args) < 2:
         return None
 
     # Get all Literal field names from first TypedDict
-    first_hints = get_type_hints(td_args[0], include_extras=True)
+    first_fields = _typeddict_fields(td_args[0])
     candidates: list[str] = []
-    for name, hint in first_hints.items():
+    for name, (hint, _req) in first_fields.items():
         base, _ = _unwrap_annotated(hint)
         if typing.get_origin(base) is typing.Literal:
             candidates.append(name)
@@ -373,11 +385,11 @@ def _find_discriminator(union_args: tuple[Any, ...]) -> str | None:
         # Check that all other TypedDicts also have this field as Literal
         all_have = True
         for td in td_args[1:]:
-            hints = get_type_hints(td, include_extras=True)
-            if name not in hints:
+            fields = _typeddict_fields(td)
+            if name not in fields:
                 all_have = False
                 break
-            base, _ = _unwrap_annotated(hints[name])
+            base, _ = _unwrap_annotated(fields[name][0])
             if typing.get_origin(base) is not typing.Literal:
                 all_have = False
                 break
@@ -518,10 +530,10 @@ def _validate(
             for candidate in non_none_args:
                 if not _is_typeddict(candidate):
                     continue
-                hints = get_type_hints(candidate, include_extras=True)
-                if disc_field not in hints:
+                fields = _typeddict_fields(candidate)
+                if disc_field not in fields:
                     continue
-                base, _ = _unwrap_annotated(hints[disc_field])
+                base, _ = _unwrap_annotated(fields[disc_field][0])
                 if typing.get_origin(base) is typing.Literal:
                     if disc_val in typing.get_args(base):
                         return _validate(value, candidate, path, errors, coerce)


### PR DESCRIPTION
## Summary

- Cache `_typeddict_fields`, `_dataclass_fields`, and `_find_discriminator` with `@functools.lru_cache(maxsize=None)`
- Replace inline `get_type_hints()` in discriminated union matching with cached `_typeddict_fields()` lookups
- Bump validate version to 0.4.1

Closes #40

## Motivation

`get_type_hints()` is expensive on Python 3.10-3.12 (~19μs/call). In real-world usage (llm-rosetta validating 83 messages with 41 tool definitions), it was called 65,800 times for only 16 unique TypedDict types, consuming 92% of total runtime.

Since TypedDict/dataclass type structures are static at runtime, caching is safe and yields **8.9-11.2x speedup** for repeated `validate()` calls.

## Test plan

- [ ] All 94 existing validate correctness tests pass
- [ ] Benchmark confirms speedup