### PR TITLE
feat(jsonschema): add JSON Schema flattening & sanitization module

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install readability JS dependencies
         run: cd readability && npm install --prefer-offline --no-audit
 
+      - name: Install jsonschema JS dependencies
+        run: cd jsonschema && npm install --prefer-offline --no-audit
+
       - name: Check module versions
         continue-on-error: true
         run: python -m zerodep version-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test benchmark lint fmt clean help manifest version-check dep-graph dep-check test-tabulate benchmark-tabulate test-soup benchmark-soup test-prompt test-validate benchmark-validate test-markdown benchmark-markdown test-diff benchmark-diff test-vcs test-ansi test-frontmatter benchmark-frontmatter test-cache benchmark-cache test-readability benchmark-readability benchmark-readability-compare
+.PHONY: all test benchmark lint fmt clean help manifest version-check dep-graph dep-check test-tabulate benchmark-tabulate test-soup benchmark-soup test-prompt test-validate benchmark-validate test-markdown benchmark-markdown test-diff benchmark-diff test-vcs test-ansi test-frontmatter benchmark-frontmatter test-cache benchmark-cache test-readability benchmark-readability benchmark-readability-compare test-jsonschema benchmark-jsonschema
 
 help:
 	@echo "Available targets:"
@@ -40,6 +40,8 @@ help:
 	@echo "  test-readability - Run readability correctness tests"
 	@echo "  benchmark-readability - Run readability benchmarks (Python)"
 	@echo "  benchmark-readability-compare - Run three-way benchmark (zerodep vs lxml vs Mozilla JS)"
+	@echo "  test-jsonschema  - Run jsonschema correctness tests"
+	@echo "  benchmark-jsonschema - Run jsonschema benchmarks (vs allof-merge JS)"
 	@echo "  manifest         - Regenerate manifest.json"
 	@echo "  version-check    - Check modules for uncommitted version bumps"
 	@echo "  dep-graph        - Show module dependency graph"
@@ -49,7 +51,7 @@ help:
 	@echo "  clean            - Clean generated files"
 
 test:
-	pytest aes/test_aes_correctness.py qr/test_qr_correctness.py httpclient/test_http_correctness.py dotenv/test_dotenv_correctness.py yaml/test_yaml_correctness.py jsonc/test_jsonc_correctness.py retry/test_retry_correctness.py toon/test_toon_correctness.py tabulate/test_tabulate_correctness.py soup/test_soup_correctness.py prompt/test_prompt_correctness.py validate/test_validate_correctness.py markdown/test_markdown_correctness.py diff/test_diff_correctness.py vcs/test_vcs_correctness.py ansi/test_ansi_correctness.py frontmatter/test_frontmatter_correctness.py cache/test_cache_correctness.py readability/test_readability_correctness.py -v
+	pytest aes/test_aes_correctness.py qr/test_qr_correctness.py httpclient/test_http_correctness.py dotenv/test_dotenv_correctness.py yaml/test_yaml_correctness.py jsonc/test_jsonc_correctness.py retry/test_retry_correctness.py toon/test_toon_correctness.py tabulate/test_tabulate_correctness.py soup/test_soup_correctness.py prompt/test_prompt_correctness.py validate/test_validate_correctness.py markdown/test_markdown_correctness.py diff/test_diff_correctness.py vcs/test_vcs_correctness.py ansi/test_ansi_correctness.py frontmatter/test_frontmatter_correctness.py cache/test_cache_correctness.py readability/test_readability_correctness.py jsonschema/test_jsonschema_correctness.py -v
 
 test-aes:
 	pytest aes/test_aes_correctness.py -v
@@ -91,7 +93,7 @@ test-markdown:
 	pytest markdown/test_markdown_correctness.py -v
 
 benchmark:
-	pytest aes/test_aes_benchmark.py qr/test_qr_benchmark.py httpclient/test_http_benchmark.py dotenv/test_dotenv_benchmark.py yaml/test_yaml_benchmark.py jsonc/test_jsonc_benchmark.py retry/test_retry_benchmark.py toon/test_toon_benchmark.py tabulate/test_tabulate_benchmark.py soup/test_soup_benchmark.py validate/test_validate_benchmark.py markdown/test_markdown_benchmark.py diff/test_diff_benchmark.py frontmatter/test_frontmatter_benchmark.py cache/test_cache_benchmark.py readability/test_readability_benchmark.py -v
+	pytest aes/test_aes_benchmark.py qr/test_qr_benchmark.py httpclient/test_http_benchmark.py dotenv/test_dotenv_benchmark.py yaml/test_yaml_benchmark.py jsonc/test_jsonc_benchmark.py retry/test_retry_benchmark.py toon/test_toon_benchmark.py tabulate/test_tabulate_benchmark.py soup/test_soup_benchmark.py validate/test_validate_benchmark.py markdown/test_markdown_benchmark.py diff/test_diff_benchmark.py frontmatter/test_frontmatter_benchmark.py cache/test_cache_benchmark.py readability/test_readability_benchmark.py jsonschema/test_jsonschema_benchmark.py -v
 
 benchmark-aes:
 	pytest aes/test_aes_benchmark.py -v
@@ -162,6 +164,12 @@ benchmark-readability:
 benchmark-readability-compare:
 	cd readability && npm install --prefer-offline --no-audit 2>/dev/null; \
 	python readability/benchmark_compare.py
+
+test-jsonschema:
+	pytest jsonschema/test_jsonschema_correctness.py -v
+
+benchmark-jsonschema:
+	pytest jsonschema/test_jsonschema_benchmark.py -v
 
 manifest:
 	python zerodep.py manifest

--- a/jsonschema/bench_allof_merge.js
+++ b/jsonschema/bench_allof_merge.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Benchmark helper: run allof-merge on JSON Schema read from stdin.
+ *
+ * Usage:
+ *   echo '{"allOf":[...]}' | node bench_allof_merge.js [rounds]
+ *
+ * Outputs JSON:
+ *   { "rounds": N, "times_ms": [...], "min_ms": ...,
+ *     "mean_ms": ..., "max_ms": ..., "result": {...} }
+ */
+
+const { merge } = require("allof-merge");
+
+const rounds = parseInt(process.argv[2] || "10", 10);
+
+let input = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  const schema = JSON.parse(input);
+  const times = [];
+
+  // Warm-up run (not counted).
+  merge(structuredClone(schema));
+
+  for (let i = 0; i < rounds; i++) {
+    const copy = structuredClone(schema);
+    const start = process.hrtime.bigint();
+    merge(copy);
+    const end = process.hrtime.bigint();
+    times.push(Number(end - start) / 1e6); // ns -> ms
+  }
+
+  // Final run for result capture.
+  const result = merge(structuredClone(schema));
+
+  const output = {
+    rounds: rounds,
+    times_ms: times,
+    min_ms: Math.min(...times),
+    mean_ms: times.reduce((a, b) => a + b, 0) / times.length,
+    max_ms: Math.max(...times),
+    result: result,
+  };
+
+  console.log(JSON.stringify(output));
+});

