### PR TITLE
perf(protobuf): optimize encode/decode hot paths and add byte_size()

### DIFF
--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -378,7 +378,9 @@ _SCALAR_BUF_WRITERS: dict[ScalarType, Any] = {
     ScalarType.SINT64: lambda buf, v: _write_varint(buf, zigzag_encode(v)),
     ScalarType.BOOL: lambda buf, v: buf.append(1 if v else 0),
     ScalarType.FIXED32: lambda buf, v: buf.extend(struct.pack("<I", v & 0xFFFFFFFF)),
-    ScalarType.FIXED64: lambda buf, v: buf.extend(struct.pack("<Q", v & 0xFFFFFFFFFFFFFFFF)),
+    ScalarType.FIXED64: lambda buf, v: buf.extend(
+        struct.pack("<Q", v & 0xFFFFFFFFFFFFFFFF)
+    ),
     ScalarType.SFIXED32: lambda buf, v: buf.extend(struct.pack("<i", v)),
     ScalarType.SFIXED64: lambda buf, v: buf.extend(struct.pack("<q", v)),
     ScalarType.FLOAT: lambda buf, v: buf.extend(struct.pack("<f", v)),
@@ -725,12 +727,8 @@ class _MessageDescriptor:
             # Default-value checker
             object.__setattr__(info, "_is_default", _make_is_default(info))
             # Cache tag bytes
-            object.__setattr__(
-                info, "_tag", make_tag(info.number, info.wire_type)
-            )
-            object.__setattr__(
-                info, "_len_tag", make_tag(info.number, WireType.LEN)
-            )
+            object.__setattr__(info, "_tag", make_tag(info.number, info.wire_type))
+            object.__setattr__(info, "_len_tag", make_tag(info.number, WireType.LEN))
             # Cache map metadata
             if info.kind == FieldKind.MAP and info.map_marker is not None:
                 object.__setattr__(info, "_map_meta", _MapMeta(info.map_marker))
@@ -1220,9 +1218,9 @@ class _MapMeta:
     )
 
     def __init__(self, map_marker: MapField) -> None:
-        self.key_scalar = _extract_proto_scalar(
-            map_marker.key_type
-        ) or _infer_scalar(_get_base_type(map_marker.key_type))
+        self.key_scalar = _extract_proto_scalar(map_marker.key_type) or _infer_scalar(
+            _get_base_type(map_marker.key_type)
+        )
         self.key_is_string = self.key_scalar.scalar_type == ScalarType.STRING
         self.key_tag = make_tag(1, self.key_scalar.wire_type)
         self.key_buf_writer = _SCALAR_BUF_WRITERS.get(self.key_scalar.scalar_type)
@@ -1348,6 +1346,179 @@ def _encode_message(obj: Any) -> bytes:
     return bytes(buf)
 
 
