### PR TITLE
feat(markdown): add GFM strikethrough, task lists, and extended autolinks

### DIFF
--- a/_plans/candidate-modules.md
+++ b/_plans/candidate-modules.md
@@ -20,7 +20,7 @@ Modules with implementation, correctness tests, and benchmarks.
 | `sse/` | httpx-sse | Low-level SSE parser + high-level client with auto-reconnect, exponential backoff, sync + async, depends on httpclient | httpx-sse |
 | `soup/` | beautifulsoup4 | HTML parser with find/find_all/select/CSS selectors, built on stdlib html.parser | beautifulsoup4 |
 | `prompt/` | questionary | confirm/select/text prompts, arrow key navigation, ANSI colors, cross-platform (termios + msvcrt) | — |
-| `markdown/` | mistune | CommonMark subset (ATX/Setext headings, emphasis, code spans/blocks, links, images, lists, blockquotes, thematic breaks, backslash escapes, autolinks, hard breaks) + GFM tables | mistune |
+| `markdown/` | mistune | CommonMark subset (ATX/Setext headings, emphasis, code spans/blocks, links, images, lists, blockquotes, thematic breaks, backslash escapes, autolinks, hard breaks) + GFM tables, strikethrough, task lists, extended autolinks | mistune |
 | `diff/` | unidiff | Unified diff parser, patch applicator, three-way merge, conflict markers | unidiff |
 | `vcs/` | — | VCS CLI wrapper (Git/SVN/Hg backend protocol), status/log/blame/diff, subprocess-based | — |
 | `ansi/` | — | ANSI escape code primitives, fg/bg/style helpers, color depth detection, strip_ansi, visible_len, cursor control | — |

--- a/markdown/markdown.py
+++ b/markdown/markdown.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.1"
+# version = "0.4.0"
 # deps = []
 # tier = "medium"
 # category = "terminal"
@@ -22,12 +22,14 @@ Supports:
     - Ordered and unordered lists with nesting
     - Block quotes with nesting
     - GFM tables with column alignment
+    - GFM strikethrough (~~text~~)
+    - GFM task lists (- [ ] / - [x])
+    - GFM extended autolinks (bare URLs)
     - Backslash escapes
 
 Does NOT implement:
     - Raw HTML passthrough (escaped for safety)
     - Footnotes, definition lists, math/LaTeX
-    - Strikethrough, task lists
 
 Example::
 
@@ -100,7 +102,12 @@ _REF_LINK_SHORT_RE = re.compile(r"\[([^\[\]]+)\](?!\()")
 _STRONG_EM_RE = re.compile(r"\*{3}(.+?)\*{3}|_{3}(.+?)_{3}")
 _STRONG_RE = re.compile(r"\*{2}(.+?)\*{2}|_{2}(.+?)_{2}")
 _EM_RE = re.compile(r"(?<!\w)\*(.+?)\*(?!\w)|(?<!\w)_(.+?)_(?!\w)")
+_STRIKETHROUGH_RE = re.compile(r"~~(.+?)~~")
+_BARE_URL_RE = re.compile(r"(https?://[^\s<>\[\]]*[^\s<>\[\].,;:!?'\")}\]])")
 _HARD_BREAK_RE = re.compile(r"(?:\\| {2,})\n")
+
+# Task list marker: [ ], [x], or [X] at start of list item content
+_TASK_LIST_RE = re.compile(r"^\[([ xX])\]\s+")
 
 # ── Placeholder system ───────────────────────────────────────────────────────
 
@@ -140,6 +147,58 @@ def _safe_url(url: str) -> str:
     ):
         return "#harmful-link"
     return html.escape(url, quote=True)
