### PR TITLE
feat(soup): add CSS pseudo-selector support

### DIFF
--- a/soup/soup.py
+++ b/soup/soup.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.5.0"
+# version = "0.6.0"
 # deps = []
 # tier = "medium"
 # category = "data"
@@ -16,9 +16,12 @@ Supports ``find``, ``find_all``, ``select``, ``select_one``, ``get_text``,
 ``decompose``, and ``find_parent`` — the subset of BeautifulSoup used by
 the vast majority of real-world scraping scripts.
 
+Supports CSS pseudo-selectors: ``:first-child``, ``:last-child``,
+``:only-child``, and ``:not(selector)``.
+
 Does NOT implement: ``.prettify()``, ``.stripped_strings``, ``.descendants``
 iterator, ``.next_sibling`` / ``.previous_sibling``, ``NavigableString`` class,
-multiple parser backends, CSS pseudo-selectors.
+multiple parser backends.
 
 Example::
 
@@ -589,6 +592,8 @@ _SIMPLE_RE = re.compile(
     |(?P<cls>\.[a-zA-Z_-][a-zA-Z0-9_-]*)  # .class
     |(?P<id>\#[a-zA-Z_-][a-zA-Z0-9_-]*)   # #id
     |(?P<attr>\[[^\]]+\])              # [attr] or [attr="val"]
+    |(?P<pseudo>:(?:first-child|last-child|only-child))  # structural pseudo
+    |(?P<not>:not\()                   # :not( — argument parsed separately
     """,
     re.VERBOSE,
 )
@@ -648,6 +653,23 @@ def _apply_regex_match(m: re.Match[str], compound: dict[str, Any]) -> None:
             compound.setdefault("attrs", []).append(
                 (am.group("name"), am.group("value"))
             )
+    elif m.group("pseudo"):
+        compound.setdefault("pseudos", []).append(m.group("pseudo")[1:])
+
+
+def _parse_not_argument(selector: str, pos: int) -> tuple[dict[str, Any], int]:
+    """Parse the simple selector inside ``:not(...)``, return (inner, new_pos).
+
+    *pos* should point right after the opening ``(``.  The closing ``)`` is
+    consumed and *new_pos* points past it.
+    """
+    inner, pos = _parse_compound(selector, pos)
+    if inner is None:
+        inner = {}
+    pos = _skip_whitespace(selector, pos)
+    if pos < len(selector) and selector[pos] == ")":
+        pos += 1
+    return inner, pos
 
 
 def _parse_compound(selector: str, pos: int) -> tuple[dict[str, Any] | None, int]:
@@ -662,8 +684,14 @@ def _parse_compound(selector: str, pos: int) -> tuple[dict[str, Any] | None, int
         if m is None:
             break
         matched_any = True
-        _apply_regex_match(m, compound)
-        pos = m.end()
+        if m.group("not"):
+            # :not( matched — parse the inner selector and closing paren
+            pos = m.end()
+            inner, pos = _parse_not_argument(selector, pos)
+            compound.setdefault("nots", []).append(inner)
+        else:
+            _apply_regex_match(m, compound)
+            pos = m.end()
     return (compound if matched_any else None), pos
 
 
@@ -739,6 +767,25 @@ def _selector_attrs_match(tag: Tag, attrs: list[tuple[str, str | None]]) -> bool
     return True
 
 
+def _element_siblings(tag: Tag) -> list[Tag]:
+    """Return element (non-text) children of *tag*'s parent."""
+    if tag.parent is None:
+        return [tag]
+    return [c for c in tag.parent.children if isinstance(c, Tag)]
+
+
+def _pseudo_matches(tag: Tag, pseudo: str) -> bool:
+    """Return True if *tag* satisfies the structural pseudo-class *pseudo*."""
+    siblings = _element_siblings(tag)
+    if pseudo == "first-child":
+        return siblings[0] is tag
+    if pseudo == "last-child":
+        return siblings[-1] is tag
+    if pseudo == "only-child":
+        return len(siblings) == 1
+    return False  # pragma: no cover
+
+
 def _simple_matches(tag: Tag, simple: dict[str, Any]) -> bool:
     """Check if *tag* matches a single compound simple selector."""
     if "tag" in simple and tag.name != simple["tag"]:
@@ -749,6 +796,14 @@ def _simple_matches(tag: Tag, simple: dict[str, Any]) -> bool:
         return False
     if "attrs" in simple and not _selector_attrs_match(tag, simple["attrs"]):
         return False
+    if "pseudos" in simple:
+        for pseudo in simple["pseudos"]:
+            if not _pseudo_matches(tag, pseudo):
+                return False
+    if "nots" in simple:
+        for inner in simple["nots"]:
+            if _simple_matches(tag, inner):
+                return False
     return True
 
 

--- a/soup/test_soup_benchmark.py
+++ b/soup/test_soup_benchmark.py
@@ -196,3 +196,81 @@ class TestTreeOpsLarge:
 
     def test_beautifulsoup4(self, benchmark):
         benchmark(_bs4_tree_ops, LARGE)
+
+
+# ── CSS select benchmarks ──
+
+_SELECT_QUERIES = [
+    "div.item",
+    "div.item > h3",
+    "div.even a",
+    '[data-id="3"]',
+]
+
+_PSEUDO_QUERIES = [
+    "div.item :first-child",
+    "div.item :last-child",
+    "div.item > :not(p)",
+    "div.item > :first-child:not(h3)",
+]
+
+
+def _zd_select(html: str, queries: list[str]) -> list:
+    soup = Soup(html)
+    return [soup.select(q) for q in queries]
+
+
+def _bs4_select(html: str, queries: list[str]) -> list:
+    soup = BeautifulSoup(html, "html.parser")
+    return [soup.select(q) for q in queries]
+
+
+class TestSelectSmall:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_select, SMALL, _SELECT_QUERIES)
+
+    def test_beautifulsoup4(self, benchmark):
+        benchmark(_bs4_select, SMALL, _SELECT_QUERIES)
+
+
+class TestSelectMedium:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_select, MEDIUM, _SELECT_QUERIES)
+
+    def test_beautifulsoup4(self, benchmark):
+        benchmark(_bs4_select, MEDIUM, _SELECT_QUERIES)
+
+
+class TestSelectLarge:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_select, LARGE, _SELECT_QUERIES)
+
+    def test_beautifulsoup4(self, benchmark):
+        benchmark(_bs4_select, LARGE, _SELECT_QUERIES)
+
+
+# ── CSS pseudo-selector benchmarks ──
+
+
+class TestPseudoSelectSmall:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_select, SMALL, _PSEUDO_QUERIES)
+
+    def test_beautifulsoup4(self, benchmark):
+        benchmark(_bs4_select, SMALL, _PSEUDO_QUERIES)
+
+
+class TestPseudoSelectMedium:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_select, MEDIUM, _PSEUDO_QUERIES)
+
+    def test_beautifulsoup4(self, benchmark):
+        benchmark(_bs4_select, MEDIUM, _PSEUDO_QUERIES)
+
+
+class TestPseudoSelectLarge:
+    def test_zerodep(self, benchmark):
+        benchmark(_zd_select, LARGE, _PSEUDO_QUERIES)
+
+    def test_beautifulsoup4(self, benchmark):
+        benchmark(_bs4_select, LARGE, _PSEUDO_QUERIES)

