### PR TITLE
feat(qr): add PNG and SVG image output

### DIFF
--- a/qr/qr.py
+++ b/qr/qr.py
@@ -1,6 +1,6 @@
 # /// zerodep
 # version = "0.3.2"
-# deps = []
+# deps = ["png"]
 # tier = "simple"
 # category = "utility"
 # note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
@@ -20,7 +20,9 @@ substantially refactored for the zerodep project:
 from __future__ import annotations
 
 import itertools
+import os
 import re
+import sys
 from collections.abc import Callable, Sequence
 from typing import Union
 
@@ -65,6 +67,8 @@ __all__ = [
     "QrSegment",
     "DataTooLongError",
     "print_qr_terminal",
+    "qr_to_svg",
+    "qr_to_png",
 ]
 
 
@@ -1680,3 +1684,136 @@ def print_qr_terminal(text: str) -> None:
         lines.append("".join(row_chars))
 
     print("\n".join(lines))
+
+
+# ---- Sibling import helpers ----
+
+
+def _ensure_sibling_path(name: str) -> str:
+    """Return the sibling module directory and prepend it to ``sys.path``."""
+    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
+    if sibling_dir not in sys.path:
+        sys.path.insert(0, sibling_dir)
+    return sibling_dir
+
+
+def _load_png_encoder():
+    """Load sibling ``png`` module's ``Image`` and ``encode_png`` on demand."""
+    _ensure_sibling_path("png")
+    sys.modules.pop("png", None)
+    try:
+        from png import Image, encode_png
+    except ImportError as exc:
+        raise ImportError(
+            "qr_to_png requires the sibling png module. "
+            "Copy png/png.py into your project."
+        ) from exc
+    return Image, encode_png
+
+
+# ---- Image output ----
+
+
+def qr_to_svg(
+    qr: QrCode,
+    dest: str | os.PathLike[str] | None = None,
+    *,
+    scale: int = 10,
+    border: int = 4,
+    fg_color: str = "#000000",
+    bg_color: str = "#ffffff",
+) -> str | None:
+    """Render a QR Code as an SVG image.
+
+    Args:
+        qr: QR Code to render.
+        dest: File path to write SVG to, or ``None`` to return the SVG string.
+        scale: Size of each QR module in SVG user units.
+        border: Width of the quiet zone in QR modules.
+        fg_color: CSS color for dark modules.
+        bg_color: CSS color for light modules.
+
+    Returns:
+        SVG string when *dest* is ``None``, otherwise ``None``.
+    """
+    size = qr.get_size()
+    total = (size + 2 * border) * scale
+
+    # Build a single <path> collecting all dark modules.
+    parts: list[str] = []
+    for y in range(size):
+        for x in range(size):
+            if qr.get_module(x, y):
+                px = (x + border) * scale
+                py = (y + border) * scale
+                parts.append(f"M{px},{py}h{scale}v{scale}h-{scale}z")
+    path_d = "".join(parts)
+
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {total} {total}" '
+        f'width="{total}" height="{total}">\n'
+        f'<rect width="100%" height="100%" fill="{bg_color}"/>\n'
+        f'<path d="{path_d}" fill="{fg_color}"/>\n'
+        f"</svg>\n"
+    )
+
+    if dest is None:
+        return svg
+    with open(dest, "w", encoding="utf-8") as fh:
+        fh.write(svg)
+    return None
+
+
+def qr_to_png(
+    qr: QrCode,
+    dest: str | os.PathLike[str] | None = None,
+    *,
+    scale: int = 10,
+    border: int = 4,
+    fg_color: int = 0,
+    bg_color: int = 255,
+) -> bytes | None:
+    """Render a QR Code as a PNG image.
+
+    Requires the sibling ``png`` module.
+
+    Args:
+        qr: QR Code to render.
+        dest: File path to write PNG to, or ``None`` to return PNG bytes.
+        scale: Pixels per QR module.
+        border: Width of the quiet zone in QR modules.
+        fg_color: Grayscale value (0--255) for dark modules.
+        bg_color: Grayscale value (0--255) for light modules.
+
+    Returns:
+        PNG bytes when *dest* is ``None``, otherwise ``None``.
+
+    Raises:
+        ImportError: If the sibling ``png`` module is not available.
+        ValueError: If *fg_color* or *bg_color* is outside 0--255.
+    """
+    if not (0 <= fg_color <= 255):
+        raise ValueError(f"fg_color must be 0-255, got {fg_color}")
+    if not (0 <= bg_color <= 255):
+        raise ValueError(f"bg_color must be 0-255, got {bg_color}")
+
+    Image, encode_png = _load_png_encoder()
+
+    size = qr.get_size()
+    total_px = (size + 2 * border) * scale
+
+    # Build grayscale pixel buffer.
+    fg_run = bytes([fg_color]) * scale
+    pixels = bytearray([bg_color]) * (total_px * total_px)
+    for y in range(size):
+        for x in range(size):
+            if qr.get_module(x, y):
+                px = (x + border) * scale
+                py = (y + border) * scale
+                for row in range(py, py + scale):
+                    offset = row * total_px + px
+                    pixels[offset : offset + scale] = fg_run
+
+    img = Image(width=total_px, height=total_px, data=bytes(pixels), mode="L")
+    return encode_png(img, dest)