+# ---- Size calculation (byte_size) ----
+
+_VARINT_MAX_BYTES = 10
+
+
+def _varint_size(value: int) -> int:
+    """Return the number of bytes needed to encode *value* as a varint."""
+    if value < 0:
+        return _VARINT_MAX_BYTES  # negative int32/int64 = 10 bytes
+    if value == 0:
+        return 1
+    return (value.bit_length() + 6) // 7
+
+
+def _tag_size(field_number: int) -> int:
+    """Return the byte size of a field tag."""
+    return _varint_size((field_number << 3))
+
+
+_SCALAR_SIZES: dict[ScalarType, int | None] = {
+    ScalarType.FIXED32: 4,
+    ScalarType.SFIXED32: 4,
+    ScalarType.FLOAT: 4,
+    ScalarType.FIXED64: 8,
+    ScalarType.SFIXED64: 8,
+    ScalarType.DOUBLE: 8,
+}
+
+
+def _scalar_value_size(scalar: ProtoScalar, value: Any) -> int:
+    """Return wire size of a scalar value (without tag)."""
+    fixed = _SCALAR_SIZES.get(scalar.scalar_type)
+    if fixed is not None:
+        return fixed
+    st = scalar.scalar_type
+    if st == ScalarType.BOOL:
+        return 1
+    if st in (ScalarType.SINT32, ScalarType.SINT64):
+        return _varint_size(zigzag_encode(value))
+    if st == ScalarType.INT32:
+        return _varint_size(
+            value & 0xFFFFFFFF if value >= 0 else value & 0xFFFFFFFFFFFFFFFF
+        )
+    if st in (ScalarType.INT64, ScalarType.UINT64):
+        return _varint_size(value & 0xFFFFFFFFFFFFFFFF)
+    if st == ScalarType.UINT32:
+        return _varint_size(value & 0xFFFFFFFF)
+    # STRING / BYTES handled separately
+    return 0  # pragma: no cover
+
+
+def _field_byte_size(info: FieldInfo, value: Any) -> int:
+    """Return the total wire size of a single field (tag + value)."""
+    tag_len = len(info._tag)
+
+    if info.kind == FieldKind.SCALAR:
+        return tag_len + _scalar_value_size(info.scalar, value)
+
+    if info.kind == FieldKind.ENUM:
+        return tag_len + _varint_size(int(value) & 0xFFFFFFFFFFFFFFFF)
+
+    if info.kind == FieldKind.STRING:
+        encoded = value.encode("utf-8")
+        return tag_len + _varint_size(len(encoded)) + len(encoded)
+
+    if info.kind == FieldKind.BYTES:
+        return tag_len + _varint_size(len(value)) + len(value)
+
+    if info.kind == FieldKind.MESSAGE:
+        inner = _message_byte_size(value)
+        return tag_len + _varint_size(inner) + inner
+
+    if info.kind == FieldKind.REPEATED_SCALAR:
+        body_size = 0
+        fixed = _SCALAR_SIZES.get(info.scalar.scalar_type)
+        if fixed is not None:
+            body_size = fixed * len(value)
+        else:
+            for v in value:
+                body_size += _scalar_value_size(info.scalar, v)
+        len_tag = len(info._len_tag)
+        return len_tag + _varint_size(body_size) + body_size
+
+    if info.kind == FieldKind.REPEATED_ENUM:
+        body_size = sum(_varint_size(int(v) & 0xFFFFFFFFFFFFFFFF) for v in value)
+        len_tag = len(info._len_tag)
+        return len_tag + _varint_size(body_size) + body_size
+
+    if info.kind == FieldKind.REPEATED_MESSAGE:
+        total = 0
+        for v in value:
+            inner = _message_byte_size(v)
+            total += tag_len + _varint_size(inner) + inner
+        return total
+
+    if info.kind == FieldKind.REPEATED_STRING:
+        total = 0
+        for v in value:
+            encoded = v.encode("utf-8")
+            total += tag_len + _varint_size(len(encoded)) + len(encoded)
+        return total
+
+    if info.kind == FieldKind.REPEATED_BYTES:
+        total = 0
+        for v in value:
+            total += tag_len + _varint_size(len(v)) + len(v)
+        return total
+
+    if info.kind == FieldKind.MAP:
+        total = 0
+        mm = info._map_meta
+        for k, v in value.items():
+            entry_size = _map_entry_size(mm, k, v)
+            len_tag = len(info._len_tag)
+            total += len_tag + _varint_size(entry_size) + entry_size
+        return total
+
+    return 0  # pragma: no cover
+
+
+def _map_entry_size(mm: _MapMeta, key: Any, value: Any) -> int:
+    """Return the wire size of a single map entry (without outer tag/length)."""
+    size = 0
+    # Key: field 1
+    key_tag_len = len(mm.key_tag)
+    if mm.key_is_string:
+        encoded = key.encode("utf-8")
+        size += key_tag_len + _varint_size(len(encoded)) + len(encoded)
+    else:
+        size += key_tag_len + _scalar_value_size(mm.key_scalar, key)
+    # Value: field 2
+    val_tag_len = len(mm.val_tag)
+    if mm.value_is_message:
+        inner = _message_byte_size(value)
+        size += val_tag_len + _varint_size(inner) + inner
+    elif mm.value_is_enum:
+        size += val_tag_len + _varint_size(int(value) & 0xFFFFFFFFFFFFFFFF)
+    elif mm.value_base is str:
+        encoded = value.encode("utf-8")
+        size += val_tag_len + _varint_size(len(encoded)) + len(encoded)
+    elif mm.value_base is bytes:
+        size += val_tag_len + _varint_size(len(value)) + len(value)
+    else:
+        size += val_tag_len + _scalar_value_size(mm.value_scalar, value)
+    return size
+
+
+def _message_byte_size(obj: Any) -> int:
+    """Return the total wire size of a message (without outer length prefix)."""
+    desc: _MessageDescriptor = obj._proto_descriptor
+    total = 0
+    for info in desc._sorted_fields:
+        value = getattr(obj, info.name)
+        if info._is_default(value):
+            continue
+        total += _field_byte_size(info, value)
+    # Unknown fields
+    unknown = getattr(obj, "_unknown_fields", None)
+    if unknown:
+        for fn, wt, raw in unknown:
+            total += len(make_tag(fn, wt))
+            if wt == WireType.LEN:
+                total += _varint_size(len(raw)) + len(raw)
+            else:
+                total += len(raw)
+    return total
+
+
+def _msg_byte_size(self: Any) -> int:
+    """Return the serialized size of this message in bytes."""
+    return _message_byte_size(self)
+
+
 # Encoder dispatch table — mirrors _FIELD_DECODERS pattern for encode side.
 # Each handler: (buf, info, value) -> None
 