+
+
+# ── Inline helper functions ──────────────────────────────────────────────────
+
+
+def _apply_bare_urls(text: str, ph: _Placeholders) -> str:
+    """Replace bare http/https URLs with link placeholders."""
+
+    def _bare_url_repl(m: re.Match[str]) -> str:
+        url = m.group(1)
+        return ph.put('<a href="' + _safe_url(url) + '">' + html.escape(url) + "</a>")
+
+    return _BARE_URL_RE.sub(_bare_url_repl, text)
+
+
+def _apply_emphasis(
+    text: str,
+    ph: _Placeholders,
+    ref_links: dict[str, tuple[str, str | None]],
+) -> str:
+    """Apply bold-italic, bold, italic, and strikethrough replacements."""
+
+    # Bold-italic ***text***
+    def _strong_em_repl(m: re.Match[str]) -> str:
+        content = m.group(1) or m.group(2)
+        return ph.put(
+            "<em><strong>" + _parse_inline(content, ref_links) + "</strong></em>"
+        )
+
+    text = _STRONG_EM_RE.sub(_strong_em_repl, text)
+
+    # Bold **text**
+    def _strong_repl(m: re.Match[str]) -> str:
+        content = m.group(1) or m.group(2)
+        return ph.put("<strong>" + _parse_inline(content, ref_links) + "</strong>")
+
+    text = _STRONG_RE.sub(_strong_repl, text)
+
+    # Italic *text*
+    def _em_repl(m: re.Match[str]) -> str:
+        content = m.group(1) or m.group(2)
+        return ph.put("<em>" + _parse_inline(content, ref_links) + "</em>")
+
+    text = _EM_RE.sub(_em_repl, text)
+
+    # Strikethrough ~~text~~
+    def _strike_repl(m: re.Match[str]) -> str:
+        content = m.group(1)
+        return ph.put("<del>" + _parse_inline(content, ref_links) + "</del>")
+
+    text = _STRIKETHROUGH_RE.sub(_strike_repl, text)
+    return text
 
 
 # ── Inline parser ─────────────────────────────────────────────────────────────