--- a/qr/test_qr_render.py
+++ b/qr/test_qr_render.py
@@ -1,0 +1,202 @@
+"""Tests for QR image output: qr_to_svg() and qr_to_png()."""
+
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "png"))
+
+from qr import QrCode, qr_to_png, qr_to_svg
+
+# Reusable fixture: a small QR code.
+_QR = QrCode.encode_text("Hello", QrCode.Ecc.LOW)
+
+
+# ---- SVG tests ----
+
+
+class TestQrToSvg:
+    """Tests for qr_to_svg()."""
+
+    def test_returns_string(self):
+        result = qr_to_svg(_QR)
+        assert isinstance(result, str)
+
+    def test_valid_xml(self):
+        svg = qr_to_svg(_QR)
+        root = ET.fromstring(svg)
+        assert root.tag == "{http://www.w3.org/2000/svg}svg"
+
+    def test_dimensions_default(self):
+        svg = qr_to_svg(_QR, scale=10, border=4)
+        root = ET.fromstring(svg)
+        expected = (_QR.get_size() + 2 * 4) * 10
+        assert root.attrib["width"] == str(expected)
+        assert root.attrib["height"] == str(expected)
+        assert root.attrib["viewBox"] == f"0 0 {expected} {expected}"
+
+    def test_custom_scale_and_border(self):
+        svg = qr_to_svg(_QR, scale=5, border=2)
+        root = ET.fromstring(svg)
+        expected = (_QR.get_size() + 2 * 2) * 5
+        assert root.attrib["width"] == str(expected)
+
+    def test_custom_colors(self):
+        svg = qr_to_svg(_QR, fg_color="red", bg_color="blue")
+        assert 'fill="red"' in svg
+        assert 'fill="blue"' in svg
+
+    def test_border_zero(self):
+        svg = qr_to_svg(_QR, border=0)
+        root = ET.fromstring(svg)
+        expected = _QR.get_size() * 10
+        assert root.attrib["width"] == str(expected)
+
+    def test_scale_one(self):
+        svg = qr_to_svg(_QR, scale=1, border=0)
+        root = ET.fromstring(svg)
+        assert root.attrib["width"] == str(_QR.get_size())
+
+    def test_write_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            result = qr_to_svg(_QR, dest=tmp_path)
+            assert result is None
+            with open(tmp_path, encoding="utf-8") as fh:
+                content = fh.read()
+            assert content == qr_to_svg(_QR)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_path_element_exists(self):
+        svg = qr_to_svg(_QR)
+        root = ET.fromstring(svg)
+        ns = {"svg": "http://www.w3.org/2000/svg"}
+        path = root.find("svg:path", ns)
+        assert path is not None
+        assert "M" in path.attrib["d"]
+
+
+# ---- PNG tests ----
+
+
+class TestQrToPng:
+    """Tests for qr_to_png()."""
+
+    def test_returns_bytes(self):
+        result = qr_to_png(_QR)
+        assert isinstance(result, bytes)
+
+    def test_png_signature(self):
+        data = qr_to_png(_QR)
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_roundtrip_dimensions(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR, scale=10, border=4)
+        img = decode_png(data)
+        expected = (_QR.get_size() + 2 * 4) * 10
+        assert img.width == expected
+        assert img.height == expected
+
+    def test_grayscale_mode(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR)
+        img = decode_png(data)
+        assert img.mode == "L"
+
+    def test_roundtrip_colors(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR, scale=10, border=4, fg_color=0, bg_color=255)
+        img = decode_png(data)
+        # Top-left corner should be background (inside quiet zone).
+        assert img.data[0] == 255
+        # Finder pattern top-left at (border*scale, border*scale).
+        offset = 4 * 10 * img.width + 4 * 10
+        assert img.data[offset] == 0
+
+    def test_custom_scale(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR, scale=5, border=2)
+        img = decode_png(data)
+        expected = (_QR.get_size() + 2 * 2) * 5
+        assert img.width == expected
+
+    def test_border_zero(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR, scale=4, border=0)
+        img = decode_png(data)
+        expected = _QR.get_size() * 4
+        assert img.width == expected
+
+    def test_custom_fg_bg(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR, scale=10, border=4, fg_color=50, bg_color=200)
+        img = decode_png(data)
+        assert img.data[0] == 200
+        offset = 4 * 10 * img.width + 4 * 10
+        assert img.data[offset] == 50
+
+    def test_write_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            result = qr_to_png(_QR, dest=tmp_path)
+            assert result is None
+            with open(tmp_path, "rb") as fh:
+                content = fh.read()
+            assert content[:8] == b"\x89PNG\r\n\x1a\n"
+        finally:
+            os.unlink(tmp_path)
+
+    def test_fg_color_out_of_range(self):
+        with pytest.raises(ValueError, match="fg_color"):
+            qr_to_png(_QR, fg_color=256)
+
+    def test_bg_color_out_of_range(self):
+        with pytest.raises(ValueError, match="bg_color"):
+            qr_to_png(_QR, bg_color=-1)
+
+    def test_scale_one(self):
+        from png import decode_png
+
+        data = qr_to_png(_QR, scale=1, border=0)
+        img = decode_png(data)
+        assert img.width == _QR.get_size()
+        assert img.height == _QR.get_size()
+
+
+# ---- Edge cases ----
+
+
+class TestEdgeCases:
+    """Edge case tests for both outputs."""
+
+    def test_large_qr_svg(self):
+        """Version 10+ QR code renders without error."""
+        qr = QrCode.encode_text("A" * 200, QrCode.Ecc.LOW)
+        svg = qr_to_svg(qr, scale=2, border=1)
+        assert isinstance(svg, str)
+        ET.fromstring(svg)  # must be valid XML
+
+    def test_large_qr_png(self):
+        """Version 10+ QR code renders without error."""
+        qr = QrCode.encode_text("A" * 200, QrCode.Ecc.LOW)
+        data = qr_to_png(qr, scale=2, border=1)
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_empty_border_produces_smaller_output(self):
+        size_with_border = len(qr_to_svg(_QR, border=4))
+        size_no_border = len(qr_to_svg(_QR, border=0))
+        assert size_no_border < size_with_border


### PR DESCRIPTION
## Summary

- Add `qr_to_svg()` — renders QR code as SVG string via path element templating (zero deps)
- Add `qr_to_png()` — renders QR code as grayscale PNG via sibling `png` module (lazy import)
- Both support configurable `scale`, `border`, foreground/background colors, and file output

Closes the "terminal only" limitation identified in `_plans/candidate-modules.md`.

## Test plan

- [x] 24 tests in `qr/test_qr_render.py` — all passing
- [x] SVG: XML validity, dimensions, colors, file write, path element structure
- [x] PNG: signature, round-trip decode, grayscale mode, colors, input validation
- [x] Edge cases: scale=1, border=0, large QR (version 10+)
- [x] ruff check + format clean