### PR TITLE
perf: cache type-checking helpers in validate module

### DIFF
--- a/validate/validate.py
+++ b/validate/validate.py
@@ -250,33 +250,44 @@ class ValidationError(Exception):
 # ── Internal Helpers ──
 
 
-def _unwrap_annotated(tp: Any) -> tuple[Any, list[Any]]:
+@functools.lru_cache(maxsize=None)
+def _unwrap_annotated(tp: Any) -> tuple[Any, tuple[Any, ...]]:
     """Extract the base type and constraint metadata from an Annotated type.
 
+    Results are cached because Annotated type structures are static at
+    runtime.
+
     Returns:
-        ``(base_type, [constraint1, constraint2, ...])`` if Annotated,
-        otherwise ``(tp, [])``.
+        ``(base_type, (constraint1, constraint2, ...))`` if Annotated,
+        otherwise ``(tp, ())``.
     """
     origin = typing.get_origin(tp)
     if origin is typing.Annotated:
         args = typing.get_args(tp)
         base = args[0]
-        constraints = [a for a in args[1:] if isinstance(a, _CONSTRAINT_TYPES)]
+        constraints = tuple(a for a in args[1:] if isinstance(a, _CONSTRAINT_TYPES))
         return base, constraints
-    return tp, []
+    return tp, ()
 
 
+@functools.lru_cache(maxsize=None)
 def _is_typeddict(tp: Any) -> bool:
     """Check if *tp* is a TypedDict class.
 
     Uses ``__required_keys__`` attribute detection to support TypedDicts
     created with both ``typing.TypedDict`` and ``typing_extensions.TypedDict``.
+
+    Results are cached because type identity is stable at runtime.
     """
     return isinstance(tp, type) and hasattr(tp, "__required_keys__")
 
 
+@functools.lru_cache(maxsize=None)
 def _is_dataclass_type(tp: Any) -> bool:
-    """Check if *tp* is a dataclass class (not an instance)."""
+    """Check if *tp* is a dataclass class (not an instance).
+
+    Results are cached because type identity is stable at runtime.
+    """
     return isinstance(tp, type) and dataclasses.is_dataclass(tp)
 
 


### PR DESCRIPTION
## Summary

- Add `@functools.lru_cache` to `_is_typeddict()`, `_is_dataclass_type()`, and `_unwrap_annotated()` to avoid redundant type introspection
- These helpers are called 50K-150K times per validation of a large payload but only encounter ~16 unique types
- Also changed `_unwrap_annotated` return type from `list` to `tuple` for hashability

## Benchmark (real Claude Code payloads, 10-run average)

| Payload | Before | After | Improvement |
|---------|--------|-------|-------------|
| 64msg (83 msgs, 41 tools) | 2,678 ± 5 μs | 2,375 ± 10 μs | **-11.3%** |
| 218msg (219 msgs, 41 tools) | 5,423 ± 24 μs | 4,945 ± 39 μs | **-8.8%** |

## Notes

Also attempted caching `typing.get_origin`/`typing.get_args` but the `__hash__` overhead for typing objects exceeded savings — not included.

## Test plan

- [x] All 104 validate tests pass
- [x] llm-rosetta 1361 tests pass with reimported module