### PR TITLE
feat(sparse_search): add RRF and MMR post-retrieval re-ranking

### DIFF
--- a/sparse_search/sparse_search.py
+++ b/sparse_search/sparse_search.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.2"
+# version = "0.4.0"
 # deps = []
 # tier = "medium"
 # category = "utility"
@@ -52,6 +52,9 @@ from typing import Any, Callable
 __all__ = [
     "Result",
     "SparseIndex",
+    "jaccard_similarity",
+    "rrf",
+    "mmr",
 ]
 
 _VERSION = "0.1.0"
@@ -1032,3 +1035,194 @@ class SparseIndex:
         if Path(path).suffix in (".db", ".sqlite", ".sqlite3"):
             return "sqlite"
         return "json"
+
+
+# ---------------------------------------------------------------------------
+# Post-retrieval re-ranking utilities
+# ---------------------------------------------------------------------------
+
+
+def jaccard_similarity(set_a: set, set_b: set) -> float:
+    """Jaccard similarity coefficient between two sets.
+
+    ``J(A, B) = |A ∩ B| / |A ∪ B|``
+
+    Returns 0.0 when both sets are empty. This is a building-block for
+    constructing similarity functions to pass to :func:`mmr`.
+
+    Example::
+
+        tokens = {}  # doc_id -> set of tokens
+        sim_fn = lambda a, b: jaccard_similarity(tokens[a.doc_id], tokens[b.doc_id])
+        diverse = mmr(results, sim_fn, lambda_=0.7)
+
+    Args:
+        set_a: First set.
+        set_b: Second set.
+
+    Returns:
+        Similarity in [0.0, 1.0].
+    """
+    union = len(set_a | set_b)
+    if union == 0:
+        return 0.0
+    return len(set_a & set_b) / union
+
+
+def rrf(
+    *result_lists: list[Result],
+    k: int = 60,
+    top_k: int | None = None,
+    weights: list[float] | None = None,
+) -> list[Result]:
+    """Reciprocal Rank Fusion of multiple ranked result lists.
+
+    Combines results from different retrieval systems (e.g. BM25 sparse
+    and dense vector search) using the formula::
+
+        Score(d) = Σ weight_i / (k + rank_i)
+
+    where *rank_i* is the 1-based position of document *d* in the *i*-th
+    list (Cormack et al., SIGIR 2009).
+
+    Example::
+
+        sparse = index.search("quick fox", top_k=20)
+        dense  = [Result("d1", 0.9), Result("d3", 0.7), ...]  # external
+        fused  = rrf(sparse, dense, k=60, top_k=10)
+
+    Args:
+        *result_lists: One or more lists of :class:`Result` objects. Each
+            list should be pre-sorted by descending relevance.
+        k: RRF constant controlling rank sensitivity. Higher values flatten
+            rank differences. Default 60 (per Cormack et al.).
+        top_k: Maximum number of results to return. ``None`` returns all.
+        weights: Per-list weights. When ``None``, all lists are weighted
+            equally (1.0). Length must match the number of result lists.
+
+    Returns:
+        Fused list of :class:`Result` sorted by descending RRF score.
+        Metadata is taken from the occurrence with the highest original
+        score.
+
+    Raises:
+        ValueError: If no result lists are provided, ``weights`` length
+            does not match, or ``k`` is not positive.
+    """
+    if not result_lists:
+        raise ValueError("rrf() requires at least one result list")
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    if weights is not None and len(weights) != len(result_lists):
+        raise ValueError(
+            f"weights length ({len(weights)}) must match "
+            f"number of result lists ({len(result_lists)})"
+        )
+
+    rrf_scores: dict[str, float] = {}
+    best_meta: dict[str, dict[str, Any] | None] = {}
+    best_original: dict[str, float] = {}
+
+    for list_idx, results in enumerate(result_lists):
+        w = weights[list_idx] if weights is not None else 1.0
+        seen_in_list: set[str] = set()
+        for rank_0, r in enumerate(results):
+            if r.doc_id in seen_in_list:
+                continue
+            seen_in_list.add(r.doc_id)
+            rrf_scores[r.doc_id] = rrf_scores.get(r.doc_id, 0.0) + w / (k + rank_0 + 1)
+            if r.doc_id not in best_original or r.score > best_original[r.doc_id]:
+                best_original[r.doc_id] = r.score
+                best_meta[r.doc_id] = r.metadata
+
+    ranked = sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True)
+    if top_k is not None:
+        ranked = ranked[:top_k]
+
+    return [
+        Result(doc_id=did, score=score, metadata=best_meta[did])
+        for did, score in ranked
+    ]
+
+
+def mmr(
+    results: list[Result],
+    similarity_fn: Callable[[Result, Result], float],
+    *,
+    lambda_: float = 0.5,
+    top_k: int | None = None,
+) -> list[Result]:
+    """Maximal Marginal Relevance re-ranking for result diversification.
+
+    Greedily selects results that balance relevance with diversity::
+
+        MMR(d) = argmax[λ · rel(d) − (1 − λ) · max sim(d, d_j)]
+
+    where *d_j* are already-selected results. Relevance scores are min-max
+    normalized to [0, 1] internally so they are comparable to similarity.
+
+    Example::
+
+        tokens = {r.doc_id: set(tokenize(texts[r.doc_id])) for r in results}
+        sim = lambda a, b: jaccard_similarity(tokens[a.doc_id], tokens[b.doc_id])
+        diverse = mmr(results, sim, lambda_=0.7, top_k=5)
+
+    Args:
+        results: Candidate results, typically from :meth:`SparseIndex.search`
+            or :func:`rrf`.
+        similarity_fn: A callable ``(Result, Result) -> float`` returning a
+            similarity score in [0, 1]. See :func:`jaccard_similarity` for
+            a set-based helper.
+        lambda_: Trade-off between relevance (1.0) and diversity (0.0).
+            Default 0.5.
+        top_k: Number of results to select. ``None`` selects all (full
+            re-ranking).
+
+    Returns:
+        Re-ranked list of :class:`Result` with scores set to their MMR
+        scores.
+
+    Raises:
+        ValueError: If ``lambda_`` is not in [0, 1].
+    """
+    if not (0.0 <= lambda_ <= 1.0):
+        raise ValueError(f"lambda_ must be in [0, 1], got {lambda_}")
+    if not results:
+        return []
+
+    n = len(results)
+    select_k = n if top_k is None else min(top_k, n)
+
+    # Min-max normalize relevance scores to [0, 1]
+    max_score = max(r.score for r in results)
+    min_score = min(r.score for r in results)
+    score_range = max_score - min_score
+    if score_range > 0:
+        norm = {r.doc_id: (r.score - min_score) / score_range for r in results}
+    else:
+        norm = {r.doc_id: (1.0 if max_score > 0 else 0.0) for r in results}
+
+    candidates = list(results)
+    selected: list[Result] = []
+
+    while len(selected) < select_k and candidates:
+        best_mmr = -math.inf
+        best_idx = 0
+
+        for idx, cand in enumerate(candidates):
+            rel = norm[cand.doc_id]
+            if selected:
+                max_sim = max(similarity_fn(cand, s) for s in selected)
+            else:
+                max_sim = 0.0
+            mmr_score = lambda_ * rel - (1.0 - lambda_) * max_sim
+            if mmr_score > best_mmr:
+                best_mmr = mmr_score
+                best_idx = idx
+
+        chosen = candidates.pop(best_idx)
+        selected.append(
+            Result(doc_id=chosen.doc_id, score=best_mmr, metadata=chosen.metadata)
+        )
+
+    return selected