@@ -1383,9 +1554,7 @@ def _dispatch_encode_repeated_scalar(
     _encode_packed_repeated(buf, info, value)
 
 
-def _dispatch_encode_repeated_enum(
-    buf: bytearray, info: FieldInfo, value: Any
-) -> None:
+def _dispatch_encode_repeated_enum(buf: bytearray, info: FieldInfo, value: Any) -> None:
     _encode_packed_enum(buf, info, value)
 
 
@@ -2186,6 +2355,7 @@ def message(cls: type) -> type:
     cls.parse = classmethod(_msg_parse)  # type: ignore[attr-defined]
     cls.to_dict = _msg_to_dict  # type: ignore[attr-defined]
     cls.from_dict = classmethod(_msg_from_dict)  # type: ignore[attr-defined]
+    cls.byte_size = _msg_byte_size  # type: ignore[attr-defined]
 
     # Add _unknown_fields support
     original_init = cls.__init__

--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -106,6 +106,23 @@ def encode_varint(value: int) -> bytes:
     return bytes(buf)
 
 
+def _write_varint(buf: bytearray, value: int) -> None:
+    """Append a varint directly to *buf* (avoids intermediate bytes object)."""
+    if value < 0:
+        value = value & 0xFFFFFFFFFFFFFFFF
+    if value < 0x80:
+        buf.append(value)
+        return
+    if value < 0x4000:
+        buf.append((value & 0x7F) | 0x80)
+        buf.append(value >> 7)
+        return
+    while value > 0x7F:
+        buf.append((value & 0x7F) | 0x80)
+        value >>= 7
+    buf.append(value & 0x7F)
+
+
 def decode_varint(data: bytes | bytearray | memoryview, pos: int) -> tuple[int, int]:
     """Decode a varint from *data* starting at *pos*.
 
@@ -347,6 +364,25 @@ _SCALAR_ENCODERS: dict[ScalarType, Any] = {
     ScalarType.SFIXED64: encode_sfixed64,
     ScalarType.FLOAT: encode_float,
     ScalarType.DOUBLE: encode_double,
+}
+
+# Buffer-writing scalar encoders: write directly to bytearray (no intermediate bytes)
+_SCALAR_BUF_WRITERS: dict[ScalarType, Any] = {
+    ScalarType.INT32: lambda buf, v: _write_varint(
+        buf, v & 0xFFFFFFFF if v >= 0 else v & 0xFFFFFFFFFFFFFFFF
+    ),
+    ScalarType.INT64: lambda buf, v: _write_varint(buf, v & 0xFFFFFFFFFFFFFFFF),
+    ScalarType.UINT32: lambda buf, v: _write_varint(buf, v & 0xFFFFFFFF),
+    ScalarType.UINT64: lambda buf, v: _write_varint(buf, v & 0xFFFFFFFFFFFFFFFF),
+    ScalarType.SINT32: lambda buf, v: _write_varint(buf, zigzag_encode(v)),
+    ScalarType.SINT64: lambda buf, v: _write_varint(buf, zigzag_encode(v)),
+    ScalarType.BOOL: lambda buf, v: buf.append(1 if v else 0),
+    ScalarType.FIXED32: lambda buf, v: buf.extend(struct.pack("<I", v & 0xFFFFFFFF)),
+    ScalarType.FIXED64: lambda buf, v: buf.extend(struct.pack("<Q", v & 0xFFFFFFFFFFFFFFFF)),
+    ScalarType.SFIXED32: lambda buf, v: buf.extend(struct.pack("<i", v)),
+    ScalarType.SFIXED64: lambda buf, v: buf.extend(struct.pack("<q", v)),
+    ScalarType.FLOAT: lambda buf, v: buf.extend(struct.pack("<f", v)),
+    ScalarType.DOUBLE: lambda buf, v: buf.extend(struct.pack("<d", v)),
 }
 
 
@@ -1010,7 +1046,7 @@ def _encode_length_delimited(data: bytes) -> bytes:
 
 def _extend_length_delimited(buf: bytearray, data: bytes | bytearray) -> None:
     """Extend *buf* with a varint length prefix followed by *data*."""
-    buf.extend(encode_varint(len(data)))
+    _write_varint(buf, len(data))
     buf.extend(data)
 
 
@@ -1095,9 +1131,14 @@ def _encode_packed_repeated(buf: bytearray, info: FieldInfo, values: list[Any]) 
         body = struct.pack(f"<{len(values)}{fmt[1]}", *values)
     else:
         body_buf = bytearray()
-        encoder = _SCALAR_ENCODERS[st]
-        for v in values:
-            body_buf.extend(encoder(v))
+        writer = _SCALAR_BUF_WRITERS.get(st)
+        if writer is not None:
+            for v in values:
+                writer(body_buf, v)
+        else:
+            encoder = _SCALAR_ENCODERS[st]
+            for v in values:
+                body_buf.extend(encoder(v))
         body = bytes(body_buf)
     buf.extend(tag)
     _extend_length_delimited(buf, body)
@@ -1109,7 +1150,7 @@ def _encode_packed_enum(buf: bytearray, info: FieldInfo, values: list[Any]) -> N
         return
     body = bytearray()
     for v in values:
-        body.extend(encode_varint(int(v) & 0xFFFFFFFFFFFFFFFF))
+        _write_varint(body, int(v) & 0xFFFFFFFFFFFFFFFF)
     tag = make_tag(info.number, WireType.LEN)
     buf.extend(tag)
     _extend_length_delimited(buf, body)
@@ -1196,7 +1237,7 @@ def _encode_map(buf: bytearray, info: FieldInfo, mapping: dict[Any, Any]) -> Non
         if value_is_message:
             _extend_length_delimited(entry, _encode_message(v))
         elif value_is_enum:
-            entry.extend(encode_varint(int(v) & 0xFFFFFFFFFFFFFFFF))
+            _write_varint(entry, int(v) & 0xFFFFFFFFFFFFFFFF)
         elif value_base is str:
             _extend_length_delimited(entry, v.encode("utf-8"))
         elif value_base is bytes:
@@ -1261,12 +1302,12 @@ def _encode_message(obj: Any) -> bytes:
 
 def _dispatch_encode_scalar(buf: bytearray, info: FieldInfo, value: Any) -> None:
     buf.extend(info._tag)
-    buf.extend(_SCALAR_ENCODERS[info.scalar.scalar_type](value))
+    _SCALAR_BUF_WRITERS[info.scalar.scalar_type](buf, value)
 
 
 def _dispatch_encode_enum(buf: bytearray, info: FieldInfo, value: Any) -> None:
     buf.extend(info._tag)
-    buf.extend(encode_varint(int(value) & 0xFFFFFFFFFFFFFFFF))
+    _write_varint(buf, int(value) & 0xFFFFFFFFFFFFFFFF)
 
 
 def _dispatch_encode_string(buf: bytearray, info: FieldInfo, value: Any) -> None:

--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -1813,7 +1813,14 @@ def _decode_message_bytes(
     fields_by_number = desc.fields_by_number
 
     while pos < end:
-        field_number, wire_type, pos = decode_tag(data, pos)
+        # Inline 1-byte tag fast-path: field numbers 1-15 fit in 1 byte
+        byte = data[pos]
+        if byte < 0x80:
+            field_number = byte >> 3
+            wire_type = byte & 0x07
+            pos += 1
+        else:
+            field_number, wire_type, pos = decode_tag(data, pos)
         info = fields_by_number.get(field_number)
 
         if info is None:

--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -624,6 +624,9 @@ class FieldInfo:
     python_type: type  # base Python type (int, str, etc.)
     default_value: Any  # proto3 zero-value
     _decoder: Any = None  # cached dispatch handler, set after _FIELD_DECODERS is built
+    _encoder: Any = None  # cached encode handler, set after _FIELD_ENCODERS is built
+    _tag: bytes = b""  # cached tag bytes for this field's native wire type
+    _len_tag: bytes = b""  # cached tag bytes for LEN wire type (repeated/map)
 
 
 class _MessageDescriptor:
@@ -668,12 +671,24 @@ class _MessageDescriptor:
         # Pre-sort fields by number for deterministic encoding
         self._sorted_fields = sorted(self.fields.values(), key=lambda f: f.number)
 
-    def _bind_decoders(self) -> None:
-        """Bind per-field decoder handlers (called after _FIELD_DECODERS is ready)."""
+    def _bind_handlers(self) -> None:
+        """Bind per-field encoder/decoder handlers and cache tags."""
         for info in self.fields.values():
+            # Decoder
             handler = _FIELD_DECODERS.get(info.kind)
             if handler is not None:
                 object.__setattr__(info, "_decoder", handler)
+            # Encoder
+            enc = _FIELD_ENCODERS.get(info.kind)
+            if enc is not None:
+                object.__setattr__(info, "_encoder", enc)
+            # Cache tag bytes
+            object.__setattr__(
+                info, "_tag", make_tag(info.number, info.wire_type)
+            )
+            object.__setattr__(
+                info, "_len_tag", make_tag(info.number, WireType.LEN)
+            )
 
     def _resolve_field(
         self,
@@ -1195,7 +1210,7 @@ def _encode_message(obj: Any) -> bytes:
         value = getattr(obj, info.name)
         if _is_default_value(info, value):
             continue
-        _encode_field(buf, info, value)
+        info._encoder(buf, info, value)
 
     # Append unknown fields
     unknown = getattr(obj, "_unknown_fields", None)
@@ -1208,6 +1223,84 @@ def _encode_message(obj: Any) -> bytes:
                 buf.extend(raw)
 
     return bytes(buf)
+
+
+# Encoder dispatch table — mirrors _FIELD_DECODERS pattern for encode side.
+# Each handler: (buf, info, value) -> None
+
+
+def _dispatch_encode_scalar(buf: bytearray, info: FieldInfo, value: Any) -> None:
+    buf.extend(info._tag)
+    buf.extend(_SCALAR_ENCODERS[info.scalar.scalar_type](value))
+
+
+def _dispatch_encode_enum(buf: bytearray, info: FieldInfo, value: Any) -> None:
+    buf.extend(info._tag)
+    buf.extend(encode_varint(int(value) & 0xFFFFFFFFFFFFFFFF))
+
+
+def _dispatch_encode_string(buf: bytearray, info: FieldInfo, value: Any) -> None:
+    buf.extend(info._tag)
+    _extend_length_delimited(buf, value.encode("utf-8"))
+
+
+def _dispatch_encode_bytes(buf: bytearray, info: FieldInfo, value: Any) -> None:
+    buf.extend(info._tag)
+    _extend_length_delimited(buf, value)
+
+
+def _dispatch_encode_message(buf: bytearray, info: FieldInfo, value: Any) -> None:
+    buf.extend(info._tag)
+    _extend_length_delimited(buf, _encode_message(value))
+
+
+def _dispatch_encode_repeated_scalar(
+    buf: bytearray, info: FieldInfo, value: Any
+) -> None:
+    _encode_packed_repeated(buf, info, value)
+
+
+def _dispatch_encode_repeated_enum(
+    buf: bytearray, info: FieldInfo, value: Any
+) -> None:
+    _encode_packed_enum(buf, info, value)
+
+
+def _dispatch_encode_repeated_message(
+    buf: bytearray, info: FieldInfo, value: Any
+) -> None:
+    _encode_repeated_messages(buf, info, value)
+
+
+def _dispatch_encode_repeated_string(
+    buf: bytearray, info: FieldInfo, value: Any
+) -> None:
+    _encode_repeated_strings(buf, info, value)
+
+
+def _dispatch_encode_repeated_bytes(
+    buf: bytearray, info: FieldInfo, value: Any
+) -> None:
+    _encode_repeated_bytes(buf, info, value)
+
+
+def _dispatch_encode_map(buf: bytearray, info: FieldInfo, value: Any) -> None:
+    _encode_map(buf, info, value)
+
+
+_FIELD_ENCODERS: dict[FieldKind, Any] = {
+    FieldKind.SCALAR: _dispatch_encode_scalar,
+    FieldKind.ENUM: _dispatch_encode_enum,
+    FieldKind.STRING: _dispatch_encode_string,
+    FieldKind.BYTES: _dispatch_encode_bytes,
+    FieldKind.MESSAGE: _dispatch_encode_message,
+    FieldKind.REPEATED_SCALAR: _dispatch_encode_repeated_scalar,
+    FieldKind.REPEATED_ENUM: _dispatch_encode_repeated_enum,
+    FieldKind.REPEATED_MESSAGE: _dispatch_encode_repeated_message,
+    FieldKind.REPEATED_STRING: _dispatch_encode_repeated_string,
+    FieldKind.REPEATED_BYTES: _dispatch_encode_repeated_bytes,
+    FieldKind.MAP: _dispatch_encode_map,
+}
 
 
 # ============================================================================
@@ -1957,7 +2050,7 @@ def message(cls: type) -> type:
 
     # Build descriptor
     descriptor = _MessageDescriptor(cls)
-    descriptor._bind_decoders()
+    descriptor._bind_handlers()
     cls._proto_descriptor = descriptor  # type: ignore[attr-defined]
 
     # Inject methods

--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -680,6 +680,8 @@ class _MessageDescriptor:
         self.fields_by_number: dict[int, FieldInfo] = {}
         self.oneof_groups: dict[str, list[FieldInfo]] = {}
         self._sorted_fields: list[FieldInfo] = []
+        self._default_attrs: dict[str, Any] = {}
+        self._mutable_defaults: list[str] = []
         self._build(cls)
 
     def _build(self, cls: type) -> None:
@@ -732,6 +734,15 @@ class _MessageDescriptor:
             # Cache map metadata
             if info.kind == FieldKind.MAP and info.map_marker is not None:
                 object.__setattr__(info, "_map_meta", _MapMeta(info.map_marker))
+        # Pre-compute default attrs template for fast message construction
+        self._default_attrs = {
+            info.name: info.default_value for info in self.fields.values()
+        }
+        self._mutable_defaults = [
+            info.name
+            for info in self.fields.values()
+            if isinstance(info.default_value, (list, dict))
+        ]
 
     def _resolve_field(
         self,
@@ -1804,12 +1815,15 @@ def _build_message_instance(
 ) -> Any:
     """Construct a message instance from decoded field values."""
     obj = cls.__new__(cls)
-    for finfo in desc.fields.values():
-        val = values.get(finfo.name, finfo.default_value)
-        if val is finfo.default_value and isinstance(val, (list, dict)):
-            val = type(val)(val)
-        object.__setattr__(obj, finfo.name, val)
-    object.__setattr__(obj, "_unknown_fields", unknown_fields)
+    attrs = dict(desc._default_attrs)
+    attrs.update(values)
+    # Copy mutable defaults (list/dict) that were not overridden by decode
+    for name in desc._mutable_defaults:
+        if name not in values:
+            val = attrs[name]
+            attrs[name] = type(val)(val)
+    attrs["_unknown_fields"] = unknown_fields
+    obj.__dict__.update(attrs)
     return obj
 
 

--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -625,6 +625,7 @@ class FieldInfo:
     default_value: Any  # proto3 zero-value
     _decoder: Any = None  # cached dispatch handler, set after _FIELD_DECODERS is built
     _encoder: Any = None  # cached encode handler, set after _FIELD_ENCODERS is built
+    _is_default: Any = None  # cached default-value check, bound at build time
     _tag: bytes = b""  # cached tag bytes for this field's native wire type
     _len_tag: bytes = b""  # cached tag bytes for LEN wire type (repeated/map)
 
@@ -682,6 +683,8 @@ class _MessageDescriptor:
             enc = _FIELD_ENCODERS.get(info.kind)
             if enc is not None:
                 object.__setattr__(info, "_encoder", enc)
+            # Default-value checker
+            object.__setattr__(info, "_is_default", _make_is_default(info))
             # Cache tag bytes
             object.__setattr__(
                 info, "_tag", make_tag(info.number, info.wire_type)
@@ -947,6 +950,33 @@ class _MessageDescriptor:
 # ============================================================================
 
 
+def _make_is_default(info: FieldInfo) -> Any:
+    """Create a specialized default-value checker for *info*."""
+    kind = info.kind
+    if kind == FieldKind.MAP or kind in (
+        FieldKind.REPEATED_SCALAR,
+        FieldKind.REPEATED_MESSAGE,
+        FieldKind.REPEATED_ENUM,
+        FieldKind.REPEATED_STRING,
+        FieldKind.REPEATED_BYTES,
+    ):
+        return lambda v: not v
+    if kind == FieldKind.MESSAGE:
+        return lambda v: v is None
+    if kind == FieldKind.ENUM:
+        return lambda v: int(v) == 0
+    if kind == FieldKind.STRING:
+        return lambda v: not v
+    if kind == FieldKind.BYTES:
+        return lambda v: not v
+    if info.scalar is not None:
+        default = _SCALAR_DEFAULTS[info.scalar.scalar_type]
+        if isinstance(default, float):
+            return lambda v, _d=default: v == _d
+        return lambda v, _d=default: v == _d
+    return lambda v: False
+
+
 def _is_default_value(info: FieldInfo, value: Any) -> bool:
     """Check if a value is the proto3 zero-value for its field."""
     if info.kind == FieldKind.MAP:
@@ -1208,7 +1238,7 @@ def _encode_message(obj: Any) -> bytes:
     # Encode known fields in field-number order for deterministic output
     for info in desc._sorted_fields:
         value = getattr(obj, info.name)
-        if _is_default_value(info, value):
+        if info._is_default(value):
             continue
         info._encoder(buf, info, value)
 
@@ -1834,7 +1864,7 @@ def _msg_to_dict(self: Any) -> dict[str, Any]:
 
     for info in desc.fields.values():
         value = getattr(self, info.name)
-        if _is_default_value(info, value):
+        if info._is_default(value):
             continue  # Omit proto3 zero-values
         result[info.name] = _value_to_dict(info, value)
 

--- a/protobuf/protobuf.py
+++ b/protobuf/protobuf.py
@@ -664,6 +664,7 @@ class FieldInfo:
     _is_default: Any = None  # cached default-value check, bound at build time
     _tag: bytes = b""  # cached tag bytes for this field's native wire type
     _len_tag: bytes = b""  # cached tag bytes for LEN wire type (repeated/map)
+    _map_meta: Any = None  # cached _MapMeta for MAP fields
 
 
 class _MessageDescriptor:
@@ -728,6 +729,9 @@ class _MessageDescriptor:
             object.__setattr__(
                 info, "_len_tag", make_tag(info.number, WireType.LEN)
             )
+            # Cache map metadata
+            if info.kind == FieldKind.MAP and info.map_marker is not None:
+                object.__setattr__(info, "_map_meta", _MapMeta(info.map_marker))
 
     def _resolve_field(
         self,
@@ -1186,42 +1190,79 @@ def _encode_repeated_bytes(
         _extend_length_delimited(buf, v)
 
 
+class _MapMeta:
+    """Pre-computed type metadata for a map field (avoids per-entry introspection)."""
+
+    __slots__ = (
+        "key_scalar",
+        "key_is_string",
+        "key_tag",
+        "key_buf_writer",
+        "value_scalar",
+        "value_base",
+        "value_is_message",
+        "value_is_enum",
+        "val_tag",
+        "val_buf_writer",
+        "default_key",
+        "default_value",
+    )
+
+    def __init__(self, map_marker: MapField) -> None:
+        self.key_scalar = _extract_proto_scalar(
+            map_marker.key_type
+        ) or _infer_scalar(_get_base_type(map_marker.key_type))
+        self.key_is_string = self.key_scalar.scalar_type == ScalarType.STRING
+        self.key_tag = make_tag(1, self.key_scalar.wire_type)
+        self.key_buf_writer = _SCALAR_BUF_WRITERS.get(self.key_scalar.scalar_type)
+
+        self.value_scalar = _extract_proto_scalar(map_marker.value_type)
+        self.value_base = _get_base_type(map_marker.value_type)
+        self.value_is_message = _is_message_type(self.value_base)
+        self.value_is_enum = _is_enum_type(self.value_base)
+
+        if self.value_is_message:
+            self.val_tag = make_tag(2, WireType.LEN)
+        elif self.value_is_enum:
+            self.val_tag = make_tag(2, WireType.VARINT)
+        elif self.value_base is str or self.value_base is bytes:
+            self.val_tag = make_tag(2, WireType.LEN)
+        elif self.value_scalar is not None:
+            self.val_tag = make_tag(2, self.value_scalar.wire_type)
+        else:
+            self.value_scalar = _infer_scalar(self.value_base)
+            self.val_tag = make_tag(2, self.value_scalar.wire_type)
+
+        self.val_buf_writer = (
+            _SCALAR_BUF_WRITERS.get(self.value_scalar.scalar_type)
+            if self.value_scalar
+            else None
+        )
+
+        self.default_key = _SCALAR_DEFAULTS.get(self.key_scalar.scalar_type, 0)
+        self.default_value = _default_map_value(
+            self.value_scalar,
+            self.value_base,
+            self.value_is_message,
+            self.value_is_enum,
+        )
+
+
 def _encode_map(buf: bytearray, info: FieldInfo, mapping: dict[Any, Any]) -> None:
     """Encode a map field as repeated key-value entry messages.
 
     Each entry is a message with field 1 = key, field 2 = value.
     """
-    assert info.map_marker is not None
-    tag = make_tag(info.number, WireType.LEN)
-
-    key_scalar = _extract_proto_scalar(info.map_marker.key_type) or _infer_scalar(
-        _get_base_type(info.map_marker.key_type)
-    )
-    value_scalar = _extract_proto_scalar(info.map_marker.value_type)
-    value_base = _get_base_type(info.map_marker.value_type)
-    value_is_message = _is_message_type(value_base)
-    value_is_enum = _is_enum_type(value_base)
-
-    # Pre-compute key/value tags outside the loop
-    key_tag = make_tag(1, key_scalar.wire_type)
-    key_is_string = key_scalar.scalar_type == ScalarType.STRING
-
-    if value_is_message:
-        val_tag = make_tag(2, WireType.LEN)
-    elif value_is_enum:
-        val_tag = make_tag(2, WireType.VARINT)
-    elif value_base is str or value_base is bytes:
-        val_tag = make_tag(2, WireType.LEN)
-    elif value_scalar is not None:
-        val_tag = make_tag(2, value_scalar.wire_type)
-    else:
-        value_scalar = _infer_scalar(value_base)
-        val_tag = make_tag(2, value_scalar.wire_type)
-
-    key_encoder = _SCALAR_ENCODERS.get(key_scalar.scalar_type)
-    val_encoder = (
-        _SCALAR_ENCODERS.get(value_scalar.scalar_type) if value_scalar else None
-    )
+    mm = info._map_meta
+    tag = info._len_tag
+    key_tag = mm.key_tag
+    key_is_string = mm.key_is_string
+    key_buf_writer = mm.key_buf_writer
+    val_tag = mm.val_tag
+    value_is_message = mm.value_is_message
+    value_is_enum = mm.value_is_enum
+    value_base = mm.value_base
+    val_buf_writer = mm.val_buf_writer
 
     for k, v in mapping.items():
         entry = bytearray()
@@ -1230,7 +1271,7 @@ def _encode_map(buf: bytearray, info: FieldInfo, mapping: dict[Any, Any]) -> Non
         if key_is_string:
             _extend_length_delimited(entry, k.encode("utf-8"))
         else:
-            entry.extend(key_encoder(k))
+            key_buf_writer(entry, k)
 
         # Value: field 2
         entry.extend(val_tag)
@@ -1243,7 +1284,7 @@ def _encode_map(buf: bytearray, info: FieldInfo, mapping: dict[Any, Any]) -> Non
         elif value_base is bytes:
             _extend_length_delimited(entry, v)
         else:
-            entry.extend(val_encoder(v))
+            val_buf_writer(entry, v)
 
         buf.extend(tag)
         _extend_length_delimited(buf, entry)
@@ -1502,38 +1543,34 @@ def _default_map_value(
 
 
 def _decode_map_entry(
-    map_marker: MapField,
+    mm: _MapMeta,
     data: bytes | bytearray | memoryview,
     pos: int,
     end: int,
 ) -> tuple[Any, Any]:
     """Decode a single map entry message (fields 1=key, 2=value)."""
-    key_scalar = _extract_proto_scalar(map_marker.key_type) or _infer_scalar(
-        _get_base_type(map_marker.key_type)
-    )
-    value_scalar = _extract_proto_scalar(map_marker.value_type)
-    value_base = _get_base_type(map_marker.value_type)
-    value_is_message = _is_message_type(value_base)
-    value_is_enum = _is_enum_type(value_base)
-
-    key: Any = _SCALAR_DEFAULTS.get(key_scalar.scalar_type, 0)
+    key: Any = mm.default_key
     value: Any = None
 
     while pos < end:
         fn, wt, pos = decode_tag(data, pos)
         if fn == 1:
-            key, pos = _decode_map_key(key_scalar, wt, data, pos)
+            key, pos = _decode_map_key(mm.key_scalar, wt, data, pos)
         elif fn == 2:
             value, pos = _decode_map_value(
-                value_scalar, value_base, value_is_message, value_is_enum, wt, data, pos
+                mm.value_scalar,
+                mm.value_base,
+                mm.value_is_message,
+                mm.value_is_enum,
+                wt,
+                data,
+                pos,
             )
         else:
             _, pos = _skip_field(wt, data, pos)
 
     if value is None:
-        value = _default_map_value(
-            value_scalar, value_base, value_is_message, value_is_enum
-        )
+        value = mm.default_value
 
     return key, value
 
@@ -1736,9 +1773,8 @@ def _decode_field_map(
     values: dict[str, Any],
 ) -> int:
     """Decode a single map entry and store it in *values*."""
-    assert info.map_marker is not None
     length, pos = decode_varint(data, pos)
-    k, v = _decode_map_entry(info.map_marker, data, pos, pos + length)
+    k, v = _decode_map_entry(info._map_meta, data, pos, pos + length)
     values[info.name][k] = v
     return pos + length
 


### PR DESCRIPTION
## Summary

- **Encoder dispatch binding**: replace 11-way if/elif in `_encode_field` with pre-bound `info._encoder` callables and cached tag bytes
- **Specialized default checks**: per-field `info._is_default` lambdas instead of generic 5-way branch
- **Inline 1-byte tag decode**: fast-path for field numbers 1-15 (single byte tags) in the decode loop
- **Write-to-buffer varint/scalar**: `_write_varint` and `_SCALAR_BUF_WRITERS` append directly to bytearray, eliminating intermediate `bytes` allocations
- **Cached map metadata**: `_MapMeta` pre-computes key/value type info, avoiding per-entry introspection (6+ calls × N entries)
- **Batch message construction**: `__dict__.update` replaces per-field `object.__setattr__` during decode
- **`byte_size()` method**: compute serialized size without materializing bytes, useful for pre-allocation and framing

## Benchmark results

| Benchmark | Before (μs) | After (μs) | Improvement |
|-----------|-------------|------------|-------------|
| encode_small | 3.18 | 1.87 | ~41% |
| encode_medium | 27.90 | 11.79 | ~58% |
| encode_large | 307.85 | 107.50 | ~65% |
| decode_small | 4.59 | 4.28 | ~7% |
| decode_medium | 32.84 | 27.94 | ~15% |
| decode_large | 302.56 | 219.83 | ~27% |
| roundtrip_large | 614.66 | 373.92 | ~39% |

## Test plan

- [x] All 90 correctness tests pass after each commit
- [x] Ruff check + format clean
- [x] Benchmarks measured after each phase to verify improvement
- [x] `byte_size()` verified against actual `serialize()` output length