@@ -239,29 +298,11 @@ def _parse_inline(
 
     text = _REF_LINK_SHORT_RE.sub(_ref_short_repl, text)
 
-    # 6. Emphasis (process from longest to shortest, protect with placeholders)
-    # Bold-italic ***text***
-    def _strong_em_repl(m: re.Match[str]) -> str:
-        content = m.group(1) or m.group(2)
-        return ph.put(
-            "<em><strong>" + _parse_inline(content, ref_links) + "</strong></em>"
-        )
+    # 5d. Extended autolinks (bare URLs without angle brackets)
+    text = _apply_bare_urls(text, ph)
 
-    text = _STRONG_EM_RE.sub(_strong_em_repl, text)
-
-    # Bold **text**
-    def _strong_repl(m: re.Match[str]) -> str:
-        content = m.group(1) or m.group(2)
-        return ph.put("<strong>" + _parse_inline(content, ref_links) + "</strong>")
-
-    text = _STRONG_RE.sub(_strong_repl, text)
-
-    # Italic *text*
-    def _em_repl(m: re.Match[str]) -> str:
-        content = m.group(1) or m.group(2)
-        return ph.put("<em>" + _parse_inline(content, ref_links) + "</em>")
-
-    text = _EM_RE.sub(_em_repl, text)
+    # 6. Emphasis + strikethrough
+    text = _apply_emphasis(text, ph, ref_links)
 
     # 7. Hard line breaks (protect with placeholder)
     text = _HARD_BREAK_RE.sub(lambda m: ph.put("<br />\n"), text)
@@ -467,15 +508,32 @@ def _render_list_item(
     ref_links: dict[str, tuple[str, str | None]],
 ) -> str:
     """Render a single <li> element, recursing for nested sub-lists."""
+    # Detect task list marker
+    task_class = ""
+    task_checkbox = ""
+    first_line = item_lines[0]
+    task_m = _TASK_LIST_RE.match(first_line)
+    if task_m:
+        checked = task_m.group(1) in ("x", "X")
+        task_class = ' class="task-list-item"'
+        task_checkbox = (
+            '<input class="task-list-item-checkbox" type="checkbox" disabled'
+        )
+        if checked:
+            task_checkbox += " checked"
+        task_checkbox += "/>"
+        item_lines = [first_line[task_m.end() :]] + item_lines[1:]
+
     has_sublist = any(
         _UL_ITEM_RE.match(il) or _OL_ITEM_RE.match(il) for il in item_lines[1:]
     )
+    open_tag = f"<li{task_class}>" + task_checkbox
     if has_sublist:
         first = _parse_inline(item_lines[0], ref_links)
         sub_html = _parse_blocks(item_lines[1:], ref_links)
-        return "<li>" + first + sub_html + "</li>\n"
+        return open_tag + first + sub_html + "</li>\n"
     content = "\n".join(item_lines).strip()
-    return "<li>" + _parse_inline(content, ref_links) + "</li>\n"
+    return open_tag + _parse_inline(content, ref_links) + "</li>\n"
 
 
 def _parse_list_block(

--- a/markdown/test_markdown_benchmark.py
+++ b/markdown/test_markdown_benchmark.py
@@ -31,6 +31,20 @@ MEDIUM = "\n\n".join(
     ]
 )
 
+MEDIUM_GFM = "\n\n".join(
+    [
+        "# Document with GFM Extensions",
+        "Paragraph with ~~strikethrough~~ and **bold**.",
+        "Visit https://example.com/docs for more info.",
+        "See http://api.example.com/v2?key=abc&format=json here.",
+        "- [ ] Write the code\n- [x] Write the tests\n- [ ] Review the PR",
+        "1. [x] Step one complete\n2. [ ] Step two pending",
+        "| Feature | Status |\n| --- | --- |\n| ~~old~~ | removed |\n| new | active |",
+        "> Quote with ~~deleted~~ and https://example.com link.",
+        "Mixed: **bold**, *italic*, ~~strike~~, `code`, https://example.com.",
+    ]
+)
+
 LARGE = "\n\n".join(
     [
         f"{'#' * (i % 6 + 1)} Heading {i}\n\n"
@@ -43,12 +57,31 @@ LARGE = "\n\n".join(
     ]
 )
 
+LARGE_GFM = "\n\n".join(
+    [
+        f"{'#' * (i % 6 + 1)} Heading {i}\n\n"
+        f"Paragraph {i} with ~~strike {i}~~ and https://example.com/{i} link.\n\n"
+        f"- [ ] task {i}a\n- [x] task {i}b\n\n"
+        f"| col{i} | ~~old~~ |\n| --- | --- |\n| val | https://example.com |"
+        for i in range(50)
+    ]
+)
+
 
 def _ref_render(text: str) -> str:
     return mistune.html(text)
 
 
-# ── Render benchmarks ──
+_gfm_ref = mistune.create_markdown(
+    plugins=["strikethrough", "task_lists", "url", "table"]
+)
+
+
+def _ref_gfm_render(text: str) -> str:
+    return _gfm_ref(text)
+
+
+# ── Render benchmarks (CommonMark) ──
 
 
 class TestRenderSmall:
@@ -73,3 +106,22 @@ class TestRenderLarge:
 
     def test_mistune(self, benchmark):
         benchmark(_ref_render, LARGE)
+
+
+# ── Render benchmarks (GFM extensions) ──
+
+
+class TestRenderGFMMedium:
+    def test_zerodep(self, benchmark):
+        benchmark(zd_render, MEDIUM_GFM)
+
+    def test_mistune(self, benchmark):
+        benchmark(_ref_gfm_render, MEDIUM_GFM)
+
+
+class TestRenderGFMLarge:
+    def test_zerodep(self, benchmark):
+        benchmark(zd_render, LARGE_GFM)
+
+    def test_mistune(self, benchmark):
+        benchmark(_ref_gfm_render, LARGE_GFM)

--- a/markdown/test_markdown_correctness.py
+++ b/markdown/test_markdown_correctness.py
@@ -19,6 +19,18 @@ def assert_same(md: str) -> None:
     assert ours == theirs, f"Mismatch:\n  ours:   {ours!r}\n  theirs: {theirs!r}"
 
 
+_gfm_ref = mistune.create_markdown(
+    plugins=["strikethrough", "task_lists", "url", "table"]
+)
+
+
+def assert_same_gfm(md: str) -> None:
+    """Assert our render matches mistune with GFM plugins (stripped)."""
+    ours = render(md).strip()
+    theirs = _gfm_ref(md).strip()
+    assert ours == theirs, f"Mismatch:\n  ours:   {ours!r}\n  theirs: {theirs!r}"
+
+
 # ── ATX Headings ──────────────────────────────────────────────────────────────
 
 
@@ -354,3 +366,111 @@ class TestEdgeCases:
         assert "<h1>" in result
         assert "<h2>" in result
         assert "<h3>" in result
+
+
+# ── Strikethrough ─────────────────────────────────────────────────────────────
+
+
+class TestStrikethrough:
+    def test_basic(self):
+        assert_same_gfm("~~deleted~~")
+
+    def test_with_inline(self):
+        assert_same_gfm("~~bold **inside** strike~~")
+
+    def test_mid_word(self):
+        assert_same_gfm("not~~this~~joined")
+
+    def test_in_paragraph(self):
+        assert_same_gfm("This has ~~struck~~ text in it.")
+
+    def test_in_blockquote(self):
+        assert_same_gfm("> ~~quoted strike~~")
+
+    def test_in_list(self):
+        assert_same_gfm("- ~~list strike~~")
+
+    def test_in_table(self):
+        assert_same_gfm("| ~~header~~ | b |\n| --- | --- |\n| c | d |")
+
+    def test_with_code_inside(self):
+        result = render("~~`code` and text~~")
+        assert "<del>" in result
+        assert "<code>code</code>" in result
+
+    def test_not_single_tilde(self):
+        result = render("~not strike~")
+        assert "<del>" not in result
+
+
+# ── Task Lists ────────────────────────────────────────────────────────────────
+
+
+class TestTaskLists:
+    def test_unchecked(self):
+        assert_same_gfm("- [ ] todo item")
+
+    def test_checked(self):
+        assert_same_gfm("- [x] done item")
+
+    def test_checked_uppercase(self):
+        assert_same_gfm("- [X] done item")
+
+    def test_mixed(self):
+        assert_same_gfm("- [ ] unchecked\n- [x] checked\n- [X] also checked")
+
+    def test_with_inline(self):
+        assert_same_gfm("- [ ] task with **bold**")
+
+    def test_ordered_task_list(self):
+        assert_same_gfm("1. [ ] ordered task\n2. [x] ordered done")
+
+    def test_regular_list_unaffected(self):
+        md = "- normal item\n- another item"
+        result = render(md)
+        assert "task-list-item" not in result
+
+    def test_checkbox_attributes(self):
+        result = render("- [ ] unchecked\n- [x] checked")
+        assert 'type="checkbox"' in result
+        assert "disabled" in result
+        assert "checked" in result
+
+
+# ── Extended Autolinks ────────────────────────────────────────────────────────
+
+
+class TestExtendedAutolinks:
+    def test_https(self):
+        assert_same_gfm("Visit https://example.com for more")
+
+    def test_http(self):
+        assert_same_gfm("See http://example.com here")
+
+    def test_trailing_dot(self):
+        assert_same_gfm("https://example.com.")
+
+    def test_trailing_comma(self):
+        assert_same_gfm("https://example.com,")
+
+    def test_in_parens(self):
+        assert_same_gfm("(https://example.com)")
+
+    def test_with_path(self):
+        assert_same_gfm("https://example.com/path/to/page.html")
+
+    def test_with_query_and_fragment(self):
+        assert_same_gfm("Visit https://example.com/path?q=1&r=2#fragment today")
+
+    def test_with_explicit_link(self):
+        assert_same_gfm("[link](https://example.com) and https://other.com")
+
+    def test_url_with_ampersand(self):
+        assert_same_gfm("See http://foo.bar/baz?a=1&b=2 here")
+
+    def test_not_bare_www(self):
+        result = render("www.example.com")
+        assert "<a " not in result
+
+    def test_angle_bracket_still_works(self):
+        assert_same("<https://example.com>")


### PR DESCRIPTION
## Summary

- **Strikethrough**: `~~text~~` → `<del>text</del>`, supports inline nesting and mid-word use
- **Task lists**: `- [ ]` / `- [x]` with `class="task-list-item"` and `<input checkbox>`, works for both ordered and unordered lists
- **Extended autolinks**: bare `https://` / `http://` URLs auto-linked with trailing punctuation stripping

All outputs match mistune with GFM plugins (`strikethrough`, `task_lists`, `url`). Performance remains ~2x faster than mistune across all benchmark sizes.

Version bumped from 0.3.1 → 0.4.0.

## Test plan

- [x] 120/120 correctness tests pass (28 new GFM tests against mistune reference)
- [x] 10/10 benchmark tests pass (4 new GFM benchmarks)
- [x] `ruff check` + `ruff format` clean