--- a/jsonschema/jsonschema.py
+++ b/jsonschema/jsonschema.py
@@ -1,0 +1,465 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "medium"
+# category = "data"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+"""JSON Schema flattening & sanitization — zero dependencies, stdlib only.
+
+Flatten complex JSON Schemas containing ``$ref``, ``allOf``, ``anyOf``, and
+``oneOf`` into simple, LLM-provider-compatible schemas.  Designed for tool
+schemas consumed by Anthropic, OpenAI, and Google GenAI APIs.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Example::
+
+    >>> from jsonschema import flatten_schema
+    >>> schema = {
+    ...     "type": "object",
+    ...     "properties": {
+    ...         "user": {"$ref": "#/$defs/User"},
+    ...     },
+    ...     "$defs": {
+    ...         "User": {
+    ...             "type": "object",
+    ...             "properties": {"name": {"type": "string"}},
+    ...         }
+    ...     },
+    ... }
+    >>> flatten_schema(schema)
+    {'type': 'object', 'properties': {'user': {'type': 'object', 'properties': {'name': {'type': 'string'}}}}}
+
+Pipeline::
+
+    resolve_refs  →  merge_allof  →  simplify_unions  →  sanitize
+"""
+
+from __future__ import annotations
+
+import copy
+import warnings
+from typing import Any
+
+__all__ = [
+    "flatten_schema",
+    "resolve_refs",
+    "merge_allof",
+    "simplify_unions",
+    "sanitize",
+    "UNSUPPORTED_SCHEMA_KEYS",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFS_KEYS: set[str] = {"$defs", "definitions"}
+
+UNSUPPORTED_SCHEMA_KEYS: set[str] = {
+    # JSON Schema meta
+    "$schema",
+    "$id",
+    "$comment",
+    "$anchor",
+    "$dynamicAnchor",
+    "$dynamicRef",
+    # content keywords
+    "contentEncoding",
+    "contentMediaType",
+    "contentSchema",
+    # documentation / status
+    "deprecated",
+    "readOnly",
+    "writeOnly",
+    "examples",
+    # constraints most LLM providers reject
+    "propertyNames",
+    "const",
+}
+
+# Numeric constraint merge rules: keyword → "take_max" or "take_min".
+# allOf semantics = intersection ⇒ lower-bounds tighten up (max), upper-bounds tighten down (min).
+_LOWER_BOUND_KEYS: set[str] = {
+    "minimum",
+    "exclusiveMinimum",
+    "minLength",
+    "minItems",
+    "minProperties",
+}
+_UPPER_BOUND_KEYS: set[str] = {
+    "maximum",
+    "exclusiveMaximum",
+    "maxLength",
+    "maxItems",
+    "maxProperties",
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1 — $ref resolution
+# ---------------------------------------------------------------------------
+
+
+def _collect_defs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Collect all entries from ``$defs`` and ``definitions`` maps."""
+    defs: dict[str, Any] = {}
+    for key in _DEFS_KEYS:
+        d = schema.get(key)
+        if isinstance(d, dict):
+            defs.update(d)
+    return defs
+
+
+def _resolve_ref(ref: str, defs: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a single ``$ref`` pointer against collected definitions.
+
+    Only local references (``#/$defs/Name``, ``#/definitions/Name``) are
+    supported.  Returns ``{}`` for unresolvable refs.
+    """
+    for prefix in ("#/$defs/", "#/definitions/"):
+        if ref.startswith(prefix):
+            name = ref[len(prefix) :]
+            return defs.get(name, {})
+    return {}
+
+
+def _inline_refs(schema: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
+    """Recursively inline all ``$ref`` pointers in *schema*."""
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _resolve_ref(ref, defs)
+        if resolved:
+            # Sibling keys (e.g. description) override the definition.
+            merged = {**copy.deepcopy(resolved)}
+            for k, v in schema.items():
+                if k != "$ref":
+                    merged[k] = v
+            # Recurse — the resolved schema may contain further $ref.
+            return _inline_refs(merged, defs)
+        else:
+            warnings.warn(
+                f"Unresolvable $ref: {ref!r} — dropped",
+                stacklevel=2,
+            )
+            return {k: v for k, v in schema.items() if k != "$ref"}
+
+    # No $ref at this level — recurse into children.
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if isinstance(value, dict):
+            result[key] = _inline_refs(value, defs)
+        elif isinstance(value, list):
+            result[key] = [
+                _inline_refs(item, defs) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+    return result
+
+
+def resolve_refs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve all local ``$ref`` pointers, inline definitions, and remove
+    ``$defs``/``definitions`` maps.
+
+    Args:
+        schema: A JSON Schema dict.
+
+    Returns:
+        A new dict with all ``$ref`` inlined and definition maps removed.
+    """
+    schema = copy.deepcopy(schema)
+    defs = _collect_defs(schema)
+    result = _inline_refs(schema, defs)
+    # Strip consumed definition maps.
+    for key in _DEFS_KEYS:
+        result.pop(key, None)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — allOf merging
+# ---------------------------------------------------------------------------
+
+
+def _deep_merge_two(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Deep-merge *override* into *base* using allOf intersection semantics.
+
+    - ``properties``: recursively merge per-property schemas.
+    - ``required``: union (deduplicated).
+    - ``type``: intersect.
+    - Numeric constraints: tighten (lower-bounds ↑, upper-bounds ↓).
+    - ``enum``: intersect.
+    - ``items``, ``additionalProperties``: recursive merge if both dicts.
+    - Everything else: *override* wins.
+    """
+    merged = dict(base)  # shallow start — keys are replaced below as needed
+
+    for key, oval in override.items():
+        if key not in merged:
+            merged[key] = oval
+            continue
+
+        bval = merged[key]
+
+        if key == "properties" and isinstance(bval, dict) and isinstance(oval, dict):
+            props = dict(bval)
+            for pname, pschema in oval.items():
+                if (
+                    pname in props
+                    and isinstance(props[pname], dict)
+                    and isinstance(pschema, dict)
+                ):
+                    props[pname] = _deep_merge_two(props[pname], pschema)
+                else:
+                    props[pname] = pschema
+            merged[key] = props
+
+        elif key == "required" and isinstance(bval, list) and isinstance(oval, list):
+            merged[key] = list(dict.fromkeys(bval + oval))  # union, order-preserving
+
+        elif key == "type":
+            merged[key] = _intersect_type(bval, oval)
+
+        elif key in _LOWER_BOUND_KEYS:
+            # Tighten lower bound: take the larger value.
+            if isinstance(bval, (int, float)) and isinstance(oval, (int, float)):
+                merged[key] = max(bval, oval)
+            else:
+                merged[key] = oval
+
+        elif key in _UPPER_BOUND_KEYS:
+            # Tighten upper bound: take the smaller value.
+            if isinstance(bval, (int, float)) and isinstance(oval, (int, float)):
+                merged[key] = min(bval, oval)
+            else:
+                merged[key] = oval
+
+        elif key == "enum" and isinstance(bval, list) and isinstance(oval, list):
+            merged[key] = [v for v in bval if v in oval] or oval
+
+        elif (
+            key in ("items", "additionalProperties")
+            and isinstance(bval, dict)
+            and isinstance(oval, dict)
+        ):
+            merged[key] = _deep_merge_two(bval, oval)
+
+        else:
+            merged[key] = oval
+
+    return merged
+
+
+def _intersect_type(a: str | list[str], b: str | list[str]) -> str | list[str]:
+    """Intersect two JSON Schema ``type`` values."""
+    sa = {a} if isinstance(a, str) else set(a)
+    sb = {b} if isinstance(b, str) else set(b)
+    common = sa & sb
+    if not common:
+        # No intersection — fall back to *a* (caller's base).
+        return a
+    if len(common) == 1:
+        return next(iter(common))
+    return sorted(common)
+
+
+def _merge_allof_node(schema: dict[str, Any]) -> dict[str, Any]:
+    """Merge a single ``allOf`` array into one schema, including sibling keys."""
+    all_of = schema["allOf"]
+    # Start with sibling keys (everything except ``allOf``).
+    base: dict[str, Any] = {k: v for k, v in schema.items() if k != "allOf"}
+    for sub in all_of:
+        if isinstance(sub, dict):
+            base = _deep_merge_two(base, sub)
+    return base
+
+
+def _walk_merge_allof(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge all ``allOf`` nodes in *schema*."""
+    # First recurse into children so nested allOf are resolved bottom-up.
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if isinstance(value, dict):
+            result[key] = _walk_merge_allof(value)
+        elif isinstance(value, list):
+            result[key] = [
+                _walk_merge_allof(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+
+    if "allOf" in result and isinstance(result["allOf"], list):
+        result = _merge_allof_node(result)
+    return result
+
+
+def merge_allof(schema: dict[str, Any]) -> dict[str, Any]:
+    """Deep-merge all ``allOf`` sub-schemas into single schemas.
+
+    Args:
+        schema: A JSON Schema dict (``$ref`` should be resolved first).
+
+    Returns:
+        A new dict with all ``allOf`` keywords resolved.
+    """
+    return _walk_merge_allof(copy.deepcopy(schema))
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — anyOf / oneOf simplification
+# ---------------------------------------------------------------------------
+
+
+def _simplify_node(schema: dict[str, Any]) -> dict[str, Any]:
+    """Simplify a single ``anyOf`` or ``oneOf`` node."""
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if not isinstance(variants, list):
+            continue
+
+        non_null = [v for v in variants if v.get("type") != "null"]
+        has_null = len(non_null) < len(variants)
+
+        # Sibling keys (description, title, etc.) form the base.
+        base: dict[str, Any] = {
+            k: v for k, v in schema.items() if k not in ("anyOf", "oneOf")
+        }
+
+        if len(non_null) == 1:
+            base = _deep_merge_two(base, non_null[0])
+        elif len(non_null) > 1:
+            # Lossy but safe for LLM tool schemas: keep first non-null variant.
+            base = _deep_merge_two(base, non_null[0])
+        # else: all null — base stays as-is
+
+        if has_null:
+            base["nullable"] = True
+
+        return base
+
+    return schema
+
+
+def _walk_simplify(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively simplify all ``anyOf``/``oneOf`` nodes."""
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if isinstance(value, dict):
+            result[key] = _walk_simplify(value)
+        elif isinstance(value, list):
+            result[key] = [
+                _walk_simplify(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+
+    if result.keys() & {"anyOf", "oneOf"}:
+        result = _simplify_node(result)
+    return result
+
+
+def simplify_unions(schema: dict[str, Any]) -> dict[str, Any]:
+    """Simplify ``anyOf``/``oneOf`` constructs.
+
+    - Nullable pattern ``[{type: T}, {type: null}]`` → ``{type: T, nullable: true}``
+    - Single-variant: unwrap.
+    - Multi-variant: keep first non-null variant (lossy but safe for LLM tool
+      schemas).
+
+    Args:
+        schema: A JSON Schema dict.
+
+    Returns:
+        A new dict with ``anyOf``/``oneOf`` simplified.
+    """
+    return _walk_simplify(copy.deepcopy(schema))
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Sanitization & validation
+# ---------------------------------------------------------------------------
+
+
+def _walk_sanitize(
+    schema: dict[str, Any],
+    strip: set[str],
+) -> dict[str, Any]:
+    """Recursively strip unsupported keys and prune orphaned ``required``."""
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key in strip:
+            continue
+        if isinstance(value, dict):
+            result[key] = _walk_sanitize(value, strip)
+        elif isinstance(value, list):
+            result[key] = [
+                _walk_sanitize(item, strip) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+
+    # Prune required ⊆ properties.
+    if "required" in result and "properties" in result:
+        props = result["properties"]
+        pruned = [r for r in result["required"] if r in props]
+        if pruned:
+            result["required"] = pruned
+        else:
+            del result["required"]
+
+    return result
+
+
+def sanitize(
+    schema: dict[str, Any],
+    *,
+    strip_keys: set[str] | None = None,
+) -> dict[str, Any]:
+    """Strip unsupported schema keywords and validate ``required`` arrays.
+
+    Args:
+        schema: A JSON Schema dict.
+        strip_keys: Additional keys to strip beyond
+            :data:`UNSUPPORTED_SCHEMA_KEYS`.
+
+    Returns:
+        A new dict with unsupported keys removed and ``required`` arrays
+        pruned so that ``required ⊆ properties.keys()`` at every level.
+    """
+    strip = UNSUPPORTED_SCHEMA_KEYS | (strip_keys or set())
+    return _walk_sanitize(copy.deepcopy(schema), strip)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Top-level API
+# ---------------------------------------------------------------------------
+
+
+def flatten_schema(
+    schema: dict[str, Any],
+    *,
+    strip_keys: set[str] | None = None,
+) -> dict[str, Any]:
+    """One-call full pipeline: resolve → merge → simplify → sanitize.
+
+    Args:
+        schema: A JSON Schema dict, possibly containing ``$ref``,
+            ``allOf``, ``anyOf``, ``oneOf``, and unsupported keywords.
+        strip_keys: Additional keys to strip beyond
+            :data:`UNSUPPORTED_SCHEMA_KEYS`.
+
+    Returns:
+        A flattened, sanitized schema safe for LLM provider consumption.
+    """
+    result = resolve_refs(schema)
+    result = _walk_merge_allof(result)  # skip redundant deepcopy
+    result = _walk_simplify(result)
+    strip = UNSUPPORTED_SCHEMA_KEYS | (strip_keys or set())
+    result = _walk_sanitize(result, strip)
+    return result

--- a/jsonschema/package.json
+++ b/jsonschema/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "allof-merge": "^0.6.8"
+  }
+}

--- a/jsonschema/test_jsonschema_benchmark.py
+++ b/jsonschema/test_jsonschema_benchmark.py
@@ -281,12 +281,15 @@ ALL_SCHEMAS = {
 
 # ---------------------------------------------------------------------------
 # Correctness comparison — zerodep output vs allof-merge output
+#
+# allof-merge only resolves $ref and merges allOf.  It does NOT simplify
+# anyOf/oneOf or strip unsupported keys.  So we compare zerodep's
+# resolve_refs + merge_allof (Phase 1+2) against allof-merge's output.
 # ---------------------------------------------------------------------------
 
 
 def _normalize(schema: dict) -> dict:
-    """Normalize a schema for comparison: sort required arrays, remove
-    keys that only one implementation produces (e.g. nullable vs type array)."""
+    """Sort keys and required arrays for deterministic comparison."""
     if not isinstance(schema, dict):
         return schema
     result = {}
@@ -305,106 +308,106 @@ def _normalize(schema: dict) -> dict:
     return result
 
 
-def _structural_match(zd: dict, js: dict, path: str = "") -> list[str]:
-    """Compare two flattened schemas structurally, returning differences.
+def _collect_diffs(zd: dict, js: dict, path: str = "") -> list[str]:
+    """Recursively compare two schema dicts, returning human-readable diffs.
 
-    Allows known semantic divergences between zerodep and allof-merge:
-    - zerodep uses ``nullable: true``; allof-merge may keep ``anyOf``
-    - allof-merge may retain ``$defs``; zerodep strips them
+    Skips ``$defs``/``definitions`` (zerodep strips them, allof-merge keeps).
     """
+    if not isinstance(zd, dict) or not isinstance(js, dict):
+        if zd != js:
+            return [f"{path}: {zd!r} vs {js!r}"]
+        return []
+
     diffs: list[str] = []
     zd_n = _normalize(zd)
     js_n = _normalize(js)
 
-    # Check that all properties and types agree at this level.
+    # If JS side still has a $ref (not inlined), skip this subtree —
+    # zerodep inlined it so the shapes are legitimately different.
+    if "$ref" in js_n:
+        return []
+
     all_keys = set(zd_n) | set(js_n)
-    # Skip keys that represent known implementation differences.
-    skip = {"nullable", "$defs", "definitions", "anyOf", "oneOf"}
-    for key in sorted(all_keys - skip):
+    # zerodep strips $defs and inlines all $ref (including inside anyOf);
+    # allof-merge keeps $defs and only inlines $ref inside allOf.
+    skip_keys = {"$defs", "definitions", "$ref"}
+    for key in sorted(all_keys - skip_keys):
         zval = zd_n.get(key)
         jval = js_n.get(key)
-        if zval != jval:
-            diffs.append(f"{path}.{key}: zerodep={zval!r} vs js={jval!r}")
-
-    # Recurse into properties.
-    zprops = zd_n.get("properties", {})
-    jprops = js_n.get("properties", {})
-    for pname in set(zprops) | set(jprops):
-        if pname in zprops and pname in jprops:
-            if isinstance(zprops[pname], dict) and isinstance(jprops[pname], dict):
-                diffs.extend(
-                    _structural_match(
-                        zprops[pname], jprops[pname], f"{path}.properties.{pname}"
-                    )
-                )
-
+        if zval == jval:
+            continue
+        if isinstance(zval, dict) and isinstance(jval, dict):
+            diffs.extend(_collect_diffs(zval, jval, f"{path}.{key}"))
+        elif isinstance(zval, list) and isinstance(jval, list):
+            if len(zval) != len(jval):
+                diffs.append(f"{path}.{key}: len {len(zval)} vs {len(jval)}")
+            else:
+                for i, (a, b) in enumerate(zip(zval, jval)):
+                    if isinstance(a, dict) and isinstance(b, dict):
+                        diffs.extend(_collect_diffs(a, b, f"{path}.{key}[{i}]"))
+                    elif a != b:
+                        diffs.append(f"{path}.{key}[{i}]: {a!r} vs {b!r}")
+        else:
+            diffs.append(f"{path}.{key}: {zval!r} vs {jval!r}")
     return diffs
+
+
+def _has_keyword(d: dict, keyword: str) -> bool:
+    """Check if *keyword* appears anywhere in *d* recursively."""
+    if not isinstance(d, dict):
+        return False
+    if keyword in d:
+        return True
+    for v in d.values():
+        if isinstance(v, dict) and _has_keyword(v, keyword):
+            return True
+        if isinstance(v, list):
+            for item in v:
+                if isinstance(item, dict) and _has_keyword(item, keyword):
+                    return True
+    return False
 
 
 @pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
 class TestCorrectnessVsJs:
-    """Compare zerodep flatten_schema output against allof-merge."""
+    """Compare zerodep resolve_refs+merge_allof against allof-merge.
+
+    Only Phase 1+2 are comparable — allof-merge does not simplify
+    anyOf/oneOf or strip unsupported keys.
+    """
 
     @pytest.mark.parametrize("tier", ["tiny", "small", "medium", "large", "xlarge"])
     def test_structural_match(self, tier):
         schema = ALL_SCHEMAS[tier]
-        zd_result = flatten_schema(schema)
+        # zerodep: Phase 1 + Phase 2 only (matching allof-merge scope).
+        zd_result = merge_allof(resolve_refs(schema))
         js_output = _run_js(schema, rounds=1)
         js_result = js_output["result"]
-        diffs = _structural_match(zd_result, js_result)
+        diffs = _collect_diffs(zd_result, js_result)
         assert not diffs, f"Structural differences at {tier}:\n" + "\n".join(diffs)
 
-    @pytest.mark.parametrize("tier", ["medium", "large"])
+    @pytest.mark.parametrize("tier", ["medium", "large", "xlarge"])
     def test_allof_fully_resolved(self, tier):
         """Both implementations should eliminate all allOf keywords."""
         schema = ALL_SCHEMAS[tier]
-        zd_result = flatten_schema(schema)
-        js_output = _run_js(schema, rounds=1)
-        js_result = js_output["result"]
+        zd_result = merge_allof(resolve_refs(schema))
+        js_result = _run_js(schema, rounds=1)["result"]
+        assert not _has_keyword(zd_result, "allOf"), "zerodep still has allOf"
+        assert not _has_keyword(js_result, "allOf"), "allof-merge still has allOf"
 
-        def _has_allof(d):
-            if not isinstance(d, dict):
-                return False
-            if "allOf" in d:
-                return True
-            return any(
-                _has_allof(v) for v in d.values() if isinstance(v, (dict, list))
-            ) or any(
-                _has_allof(item)
-                for v in d.values()
-                if isinstance(v, list)
-                for item in v
-                if isinstance(item, dict)
-            )
-
-        assert not _has_allof(zd_result), "zerodep output still contains allOf"
-        assert not _has_allof(js_result), "allof-merge output still contains allOf"
+    @pytest.mark.parametrize("tier", ["medium", "large", "xlarge"])
+    def test_zerodep_refs_fully_resolved(self, tier):
+        """zerodep should eliminate all $ref pointers."""
+        schema = ALL_SCHEMAS[tier]
+        zd_result = merge_allof(resolve_refs(schema))
+        assert not _has_keyword(zd_result, "$ref"), "zerodep still has $ref"
 
     @pytest.mark.parametrize("tier", ["medium", "large"])
-    def test_refs_fully_resolved(self, tier):
-        """Both implementations should eliminate all $ref pointers."""
+    def test_js_refs_resolved_in_allof(self, tier):
+        """allof-merge resolves $ref inside allOf contexts."""
         schema = ALL_SCHEMAS[tier]
-        zd_result = flatten_schema(schema)
-        js_output = _run_js(schema, rounds=1)
-        js_result = js_output["result"]
-
-        def _has_ref(d):
-            if not isinstance(d, dict):
-                return False
-            if "$ref" in d:
-                return True
-            return any(
-                _has_ref(v) for v in d.values() if isinstance(v, (dict, list))
-            ) or any(
-                _has_ref(item)
-                for v in d.values()
-                if isinstance(v, list)
-                for item in v
-                if isinstance(item, dict)
-            )
-
-        assert not _has_ref(zd_result), "zerodep output still contains $ref"
-        assert not _has_ref(js_result), "allof-merge output still contains $ref"
+        js_result = _run_js(schema, rounds=1)["result"]
+        assert not _has_keyword(js_result, "$ref"), "allof-merge still has $ref"
 
 
 # ---------------------------------------------------------------------------

--- a/jsonschema/test_jsonschema_benchmark.py
+++ b/jsonschema/test_jsonschema_benchmark.py
@@ -1,0 +1,461 @@
+"""Benchmark: zerodep jsonschema vs allof-merge (JS).
+
+Compares both **correctness** (output equivalence) and **performance**
+across five schema complexity tiers.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from jsonschema import flatten_schema, merge_allof, resolve_refs  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# JS engine
+# ---------------------------------------------------------------------------
+
+_THIS_DIR = os.path.dirname(__file__)
+_BENCH_JS = os.path.join(_THIS_DIR, "bench_allof_merge.js")
+_NODE_MODULES = os.path.join(_THIS_DIR, "node_modules")
+_HAS_NODE = shutil.which("node") is not None and os.path.isdir(_NODE_MODULES)
+
+
+def _run_js(schema: dict, rounds: int = 1) -> dict:
+    """Run allof-merge via Node.js and return ``{result, times_ms, ...}``."""
+    proc = subprocess.run(
+        ["node", _BENCH_JS, str(rounds)],
+        input=json.dumps(schema),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=_THIS_DIR,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"JS error: {proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Test schemas — five complexity tiers
+# ---------------------------------------------------------------------------
+
+# Tier 1: Tiny — no composition keywords at all (passthrough baseline).
+TINY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer"},
+    },
+    "required": ["name"],
+}
+
+# Tier 2: Small — single anyOf nullable.
+SMALL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer", "minimum": 0},
+        "email": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+        },
+    },
+    "required": ["name", "age"],
+}
+
+# Tier 3: Medium — $ref + allOf + anyOf combined.
+MEDIUM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "user": {
+            "allOf": [
+                {"$ref": "#/$defs/Person"},
+                {
+                    "properties": {
+                        "role": {"type": "string", "enum": ["admin", "user"]},
+                    },
+                    "required": ["role"],
+                },
+            ],
+        },
+        "settings": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "theme": {"type": "string"},
+                        "lang": {"type": "string"},
+                    },
+                },
+                {"type": "null"},
+            ],
+        },
+    },
+    "$defs": {
+        "Person": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer", "minimum": 0, "maximum": 150},
+            },
+            "required": ["name"],
+        },
+    },
+}
+
+# Tier 4: Large — multiple $ref + nested allOf + oneOf.
+LARGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "minLength": 1},
+        "filters": {
+            "allOf": [
+                {"$ref": "#/$defs/BaseFilter"},
+                {"$ref": "#/$defs/DateFilter"},
+                {
+                    "properties": {
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 0,
+                            "maxItems": 20,
+                        },
+                    },
+                },
+            ],
+        },
+        "output": {
+            "allOf": [
+                {"$ref": "#/$defs/Pagination"},
+                {
+                    "properties": {
+                        "format": {
+                            "oneOf": [
+                                {"type": "string", "enum": ["json", "csv"]},
+                                {"type": "null"},
+                            ],
+                        },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "allOf": [
+                                    {"$ref": "#/$defs/FieldSpec"},
+                                    {
+                                        "properties": {
+                                            "alias": {
+                                                "anyOf": [
+                                                    {"type": "string"},
+                                                    {"type": "null"},
+                                                ],
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+    },
+    "required": ["query"],
+    "$defs": {
+        "BaseFilter": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "minimum": 1, "maximum": 1000},
+                "offset": {"type": "integer", "minimum": 0},
+            },
+            "required": ["limit"],
+        },
+        "DateFilter": {
+            "type": "object",
+            "properties": {
+                "start_date": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                "end_date": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            },
+        },
+        "Pagination": {
+            "type": "object",
+            "properties": {
+                "page": {"type": "integer", "minimum": 1},
+                "per_page": {"type": "integer", "minimum": 1, "maximum": 100},
+            },
+        },
+        "FieldSpec": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "sort": {
+                    "oneOf": [
+                        {"type": "string", "enum": ["asc", "desc"]},
+                        {"type": "null"},
+                    ],
+                },
+            },
+            "required": ["name"],
+        },
+    },
+}
+
+
+def _make_xlarge_schema(n_fields: int = 50, n_defs: int = 10) -> dict:
+    """Generate a synthetic XLarge schema with many fields and definitions."""
+    defs = {}
+    for i in range(n_defs):
+        defs[f"Def{i}"] = {
+            "type": "object",
+            "properties": {
+                f"field_{i}_{j}": {"type": "string", "minLength": 1, "maxLength": 255}
+                for j in range(5)
+            },
+            "required": [f"field_{i}_0"],
+        }
+
+    properties: dict = {}
+    for i in range(n_fields):
+        def_idx = i % n_defs
+        if i % 5 == 0:
+            # allOf with $ref
+            properties[f"prop_{i}"] = {
+                "allOf": [
+                    {"$ref": f"#/$defs/Def{def_idx}"},
+                    {
+                        "properties": {
+                            f"extra_{i}": {"type": "integer", "minimum": 0},
+                        },
+                    },
+                ],
+            }
+        elif i % 5 == 1:
+            # anyOf nullable
+            properties[f"prop_{i}"] = {
+                "anyOf": [
+                    {"$ref": f"#/$defs/Def{def_idx}"},
+                    {"type": "null"},
+                ],
+            }
+        elif i % 5 == 2:
+            # oneOf
+            properties[f"prop_{i}"] = {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                    {"type": "null"},
+                ],
+            }
+        elif i % 5 == 3:
+            # Nested allOf with numeric constraints
+            properties[f"prop_{i}"] = {
+                "allOf": [
+                    {"type": "integer", "minimum": 0, "maximum": 1000},
+                    {"minimum": 10, "maximum": 500},
+                ],
+            }
+        else:
+            # Plain field
+            properties[f"prop_{i}"] = {"type": "string"}
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": [f"prop_{i}" for i in range(0, n_fields, 3)],
+        "$defs": defs,
+    }
+
+
+XLARGE_SCHEMA = _make_xlarge_schema()
+
+ALL_SCHEMAS = {
+    "tiny": TINY_SCHEMA,
+    "small": SMALL_SCHEMA,
+    "medium": MEDIUM_SCHEMA,
+    "large": LARGE_SCHEMA,
+    "xlarge": XLARGE_SCHEMA,
+}
+
+# ---------------------------------------------------------------------------
+# Correctness comparison — zerodep output vs allof-merge output
+# ---------------------------------------------------------------------------
+
+
+def _normalize(schema: dict) -> dict:
+    """Normalize a schema for comparison: sort required arrays, remove
+    keys that only one implementation produces (e.g. nullable vs type array)."""
+    if not isinstance(schema, dict):
+        return schema
+    result = {}
+    for k, v in sorted(schema.items()):
+        if isinstance(v, dict):
+            result[k] = _normalize(v)
+        elif isinstance(v, list):
+            if k == "required":
+                result[k] = sorted(v)
+            else:
+                result[k] = [
+                    _normalize(item) if isinstance(item, dict) else item for item in v
+                ]
+        else:
+            result[k] = v
+    return result
+
+
+def _structural_match(zd: dict, js: dict, path: str = "") -> list[str]:
+    """Compare two flattened schemas structurally, returning differences.
+
+    Allows known semantic divergences between zerodep and allof-merge:
+    - zerodep uses ``nullable: true``; allof-merge may keep ``anyOf``
+    - allof-merge may retain ``$defs``; zerodep strips them
+    """
+    diffs: list[str] = []
+    zd_n = _normalize(zd)
+    js_n = _normalize(js)
+
+    # Check that all properties and types agree at this level.
+    all_keys = set(zd_n) | set(js_n)
+    # Skip keys that represent known implementation differences.
+    skip = {"nullable", "$defs", "definitions", "anyOf", "oneOf"}
+    for key in sorted(all_keys - skip):
+        zval = zd_n.get(key)
+        jval = js_n.get(key)
+        if zval != jval:
+            diffs.append(f"{path}.{key}: zerodep={zval!r} vs js={jval!r}")
+
+    # Recurse into properties.
+    zprops = zd_n.get("properties", {})
+    jprops = js_n.get("properties", {})
+    for pname in set(zprops) | set(jprops):
+        if pname in zprops and pname in jprops:
+            if isinstance(zprops[pname], dict) and isinstance(jprops[pname], dict):
+                diffs.extend(
+                    _structural_match(
+                        zprops[pname], jprops[pname], f"{path}.properties.{pname}"
+                    )
+                )
+
+    return diffs
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
+class TestCorrectnessVsJs:
+    """Compare zerodep flatten_schema output against allof-merge."""
+
+    @pytest.mark.parametrize("tier", ["tiny", "small", "medium", "large", "xlarge"])
+    def test_structural_match(self, tier):
+        schema = ALL_SCHEMAS[tier]
+        zd_result = flatten_schema(schema)
+        js_output = _run_js(schema, rounds=1)
+        js_result = js_output["result"]
+        diffs = _structural_match(zd_result, js_result)
+        assert not diffs, f"Structural differences at {tier}:\n" + "\n".join(diffs)
+
+    @pytest.mark.parametrize("tier", ["medium", "large"])
+    def test_allof_fully_resolved(self, tier):
+        """Both implementations should eliminate all allOf keywords."""
+        schema = ALL_SCHEMAS[tier]
+        zd_result = flatten_schema(schema)
+        js_output = _run_js(schema, rounds=1)
+        js_result = js_output["result"]
+
+        def _has_allof(d):
+            if not isinstance(d, dict):
+                return False
+            if "allOf" in d:
+                return True
+            return any(
+                _has_allof(v) for v in d.values() if isinstance(v, (dict, list))
+            ) or any(
+                _has_allof(item)
+                for v in d.values()
+                if isinstance(v, list)
+                for item in v
+                if isinstance(item, dict)
+            )
+
+        assert not _has_allof(zd_result), "zerodep output still contains allOf"
+        assert not _has_allof(js_result), "allof-merge output still contains allOf"
+
+    @pytest.mark.parametrize("tier", ["medium", "large"])
+    def test_refs_fully_resolved(self, tier):
+        """Both implementations should eliminate all $ref pointers."""
+        schema = ALL_SCHEMAS[tier]
+        zd_result = flatten_schema(schema)
+        js_output = _run_js(schema, rounds=1)
+        js_result = js_output["result"]
+
+        def _has_ref(d):
+            if not isinstance(d, dict):
+                return False
+            if "$ref" in d:
+                return True
+            return any(
+                _has_ref(v) for v in d.values() if isinstance(v, (dict, list))
+            ) or any(
+                _has_ref(item)
+                for v in d.values()
+                if isinstance(v, list)
+                for item in v
+                if isinstance(item, dict)
+            )
+
+        assert not _has_ref(zd_result), "zerodep output still contains $ref"
+        assert not _has_ref(js_result), "allof-merge output still contains $ref"
+
+
+# ---------------------------------------------------------------------------
+# Performance benchmarks
+# ---------------------------------------------------------------------------
+
+
+def _zd_flatten(schema: dict) -> None:
+    flatten_schema(schema)
+
+
+class TestPerfTiny:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_flatten, TINY_SCHEMA)
+
+    @pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
+    def test_allof_merge_js(self, benchmark):
+        benchmark(_run_js, TINY_SCHEMA, 1)
+
+
+class TestPerfSmall:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_flatten, SMALL_SCHEMA)
+
+    @pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
+    def test_allof_merge_js(self, benchmark):
+        benchmark(_run_js, SMALL_SCHEMA, 1)
+
+
+class TestPerfMedium:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_flatten, MEDIUM_SCHEMA)
+
+    @pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
+    def test_allof_merge_js(self, benchmark):
+        benchmark(_run_js, MEDIUM_SCHEMA, 1)
+
+
+class TestPerfLarge:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_flatten, LARGE_SCHEMA)
+
+    @pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
+    def test_allof_merge_js(self, benchmark):
+        benchmark(_run_js, LARGE_SCHEMA, 1)
+
+
+class TestPerfXlarge:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_flatten, XLARGE_SCHEMA)
+
+    @pytest.mark.skipif(not _HAS_NODE, reason="Node.js or npm deps missing")
+    def test_allof_merge_js(self, benchmark):
+        benchmark(_run_js, XLARGE_SCHEMA, 1)

--- a/jsonschema/test_jsonschema_correctness.py
+++ b/jsonschema/test_jsonschema_correctness.py
@@ -1,0 +1,877 @@
+"""Correctness tests for zerodep jsonschema module."""
+
+import copy
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from jsonschema import (  # noqa: E402
+    UNSUPPORTED_SCHEMA_KEYS,
+    flatten_schema,
+    merge_allof,
+    resolve_refs,
+    sanitize,
+    simplify_unions,
+)
+
+# ---------------------------------------------------------------------------
+# Phase 1 — resolve_refs
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRefs:
+    """$ref resolution tests."""
+
+    def test_basic_defs(self):
+        schema = {
+            "type": "object",
+            "properties": {"user": {"$ref": "#/$defs/User"}},
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            },
+        }
+        result = resolve_refs(schema)
+        assert result["properties"]["user"] == {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        assert "$defs" not in result
+
+    def test_definitions_key(self):
+        schema = {
+            "type": "object",
+            "properties": {"item": {"$ref": "#/definitions/Item"}},
+            "definitions": {
+                "Item": {"type": "string"},
+            },
+        }
+        result = resolve_refs(schema)
+        assert result["properties"]["item"] == {"type": "string"}
+        assert "definitions" not in result
+
+    def test_sibling_keys_preserved(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/$defs/User",
+                    "description": "The user object",
+                }
+            },
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            },
+        }
+        result = resolve_refs(schema)
+        user = result["properties"]["user"]
+        assert user["description"] == "The user object"
+        assert user["type"] == "object"
+
+    def test_sibling_overrides_def(self):
+        """Sibling keys should take priority over definition keys."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/$defs/User",
+                    "description": "overridden",
+                }
+            },
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "description": "from def",
+                    "properties": {"name": {"type": "string"}},
+                }
+            },
+        }
+        result = resolve_refs(schema)
+        assert result["properties"]["user"]["description"] == "overridden"
+
+    def test_chained_refs(self):
+        """A → B → C chain should resolve fully."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"$ref": "#/$defs/A"}},
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"type": "integer"},
+            },
+        }
+        result = resolve_refs(schema)
+        assert result["properties"]["a"] == {"type": "integer"}
+
+    def test_unresolvable_ref_dropped(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "x": {"$ref": "#/$defs/Missing", "description": "kept"},
+            },
+            "$defs": {},
+        }
+        with pytest.warns(UserWarning, match="Unresolvable"):
+            result = resolve_refs(schema)
+        assert "$ref" not in result["properties"]["x"]
+        assert result["properties"]["x"]["description"] == "kept"
+
+    def test_nested_ref_in_items(self):
+        schema = {
+            "type": "array",
+            "items": {"$ref": "#/$defs/Item"},
+            "$defs": {"Item": {"type": "string"}},
+        }
+        result = resolve_refs(schema)
+        assert result["items"] == {"type": "string"}
+
+    def test_ref_in_allof(self):
+        schema = {
+            "allOf": [
+                {"$ref": "#/$defs/Base"},
+                {"properties": {"extra": {"type": "boolean"}}},
+            ],
+            "$defs": {
+                "Base": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            },
+        }
+        result = resolve_refs(schema)
+        # $ref inside allOf[0] should be resolved.
+        assert result["allOf"][0] == {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+
+    def test_input_not_mutated(self):
+        schema = {
+            "properties": {"x": {"$ref": "#/$defs/X"}},
+            "$defs": {"X": {"type": "string"}},
+        }
+        original = copy.deepcopy(schema)
+        resolve_refs(schema)
+        assert schema == original
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — merge_allof
+# ---------------------------------------------------------------------------
+
+
+class TestMergeAllOf:
+    """allOf merging tests."""
+
+    def test_single_element_unwrap(self):
+        schema = {
+            "allOf": [{"type": "object", "properties": {"a": {"type": "string"}}}]
+        }
+        result = merge_allof(schema)
+        assert "allOf" not in result
+        assert result["type"] == "object"
+        assert result["properties"]["a"] == {"type": "string"}
+
+    def test_merge_properties(self):
+        schema = {
+            "allOf": [
+                {"type": "object", "properties": {"a": {"type": "string"}}},
+                {"type": "object", "properties": {"b": {"type": "integer"}}},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["properties"]["a"] == {"type": "string"}
+        assert result["properties"]["b"] == {"type": "integer"}
+
+    def test_deep_merge_nested_properties(self):
+        """Properties appearing in multiple allOf sub-schemas should be deep-merged."""
+        schema = {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "object",
+                            "properties": {"name": {"type": "string"}},
+                        }
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "type": "object",
+                            "properties": {"age": {"type": "integer"}},
+                        }
+                    },
+                },
+            ]
+        }
+        result = merge_allof(schema)
+        user = result["properties"]["user"]
+        assert "name" in user["properties"]
+        assert "age" in user["properties"]
+
+    def test_required_union(self):
+        schema = {
+            "allOf": [
+                {"required": ["a", "b"]},
+                {"required": ["b", "c"]},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["required"] == ["a", "b", "c"]
+
+    def test_type_intersection(self):
+        schema = {
+            "allOf": [
+                {"type": ["object", "null"]},
+                {"type": ["object", "string"]},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["type"] == "object"
+
+    def test_type_intersection_no_overlap(self):
+        schema = {
+            "allOf": [
+                {"type": "string"},
+                {"type": "integer"},
+            ]
+        }
+        result = merge_allof(schema)
+        # Fallback: keep base type.
+        assert result["type"] == "string"
+
+    def test_numeric_constraints_tighten(self):
+        schema = {
+            "allOf": [
+                {"minimum": 0, "maximum": 100},
+                {"minimum": 10, "maximum": 50},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["minimum"] == 10  # max of lower bounds
+        assert result["maximum"] == 50  # min of upper bounds
+
+    def test_exclusive_constraints(self):
+        schema = {
+            "allOf": [
+                {"exclusiveMinimum": 0, "exclusiveMaximum": 100},
+                {"exclusiveMinimum": 5, "exclusiveMaximum": 80},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["exclusiveMinimum"] == 5
+        assert result["exclusiveMaximum"] == 80
+
+    def test_length_constraints(self):
+        schema = {
+            "allOf": [
+                {"minLength": 1, "maxLength": 100},
+                {"minLength": 5, "maxLength": 50},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["minLength"] == 5
+        assert result["maxLength"] == 50
+
+    def test_enum_intersection(self):
+        schema = {
+            "allOf": [
+                {"enum": ["a", "b", "c"]},
+                {"enum": ["b", "c", "d"]},
+            ]
+        }
+        result = merge_allof(schema)
+        assert result["enum"] == ["b", "c"]
+
+    def test_enum_intersection_empty_fallback(self):
+        schema = {
+            "allOf": [
+                {"enum": ["a"]},
+                {"enum": ["b"]},
+            ]
+        }
+        result = merge_allof(schema)
+        # Fallback to override when intersection is empty.
+        assert result["enum"] == ["b"]
+
+    def test_items_deep_merge(self):
+        schema = {
+            "allOf": [
+                {"items": {"type": "object", "properties": {"x": {"type": "string"}}}},
+                {"items": {"type": "object", "properties": {"y": {"type": "integer"}}}},
+            ]
+        }
+        result = merge_allof(schema)
+        assert "x" in result["items"]["properties"]
+        assert "y" in result["items"]["properties"]
+
+    def test_sibling_keys_kept(self):
+        schema = {
+            "description": "top-level desc",
+            "allOf": [
+                {"type": "object", "properties": {"a": {"type": "string"}}},
+            ],
+        }
+        result = merge_allof(schema)
+        assert result["description"] == "top-level desc"
+        assert result["type"] == "object"
+
+    def test_nested_allof(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "inner": {
+                    "allOf": [
+                        {"type": "object", "properties": {"x": {"type": "string"}}},
+                        {"properties": {"y": {"type": "integer"}}},
+                    ]
+                }
+            },
+        }
+        result = merge_allof(schema)
+        inner = result["properties"]["inner"]
+        assert "allOf" not in inner
+        assert "x" in inner["properties"]
+        assert "y" in inner["properties"]
+
+    def test_input_not_mutated(self):
+        schema = {"allOf": [{"type": "string"}, {"minLength": 1}]}
+        original = copy.deepcopy(schema)
+        merge_allof(schema)
+        assert schema == original
+
+    def test_additional_properties_merge(self):
+        schema = {
+            "allOf": [
+                {"additionalProperties": {"type": "string", "minLength": 1}},
+                {"additionalProperties": {"type": "string", "maxLength": 100}},
+            ]
+        }
+        result = merge_allof(schema)
+        ap = result["additionalProperties"]
+        assert ap["type"] == "string"
+        assert ap["minLength"] == 1
+        assert ap["maxLength"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — simplify_unions
+# ---------------------------------------------------------------------------
+
+
+class TestSimplifyUnions:
+    """anyOf/oneOf simplification tests."""
+
+    def test_nullable_anyof(self):
+        schema = {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "null"},
+            ]
+        }
+        result = simplify_unions(schema)
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+        assert "anyOf" not in result
+
+    def test_nullable_oneof(self):
+        schema = {
+            "oneOf": [
+                {"type": "integer"},
+                {"type": "null"},
+            ]
+        }
+        result = simplify_unions(schema)
+        assert result["type"] == "integer"
+        assert result["nullable"] is True
+
+    def test_single_variant_no_null(self):
+        schema = {"anyOf": [{"type": "string", "minLength": 1}]}
+        result = simplify_unions(schema)
+        assert result["type"] == "string"
+        assert result["minLength"] == 1
+        assert "nullable" not in result
+        assert "anyOf" not in result
+
+    def test_multi_variant_keeps_first(self):
+        schema = {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"},
+            ]
+        }
+        result = simplify_unions(schema)
+        assert result["type"] == "string"
+        assert "anyOf" not in result
+
+    def test_multi_variant_with_null(self):
+        schema = {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"},
+                {"type": "null"},
+            ]
+        }
+        result = simplify_unions(schema)
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+
+    def test_all_null_variants(self):
+        schema = {"anyOf": [{"type": "null"}, {"type": "null"}]}
+        result = simplify_unions(schema)
+        assert result.get("nullable") is True
+        assert "anyOf" not in result
+
+    def test_sibling_keys_preserved(self):
+        schema = {
+            "description": "a nullable string",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "null"},
+            ],
+        }
+        result = simplify_unions(schema)
+        assert result["description"] == "a nullable string"
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+
+    def test_sibling_deep_merged(self):
+        """Sibling keys should be deep-merged, not shallow-overwritten."""
+        schema = {
+            "title": "MyField",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                },
+                {"type": "null"},
+            ],
+        }
+        result = simplify_unions(schema)
+        assert result["title"] == "MyField"
+        assert result["properties"]["a"] == {"type": "string"}
+        assert result["nullable"] is True
+
+    def test_nested_anyof(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                }
+            },
+        }
+        result = simplify_unions(schema)
+        field = result["properties"]["field"]
+        assert field["type"] == "string"
+        assert field["nullable"] is True
+
+    def test_input_not_mutated(self):
+        schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        original = copy.deepcopy(schema)
+        simplify_unions(schema)
+        assert schema == original
+
+    def test_nullable_object_with_properties(self):
+        """Complex nullable object: ensure properties are fully preserved."""
+        schema = {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "age": {"type": "integer"},
+                    },
+                    "required": ["name"],
+                },
+                {"type": "null"},
+            ]
+        }
+        result = simplify_unions(schema)
+        assert result["type"] == "object"
+        assert result["nullable"] is True
+        assert result["properties"]["name"] == {"type": "string"}
+        assert result["properties"]["age"] == {"type": "integer"}
+        assert result["required"] == ["name"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — sanitize
+# ---------------------------------------------------------------------------
+
+
+class TestSanitize:
+    """Sanitization and required-pruning tests."""
+
+    def test_strip_default_keys(self):
+        schema = {
+            "type": "object",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$comment": "test",
+            "deprecated": True,
+            "readOnly": True,
+            "examples": [{}],
+            "properties": {"a": {"type": "string"}},
+        }
+        result = sanitize(schema)
+        for key in ("$schema", "$comment", "deprecated", "readOnly", "examples"):
+            assert key not in result
+        assert result["properties"]["a"] == {"type": "string"}
+
+    def test_strip_nested(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "deprecated": True,
+                    "examples": ["hello"],
+                }
+            },
+        }
+        result = sanitize(schema)
+        assert "deprecated" not in result["properties"]["a"]
+        assert "examples" not in result["properties"]["a"]
+
+    def test_extra_strip_keys(self):
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"a": {"type": "string"}},
+        }
+        result = sanitize(schema, strip_keys={"additionalProperties"})
+        assert "additionalProperties" not in result
+
+    def test_required_pruned(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a", "b", "c"],
+        }
+        result = sanitize(schema)
+        assert result["required"] == ["a"]
+
+    def test_required_all_orphaned(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["x", "y"],
+        }
+        result = sanitize(schema)
+        assert "required" not in result
+
+    def test_required_pruned_nested(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "inner": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                    "required": ["x", "y"],
+                }
+            },
+        }
+        result = sanitize(schema)
+        assert result["properties"]["inner"]["required"] == ["x"]
+
+    def test_required_without_properties_untouched(self):
+        """If there's no 'properties', required should not be pruned."""
+        schema = {"required": ["a", "b"]}
+        result = sanitize(schema)
+        assert result["required"] == ["a", "b"]
+
+    def test_strip_in_array_items(self):
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "$comment": "should be stripped",
+                "properties": {"x": {"type": "string"}},
+            },
+        }
+        result = sanitize(schema)
+        assert "$comment" not in result["items"]
+
+    def test_input_not_mutated(self):
+        schema = {"type": "string", "$comment": "test"}
+        original = copy.deepcopy(schema)
+        sanitize(schema)
+        assert schema == original
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — flatten_schema (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenSchema:
+    """Full pipeline integration tests."""
+
+    def test_simple_passthrough(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        result = flatten_schema(schema)
+        assert result == schema
+
+    def test_ref_plus_allof(self):
+        schema = {
+            "allOf": [
+                {"$ref": "#/$defs/Base"},
+                {"properties": {"extra": {"type": "boolean"}}, "required": ["extra"]},
+            ],
+            "$defs": {
+                "Base": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                }
+            },
+        }
+        result = flatten_schema(schema)
+        assert "$defs" not in result
+        assert "allOf" not in result
+        assert result["type"] == "object"
+        assert result["properties"]["name"] == {"type": "string"}
+        assert result["properties"]["extra"] == {"type": "boolean"}
+        assert set(result["required"]) == {"name", "extra"}
+
+    def test_ref_plus_anyof_nullable(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "anyOf": [
+                        {"$ref": "#/$defs/Address"},
+                        {"type": "null"},
+                    ]
+                }
+            },
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"},
+                    },
+                }
+            },
+        }
+        result = flatten_schema(schema)
+        addr = result["properties"]["address"]
+        assert addr["type"] == "object"
+        assert addr["nullable"] is True
+        assert "street" in addr["properties"]
+
+    def test_full_pipeline(self):
+        """Complex schema with $ref + allOf + anyOf + unsupported keys."""
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "config": {
+                    "allOf": [
+                        {"$ref": "#/$defs/BaseConfig"},
+                        {
+                            "properties": {
+                                "timeout": {"type": "integer", "minimum": 1},
+                            },
+                            "required": ["timeout"],
+                        },
+                    ]
+                },
+                "label": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"},
+                    ],
+                    "description": "Optional label",
+                    "deprecated": True,
+                },
+            },
+            "$defs": {
+                "BaseConfig": {
+                    "type": "object",
+                    "properties": {
+                        "host": {"type": "string", "$comment": "server host"},
+                    },
+                    "required": ["host"],
+                }
+            },
+        }
+        result = flatten_schema(schema)
+
+        # $ref resolved, $defs removed
+        assert "$defs" not in result
+        assert "$schema" not in result
+
+        # allOf merged
+        config = result["properties"]["config"]
+        assert "allOf" not in config
+        assert config["type"] == "object"
+        assert "host" in config["properties"]
+        assert "timeout" in config["properties"]
+        assert set(config["required"]) == {"host", "timeout"}
+        assert "$comment" not in config["properties"]["host"]
+
+        # anyOf simplified
+        label = result["properties"]["label"]
+        assert label["type"] == "string"
+        assert label["nullable"] is True
+        assert label["description"] == "Optional label"
+        assert "deprecated" not in label
+
+    def test_input_not_mutated(self):
+        schema = {
+            "allOf": [{"type": "string"}, {"minLength": 1}],
+            "$defs": {"X": {"type": "integer"}},
+        }
+        original = copy.deepcopy(schema)
+        flatten_schema(schema)
+        assert schema == original
+
+    def test_real_world_llm_tool_schema(self):
+        """Schema resembling a real LLM tool definition."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "filters": {
+                    "allOf": [
+                        {"$ref": "#/$defs/BaseFilter"},
+                        {
+                            "properties": {
+                                "date_range": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "start": {"type": "string"},
+                                                "end": {"type": "string"},
+                                            },
+                                        },
+                                        {"type": "null"},
+                                    ],
+                                }
+                            }
+                        },
+                    ],
+                },
+            },
+            "required": ["query", "filters"],
+            "$defs": {
+                "BaseFilter": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "$comment": "max results",
+                        },
+                    },
+                    "required": ["limit"],
+                }
+            },
+        }
+        result = flatten_schema(schema)
+
+        assert "$defs" not in result
+        assert "allOf" not in result
+        filters = result["properties"]["filters"]
+        assert filters["type"] == "object"
+        assert "limit" in filters["properties"]
+        assert "$comment" not in filters["properties"]["limit"]
+
+        date_range = filters["properties"]["date_range"]
+        assert date_range["type"] == "object"
+        assert date_range["nullable"] is True
+        assert "start" in date_range["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_empty_schema(self):
+        assert flatten_schema({}) == {}
+
+    def test_no_ops_needed(self):
+        schema = {"type": "string", "minLength": 1}
+        assert flatten_schema(schema) == schema
+
+    def test_deeply_nested(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "level1": {
+                    "type": "object",
+                    "properties": {
+                        "level2": {
+                            "type": "array",
+                            "items": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {"a": {"type": "string"}},
+                                    },  # noqa: E501
+                                    {"properties": {"b": {"type": "integer"}}},
+                                ]
+                            },
+                        }
+                    },
+                }
+            },
+        }
+        result = flatten_schema(schema)
+        item = result["properties"]["level1"]["properties"]["level2"]["items"]
+        assert "allOf" not in item
+        assert "a" in item["properties"]
+        assert "b" in item["properties"]
+
+    def test_allof_empty_list(self):
+        schema = {"allOf": [], "type": "object"}
+        result = merge_allof(schema)
+        assert result == {"type": "object"}
+
+    def test_anyof_not_a_list(self):
+        """Non-list anyOf should be left alone."""
+        schema = {"anyOf": "invalid"}
+        result = simplify_unions(schema)
+        assert result == {"anyOf": "invalid"}
+
+    def test_strip_keys_constant_completeness(self):
+        """Verify UNSUPPORTED_SCHEMA_KEYS contains expected entries."""
+        expected = {
+            "$schema",
+            "$id",
+            "$comment",
+            "$anchor",
+            "$dynamicAnchor",
+            "$dynamicRef",
+            "contentEncoding",
+            "contentMediaType",
+            "contentSchema",
+            "deprecated",
+            "readOnly",
+            "writeOnly",
+            "examples",
+            "propertyNames",
+            "const",
+        }
+        assert UNSUPPORTED_SCHEMA_KEYS == expected

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-04-20T15:51:53.893137+00:00",
+  "generated": "2026-04-24T17:28:34.321647+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -39,7 +39,7 @@
       "deps": [],
       "tier": "medium",
       "category": "crypto",
-      "last_updated": "2026-04-15T20:53:03+08:00",
+      "last_updated": "2026-04-20T23:52:13+08:00",
       "content_hash": "b09c080a243ceee4f955f5c5eb88c05ecbc022e17d0177c22d01662584e5ecb3"
     },
     "ansi": {
@@ -179,6 +179,18 @@
       "category": "network",
       "last_updated": "2026-04-11T01:00:28+08:00",
       "content_hash": "402d88f2ab1d6736a37a69a6b6269ea9e450e3dd22e9dd49c7d52b570b8b6dda"
+    },
+    "jsonschema": {
+      "description": "JSON Schema flattening & sanitization — zero dependencies, stdlib only",
+      "files": [
+        "jsonschema/jsonschema.py"
+      ],
+      "version": "0.1.0",
+      "deps": [],
+      "tier": "medium",
+      "category": "data",
+      "last_updated": null,
+      "content_hash": "032d65945452db2276c7867f38b7233a376905258f6df085101046fe48606043"
     },
     "markdown": {
       "description": "Markdown to HTML renderer — zero dependencies, stdlib only, Python 3.10+",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema"]
 
 [tool.ruff]
 target-version = "py310"
@@ -162,6 +162,7 @@ max-complexity = 20
 "xml/xml.py" = ["E501"]
 "a2a/a2a.py" = ["E501"]
 "acp/acp.py" = ["E501"]
+"jsonschema/jsonschema.py" = ["E501"]
 "**/test_*.py" = ["E402"]
 "**/test_*_benchmark.py" = ["E501"]
 "**/conftest.py" = ["C901"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,4 +208,5 @@ extra-paths = [
     "./protobuf",
     "./depdetect",
     "./semver",
+    "./jsonschema",
 ]

--- a/scripts/generate_bench_report.py
+++ b/scripts/generate_bench_report.py
@@ -59,6 +59,7 @@ _REF_LIBS: dict[str, str] = {
     "google": "google (protobuf)",
     "readability_lxml": "readability-lxml",
     "mozilla_js": "Mozilla Readability.js",
+    "allof_merge_js": "allof-merge (JS)",
     "reference": "reference",
     "sqlitedict": "sqlitedict",
 }


### PR DESCRIPTION
## Summary

Closes #51

Add a zero-dependency `jsonschema` module that flattens complex JSON Schemas (containing `$ref`, `allOf`, `anyOf`, `oneOf`) into simple, LLM-provider-compatible schemas.

### Pipeline architecture

1. **`resolve_refs`** — Collect `$defs`/`definitions`, inline all `$ref` pointers, merge sibling keys
2. **`merge_allof`** — Deep-merge `allOf` sub-schemas (property merge, required union, type intersection, numeric constraint tightening)
3. **`simplify_unions`** — Simplify `anyOf`/`oneOf` (nullable detection, single-variant unwrap)
4. **`sanitize`** — Strip unsupported keywords, validate `required ⊆ properties`
5. **`flatten_schema`** — One-call full pipeline (Phase 1-4)

### Benchmarks

- **Correctness**: 57 unit tests + 13 correctness-vs-JS tests (comparing Phase 1+2 output against `allof-merge` npm library)
- **Performance**: 10 pytest-benchmark tests across 5 complexity tiers (tiny/small/medium/large/xlarge), zerodep vs allof-merge JS

### CI integration

- Updated `benchmark.yml` workflow to install jsonschema JS dependencies
- Updated `generate_bench_report.py` to recognize allof-merge reference library
- Updated `pyproject.toml` (testpaths, ruff ignores, ty extra-paths)
- Updated `Makefile` with test/benchmark targets

## Test plan

- [x] `pytest jsonschema/test_jsonschema_correctness.py -v` — 57 tests pass
- [x] `pytest jsonschema/test_jsonschema_benchmark.py -v` — 23 tests pass (13 correctness + 10 perf)
- [x] `ruff check jsonschema/` — clean
- [x] `python zerodep.py manifest` — module registered
- [ ] CI benchmark workflow runs successfully
