### PR TITLE
fix: strip Required/NotRequired wrappers in _typeddict_fields

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-04-10T08:37:08.549244+00:00",
+  "generated": "2026-04-10T08:42:43.482724+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -383,12 +383,12 @@
       "files": [
         "validate/validate.py"
       ],
-      "version": "0.4.1",
+      "version": "0.4.2",
       "deps": [],
       "tier": "medium",
       "category": "data",
-      "last_updated": "2026-04-09T22:14:17+08:00",
-      "content_hash": "95c75e3a8c306ba50580cab4fdc5e83d40a2ce93b9ae16bd34ffedb1d70360e4"
+      "last_updated": "2026-04-10T16:37:38+08:00",
+      "content_hash": "f537737e8bd1cf86570006237f1050838041ef6d405dda121a5d134d00b57400"
     },
     "vcs": {
       "description": "VCS CLI wrapper — zero dependencies, stdlib only, Python 3.10+",

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.1"
+# version = "0.4.2"
 # deps = []
 # tier = "medium"
 # category = "data"
@@ -280,12 +280,30 @@ def _is_dataclass_type(tp: Any) -> bool:
     return isinstance(tp, type) and dataclasses.is_dataclass(tp)
 
 
+def _strip_required(tp: Any) -> Any:
+    """Strip ``Required`` / ``NotRequired`` wrappers, returning the inner type."""
+    import sys
+
+    origin = typing.get_origin(tp)
+    if sys.version_info >= (3, 11):
+        from typing import NotRequired, Required
+    else:
+        from typing_extensions import NotRequired, Required
+    if origin is Required or origin is NotRequired:
+        args = typing.get_args(tp)
+        return args[0] if args else tp
+    return tp
+
+
 @functools.lru_cache(maxsize=None)
 def _typeddict_fields(td: type) -> dict[str, tuple[Any, bool]]:
     """Get fields of a TypedDict with their types and required status.
 
     Results are cached because TypedDict type structures are static at
     runtime, and ``get_type_hints()`` is expensive on Python 3.10-3.12.
+
+    Strips ``Required``/``NotRequired`` wrappers so downstream sees the
+    actual type (e.g. ``Literal["response"]``, not ``Required[Literal["response"]]``).
 
     Returns:
         Dict mapping field name to ``(type_hint, is_required)``.
@@ -295,13 +313,14 @@ def _typeddict_fields(td: type) -> dict[str, tuple[Any, bool]]:
     optional = getattr(td, "__optional_keys__", set())
     result: dict[str, tuple[Any, bool]] = {}
     for name, tp in hints.items():
+        inner = _strip_required(tp)
         if name in required:
-            result[name] = (tp, True)
+            result[name] = (inner, True)
         elif name in optional:
-            result[name] = (tp, False)
+            result[name] = (inner, False)
         else:
             # Default: assume required (total=True is the default)
-            result[name] = (tp, True)
+            result[name] = (inner, True)
     return result
 
 


### PR DESCRIPTION
## Summary

- Add `_strip_required()` helper to unwrap `Required[T]` / `NotRequired[T]` wrappers from `get_type_hints(include_extras=True)` output
- Apply in `_typeddict_fields` so all downstream consumers (discriminator matching, field validation) see the actual inner type
- Bump validate version to 0.4.2

## Problem

When TypedDict fields use `typing_extensions.Required` or `NotRequired`, `get_type_hints(include_extras=True)` returns wrapped types like `Required[Literal["system"]]`. The discriminator matching in `_find_discriminator` and field validation in `_validate` expected unwrapped types, causing:
- Discriminated union matching to fail silently (falling through to expensive try-each-variant path)
- Type validation to miss invalid values for wrapped Literal fields

## Test plan

- [ ] All 94 existing validate correctness tests pass
- [ ] Verified fix with llm-rosetta's `test_invalid_message_role` test (previously failing after v0.4.1 import)