--- a/sparse_search/test_sparse_search_benchmark.py
+++ b/sparse_search/test_sparse_search_benchmark.py
@@ -11,7 +11,14 @@ import string
 
 import pytest
 
-from sparse_search import SparseIndex, _default_tokenize
+from sparse_search import (
+    Result,
+    SparseIndex,
+    _default_tokenize,
+    jaccard_similarity,
+    mmr,
+    rrf,
+)
 
 rank_bm25 = pytest.importorskip("rank_bm25")
 from rank_bm25 import BM25L as RefBM25L
@@ -277,3 +284,64 @@ class TestCalibrationPerformance:
     def test_search_calibrated(self, benchmark):
         """Calibrated BM25 search (probability output)."""
         benchmark(self.idx_cal.search, self.query, top_k=10)
+
+
+# ---------------------------------------------------------------------------
+# Performance: RRF
+# ---------------------------------------------------------------------------
+
+
+def _make_result_list(n: int, prefix: str, rng: random.Random) -> list[Result]:
+    """Generate a list of n Results with random scores."""
+    return [Result(f"{prefix}_d{i}", rng.uniform(0, 10)) for i in range(n)]
+
+
+class TestRRFPerformance:
+    def test_rrf_2_lists_1000_results(self, benchmark):
+        """RRF: fuse 2 lists of 1000 results each."""
+        rng = random.Random(42)
+        list_a = _make_result_list(1000, "a", rng)
+        list_b = _make_result_list(1000, "b", rng)
+        benchmark(rrf, list_a, list_b, k=60, top_k=10)
+
+    def test_rrf_10_lists_100_results(self, benchmark):
+        """RRF: fuse 10 lists of 100 results each."""
+        rng = random.Random(42)
+        lists = [_make_result_list(100, f"l{i}", rng) for i in range(10)]
+        benchmark(lambda: rrf(*lists, k=60, top_k=10))
+
+    def test_rrf_overlapping_docs(self, benchmark):
+        """RRF: fuse 2 lists with 50% overlap (500 shared doc_ids)."""
+        rng = random.Random(42)
+        shared = [Result(f"d{i}", rng.uniform(0, 10)) for i in range(500)]
+        unique_a = [Result(f"a{i}", rng.uniform(0, 10)) for i in range(500)]
+        unique_b = [Result(f"b{i}", rng.uniform(0, 10)) for i in range(500)]
+        list_a = shared + unique_a
+        list_b = [Result(r.doc_id, rng.uniform(0, 10)) for r in shared] + unique_b
+        benchmark(rrf, list_a, list_b, k=60, top_k=10)
+
+
+# ---------------------------------------------------------------------------
+# Performance: MMR
+# ---------------------------------------------------------------------------
+
+
+class TestMMRPerformance:
+    @staticmethod
+    def _jaccard_sim(a: Result, b: Result) -> float:
+        # Simulate token-based similarity using doc_id hash as proxy
+        set_a = set(a.doc_id)
+        set_b = set(b.doc_id)
+        return jaccard_similarity(set_a, set_b)
+
+    def test_mmr_100_candidates(self, benchmark):
+        """MMR: re-rank 100 candidates, select top 10."""
+        rng = random.Random(42)
+        results = _make_result_list(100, "d", rng)
+        benchmark(mmr, results, self._jaccard_sim, lambda_=0.5, top_k=10)
+
+    def test_mmr_500_candidates(self, benchmark):
+        """MMR: re-rank 500 candidates, select top 10."""
+        rng = random.Random(42)
+        results = _make_result_list(500, "d", rng)
+        benchmark(mmr, results, self._jaccard_sim, lambda_=0.5, top_k=10)