--- a/soup/test_soup_correctness.py
+++ b/soup/test_soup_correctness.py
@@ -1216,3 +1216,121 @@ class TestNewTag:
         span.children.append("Added")
         div.append(span)
         assert div.find("span").text == "Added"
+
+
+# ── TestPseudoSelectors ──
+
+PSEUDO_HTML = """
+<ul>
+    <li class="a">First</li>
+    <li class="b">Second</li>
+    <li class="c">Third</li>
+</ul>
+<div><span class="only">Alone</span></div>
+<ol>
+    <li class="x">Alpha</li>
+</ol>
+"""
+
+
+class TestPseudoSelectors:
+    """CSS pseudo-selector tests: compare zerodep soup vs beautifulsoup4."""
+
+    def test_first_child(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        assert len(ours.select("li:first-child")) == len(
+            theirs.select("li:first-child")
+        )
+        assert ours.select("li:first-child")[0].text == "First"
+
+    def test_last_child(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        assert len(ours.select("li:last-child")) == len(
+            theirs.select("li:last-child")
+        )
+        assert ours.select("li:last-child")[0].text == "Third"
+
+    def test_only_child(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        our_results = ours.select("span:only-child")
+        their_results = theirs.select("span:only-child")
+        assert len(our_results) == len(their_results)
+        assert our_results[0].text == "Alone"
+
+    def test_only_child_li(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        our_results = ours.select("li:only-child")
+        their_results = theirs.select("li:only-child")
+        assert len(our_results) == len(their_results)
+        assert our_results[0].text == "Alpha"
+
+    def test_not_class(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        our_results = ours.select("li:not(.a)")
+        their_results = theirs.select("li:not(.a)")
+        assert len(our_results) == len(their_results)
+
+    def test_not_tag(self):
+        html = '<div><span>A</span><em>B</em><span>C</span></div>'
+        ours = _ours(html)
+        theirs = _theirs(html)
+        our_results = ours.select("div > :not(span)")
+        their_results = theirs.select("div > :not(span)")
+        assert len(our_results) == len(their_results)
+        assert our_results[0].text == "B"
+
+    def test_first_child_with_class(self):
+        html = '<div><p class="x">1</p><p class="x">2</p></div>'
+        ours = _ours(html)
+        theirs = _theirs(html)
+        our_results = ours.select("p.x:first-child")
+        their_results = theirs.select("p.x:first-child")
+        assert len(our_results) == len(their_results)
+        assert our_results[0].text == "1"
+
+    def test_last_child_descendant(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        our_results = ours.select("ul li:last-child")
+        their_results = theirs.select("ul li:last-child")
+        assert len(our_results) == len(their_results)
+        assert our_results[0].text == "Third"
+
+    def test_not_with_id(self):
+        html = '<div><p id="a">A</p><p id="b">B</p><p id="c">C</p></div>'
+        ours = _ours(html)
+        theirs = _theirs(html)
+        our_results = ours.select("p:not(#b)")
+        their_results = theirs.select("p:not(#b)")
+        assert len(our_results) == len(their_results)
+        assert [t.text for t in our_results] == ["A", "C"]
+
+    def test_combined_pseudo_selectors(self):
+        html = '<ul><li class="a">Only</li></ul>'
+        ours = _ours(html)
+        theirs = _theirs(html)
+        our_results = ours.select("li:first-child:last-child")
+        their_results = theirs.select("li:first-child:last-child")
+        assert len(our_results) == len(their_results)
+        assert our_results[0].text == "Only"
+
+    def test_first_child_no_match(self):
+        html = '<div><span>A</span><p>B</p></div>'
+        ours = _ours(html)
+        theirs = _theirs(html)
+        assert len(ours.select("p:first-child")) == len(
+            theirs.select("p:first-child")
+        )
+        assert len(ours.select("p:first-child")) == 0
+
+    def test_not_first_child(self):
+        ours = _ours(PSEUDO_HTML)
+        theirs = _theirs(PSEUDO_HTML)
+        our_results = ours.select("li:not(:first-child)")
+        their_results = theirs.select("li:not(:first-child)")
+        assert len(our_results) == len(their_results)

--- a/soup/test_soup_correctness.py
+++ b/soup/test_soup_correctness.py
@@ -1247,9 +1247,7 @@ class TestPseudoSelectors:
     def test_last_child(self):
         ours = _ours(PSEUDO_HTML)
         theirs = _theirs(PSEUDO_HTML)
-        assert len(ours.select("li:last-child")) == len(
-            theirs.select("li:last-child")
-        )
+        assert len(ours.select("li:last-child")) == len(theirs.select("li:last-child"))
         assert ours.select("li:last-child")[0].text == "Third"
 
     def test_only_child(self):
@@ -1276,7 +1274,7 @@ class TestPseudoSelectors:
         assert len(our_results) == len(their_results)
 
     def test_not_tag(self):
-        html = '<div><span>A</span><em>B</em><span>C</span></div>'
+        html = "<div><span>A</span><em>B</em><span>C</span></div>"
         ours = _ours(html)
         theirs = _theirs(html)
         our_results = ours.select("div > :not(span)")
@@ -1320,12 +1318,10 @@ class TestPseudoSelectors:
         assert our_results[0].text == "Only"
 
     def test_first_child_no_match(self):
-        html = '<div><span>A</span><p>B</p></div>'
+        html = "<div><span>A</span><p>B</p></div>"
         ours = _ours(html)
         theirs = _theirs(html)
-        assert len(ours.select("p:first-child")) == len(
-            theirs.select("p:first-child")
-        )
+        assert len(ours.select("p:first-child")) == len(theirs.select("p:first-child"))
         assert len(ours.select("p:first-child")) == 0
 
     def test_not_first_child(self):


### PR DESCRIPTION
## Summary
- Add `:first-child`, `:last-child`, `:only-child`, and `:not(selector)` CSS pseudo-selectors to the soup module's selector engine
- Bump soup version 0.5.0 → 0.6.0
- Add 12 correctness tests comparing against BeautifulSoup4
- Add CSS select and pseudo-select benchmarks (Small/Medium/Large)

## Test plan
- [x] All 142 correctness tests pass (including 12 new pseudo-selector tests)
- [x] All 30 benchmarks pass (including 12 new select/pseudo-select benchmarks)
- [ ] CI green on all matrix entries