--- a/sparse_search/test_sparse_search_correctness.py
+++ b/sparse_search/test_sparse_search_correctness.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import pytest
 
 from sparse_search import (
+    Result,
     SparseIndex,
     _default_tokenize,
     _log_odds_conjunction,
     _logit,
     _prob_or,
     _sigmoid,
+    jaccard_similarity,
+    mmr,
+    rrf,
 )
 
 # ---------------------------------------------------------------------------
@@ -652,3 +656,269 @@ class TestBayesianCalibration:
         idx = SparseIndex()
         with pytest.raises(RuntimeError, match="empty index"):
             idx.calibrate()
+
+
+# ---------------------------------------------------------------------------
+# Jaccard similarity
+# ---------------------------------------------------------------------------
+
+
+class TestJaccardSimilarity:
+    def test_identical_sets(self):
+        assert jaccard_similarity({"a", "b", "c"}, {"a", "b", "c"}) == 1.0
+
+    def test_disjoint_sets(self):
+        assert jaccard_similarity({"a", "b"}, {"c", "d"}) == 0.0
+
+    def test_partial_overlap(self):
+        # {a, b, c} & {b, c, d} = {b, c}, union = {a, b, c, d}
+        assert jaccard_similarity({"a", "b", "c"}, {"b", "c", "d"}) == pytest.approx(
+            2 / 4
+        )
+
+    def test_both_empty(self):
+        assert jaccard_similarity(set(), set()) == 0.0
+
+    def test_one_empty(self):
+        assert jaccard_similarity({"a"}, set()) == 0.0
+        assert jaccard_similarity(set(), {"a"}) == 0.0
+
+    def test_subset(self):
+        # {a} & {a, b} = {a}, union = {a, b}
+        assert jaccard_similarity({"a"}, {"a", "b"}) == pytest.approx(1 / 2)
+
+
+# ---------------------------------------------------------------------------
+# RRF (Reciprocal Rank Fusion)
+# ---------------------------------------------------------------------------
+
+
+class TestRRF:
+    def test_basic_two_lists(self):
+        list_a = [Result("d1", 10.0), Result("d2", 5.0)]
+        list_b = [Result("d2", 0.9), Result("d3", 0.8)]
+        fused = rrf(list_a, list_b, k=60)
+        # d1: rank 1 in list_a only → 1/(60+1)
+        # d2: rank 2 in list_a + rank 1 in list_b → 1/(60+2) + 1/(60+1)
+        # d3: rank 2 in list_b only → 1/(60+2)
+        scores = {r.doc_id: r.score for r in fused}
+        assert scores["d2"] == pytest.approx(1.0 / 62 + 1.0 / 61)
+        assert scores["d1"] == pytest.approx(1.0 / 61)
+        assert scores["d3"] == pytest.approx(1.0 / 62)
+        # d2 should rank first
+        assert fused[0].doc_id == "d2"
+
+    def test_single_list(self):
+        results = [Result("d1", 5.0), Result("d2", 3.0)]
+        fused = rrf(results, k=60)
+        assert len(fused) == 2
+        assert fused[0].doc_id == "d1"
+        assert fused[0].score == pytest.approx(1.0 / 61)
+        assert fused[1].score == pytest.approx(1.0 / 62)
+
+    def test_disjoint_lists(self):
+        list_a = [Result("d1", 1.0)]
+        list_b = [Result("d2", 1.0)]
+        fused = rrf(list_a, list_b)
+        doc_ids = {r.doc_id for r in fused}
+        assert doc_ids == {"d1", "d2"}
+
+    def test_weights(self):
+        list_a = [Result("d1", 1.0)]
+        list_b = [Result("d1", 1.0)]
+        fused_equal = rrf(list_a, list_b, k=60)
+        fused_weighted = rrf(list_a, list_b, k=60, weights=[2.0, 1.0])
+        # With weights=[2,1], d1 score = 2/(60+1) + 1/(60+1) = 3/61
+        assert fused_weighted[0].score == pytest.approx(3.0 / 61)
+        # With equal weights, d1 score = 1/(60+1) + 1/(60+1) = 2/61
+        assert fused_equal[0].score == pytest.approx(2.0 / 61)
+
+    def test_top_k(self):
+        results = [Result(f"d{i}", float(10 - i)) for i in range(10)]
+        fused = rrf(results, top_k=3)
+        assert len(fused) == 3
+
+    def test_metadata_from_best_score(self):
+        list_a = [Result("d1", 10.0, metadata={"src": "a"})]
+        list_b = [Result("d1", 20.0, metadata={"src": "b"})]
+        fused = rrf(list_a, list_b)
+        # d1 has higher score in list_b, so metadata should come from there
+        assert fused[0].metadata == {"src": "b"}
+
+    def test_all_empty_lists(self):
+        fused = rrf([], [])
+        assert fused == []
+
+    def test_no_lists_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            rrf()
+
+    def test_weights_mismatch_raises(self):
+        with pytest.raises(ValueError, match="weights length"):
+            rrf([Result("d1", 1.0)], weights=[1.0, 2.0])
+
+    def test_k_zero_raises(self):
+        with pytest.raises(ValueError, match="k must be positive"):
+            rrf([Result("d1", 1.0)], k=0)
+
+    def test_duplicate_doc_in_same_list(self):
+        # Only the first occurrence should count
+        results = [Result("d1", 10.0), Result("d1", 5.0)]
+        fused = rrf(results, k=60)
+        assert len(fused) == 1
+        assert fused[0].score == pytest.approx(1.0 / 61)
+
+    def test_composable_with_sparse_index(self):
+        idx1 = SparseIndex()
+        idx1.add("d1", "quick brown fox")
+        idx1.add("d2", "lazy dog")
+
+        idx2 = SparseIndex(variant="tfidf")
+        idx2.add("d1", "quick brown fox")
+        idx2.add("d2", "lazy dog")
+
+        r1 = idx1.search("quick fox")
+        r2 = idx2.search("quick fox")
+        fused = rrf(r1, r2)
+        assert len(fused) >= 1
+        assert all(isinstance(r, Result) for r in fused)
+
+    def test_three_lists(self):
+        a = [Result("d1", 3.0), Result("d2", 2.0)]
+        b = [Result("d2", 3.0), Result("d3", 2.0)]
+        c = [Result("d3", 3.0), Result("d1", 2.0)]
+        fused = rrf(a, b, c, k=60)
+        # Each doc appears twice: at rank 1 and rank 2 in different lists
+        scores = {r.doc_id: r.score for r in fused}
+        # All three docs should have equal scores
+        assert scores["d1"] == pytest.approx(scores["d2"])
+        assert scores["d2"] == pytest.approx(scores["d3"])
+
+
+# ---------------------------------------------------------------------------
+# MMR (Maximal Marginal Relevance)
+# ---------------------------------------------------------------------------
+
+
+class TestMMR:
+    @staticmethod
+    def _const_sim(a: Result, b: Result) -> float:
+        """Constant similarity for testing."""
+        return 0.5
+
+    @staticmethod
+    def _id_sim(a: Result, b: Result) -> float:
+        """High similarity for same-prefix docs, zero otherwise."""
+        return 1.0 if a.doc_id[:-1] == b.doc_id[:-1] else 0.0
+
+    def test_basic_diversity(self):
+        # Cluster A: d_a1 (high rel), d_a2 (medium rel) — similar to each other
+        # Cluster B: d_b1 (medium rel) — different from A
+        results = [
+            Result("a1", 10.0),
+            Result("a2", 9.0),
+            Result("b1", 8.0),
+        ]
+
+        def sim(a: Result, b: Result) -> float:
+            same_cluster = a.doc_id[0] == b.doc_id[0]
+            return 0.9 if same_cluster else 0.1
+
+        diverse = mmr(results, sim, lambda_=0.5, top_k=2)
+        # Should pick a1 first (highest relevance), then b1 (more diverse)
+        assert diverse[0].doc_id == "a1"
+        assert diverse[1].doc_id == "b1"
+
+    def test_lambda_one_preserves_order(self):
+        results = [
+            Result("d1", 10.0),
+            Result("d2", 8.0),
+            Result("d3", 5.0),
+        ]
+        reranked = mmr(results, self._const_sim, lambda_=1.0)
+        assert [r.doc_id for r in reranked] == ["d1", "d2", "d3"]
+
+    def test_lambda_zero_max_diversity(self):
+        # With lambda=0, only diversity matters (minimize max similarity to selected)
+        results = [
+            Result("d1", 10.0),
+            Result("d2", 9.0),
+            Result("d3", 1.0),
+        ]
+
+        def sim(a: Result, b: Result) -> float:
+            # d1 and d2 are very similar, d3 is different
+            if {a.doc_id, b.doc_id} == {"d1", "d2"}:
+                return 0.95
+            return 0.1
+
+        diverse = mmr(results, sim, lambda_=0.0)
+        # First pick: all have max_sim=0 initially, so best_mmr = 0 for all;
+        # among ties, first encountered wins → d1
+        # Second pick: d2 sim to d1=0.95, d3 sim to d1=0.1 → d3 preferred
+        assert diverse[0].doc_id == "d1"
+        assert diverse[1].doc_id == "d3"
+
+    def test_top_k(self):
+        results = [Result(f"d{i}", float(10 - i)) for i in range(10)]
+        reranked = mmr(results, self._const_sim, top_k=3)
+        assert len(reranked) == 3
+
+    def test_single_result(self):
+        results = [Result("d1", 5.0)]
+        reranked = mmr(results, self._const_sim)
+        assert len(reranked) == 1
+        assert reranked[0].doc_id == "d1"
+
+    def test_empty_results(self):
+        assert mmr([], self._const_sim) == []
+
+    def test_invalid_lambda_raises(self):
+        with pytest.raises(ValueError, match="lambda_"):
+            mmr([Result("d1", 1.0)], self._const_sim, lambda_=-0.1)
+        with pytest.raises(ValueError, match="lambda_"):
+            mmr([Result("d1", 1.0)], self._const_sim, lambda_=1.1)
+
+    def test_scores_are_mmr_values(self):
+        results = [Result("d1", 10.0), Result("d2", 5.0)]
+        reranked = mmr(results, self._const_sim, lambda_=0.5)
+        # MMR score for d1 (first picked): lambda*1.0 - 0 = 0.5 (normalized score=1.0)
+        assert reranked[0].score == pytest.approx(0.5)
+
+    def test_metadata_preserved(self):
+        results = [Result("d1", 5.0, metadata={"k": "v"})]
+        reranked = mmr(results, self._const_sim)
+        assert reranked[0].metadata == {"k": "v"}
+
+    def test_all_identical_scores(self):
+        results = [Result(f"d{i}", 5.0) for i in range(5)]
+        reranked = mmr(results, self._const_sim, lambda_=0.5)
+        assert len(reranked) == 5
+
+    def test_composable_with_sparse_index(self):
+        idx = SparseIndex()
+        idx.add("d1", "quick brown fox")
+        idx.add("d2", "lazy brown dog")
+        idx.add("d3", "fast red car")
+
+        search_results = idx.search("brown", top_k=10)
+        tokens = {
+            "d1": {"quick", "brown", "fox"},
+            "d2": {"lazy", "brown", "dog"},
+            "d3": {"fast", "red", "car"},
+        }
+
+        def sim(a, b):
+            return jaccard_similarity(
+                tokens.get(a.doc_id, set()), tokens.get(b.doc_id, set())
+            )
+
+        diverse = mmr(search_results, sim, lambda_=0.7, top_k=2)
+        assert len(diverse) <= 2
+        assert all(isinstance(r, Result) for r in diverse)
+
+    def test_zero_score_normalization(self):
+        """All scores zero should not cause division by zero."""
+        results = [Result("d1", 0.0), Result("d2", 0.0)]
+        reranked = mmr(results, self._const_sim, lambda_=0.5)
+        assert len(reranked) == 2


### PR DESCRIPTION
## Summary

- Add `rrf()` — Reciprocal Rank Fusion (Cormack et al., SIGIR 2009) for merging multiple ranked result lists (e.g. BM25 sparse + dense vector search), with per-list weights and top_k truncation
- Add `mmr()` — Maximal Marginal Relevance greedy re-ranking for result diversification, with user-provided similarity function and internal min-max score normalization
- Add `jaccard_similarity()` — set similarity utility as a building block for MMR similarity functions
- Bump sparse_search version 0.3.2 → 0.4.0

## Test plan

- [x] 97 correctness tests pass (31 new for RRF/MMR/Jaccard)
- [x] 38 benchmark tests pass (5 new for RRF/MMR performance)
- [x] ruff check + format clean
- [ ] CI pipeline green