### PR TITLE
feat(llmstxt): add llms.txt parser and markdown URL candidate finder

### DIFF
--- a/llmstxt/llmstxt.py
+++ b/llmstxt/llmstxt.py
@@ -1,0 +1,297 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "simple"
+# category = "data"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+
+"""llms.txt parser — zero dependencies, stdlib only, Python 3.10+.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Parse llms.txt files per the llmstxt.org specification into structured data,
+and generate candidate per-page markdown URLs for content discovery.
+
+Example::
+
+    from llmstxt import parse, find_candidates
+
+    doc = parse(\"\"\"# My Project
+    > A cool project
+
+    Some details here.
+
+    ## Docs
+    - [Guide](https://example.com/guide.md): The main guide
+    \"\"\")
+    print(doc.title)       # 'My Project'
+    print(doc.sections)    # {'Docs': [FileEntry(name='Guide', ...)]}
+
+    # With a parsed llms.txt — looks up matching entries, falls back to heuristic
+    matches = find_candidates("https://example.com/guide", doc=doc)
+    # [FileEntry(name='Guide', url='https://example.com/guide.md', ...)]
+
+    # Without llms.txt — pure heuristic URL generation
+    matches = find_candidates("https://example.com/docs")
+    # [FileEntry(name='', url='https://example.com/docs.md', ...)]
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import urllib.parse
+
+__all__ = [
+    "LlmsTxtError",
+    "FileEntry",
+    "LlmsTxt",
+    "parse",
+    "find_candidates",
+]
+
+# ── Exceptions ───────────────────────────────────────────────────────────────
+
+
+class LlmsTxtError(Exception):
+    """Raised when llms.txt parsing fails due to structural issues."""
+
+
+# ── Data Classes ─────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FileEntry:
+    """A linked resource entry from an llms.txt file list.
+
+    Attributes:
+        name: Display name of the link.
+        url: URL of the linked resource.
+        notes: Descriptive text after the ``: `` separator, or empty string.
+    """
+
+    name: str
+    url: str
+    notes: str = ""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LlmsTxt:
+    """Parsed representation of an llms.txt file.
+
+    Attributes:
+        title: The H1 heading (project/site name).
+        description: The blockquote summary, or empty string if absent.
+        details: Text paragraphs between blockquote and first H2, or empty
+            string.
+        sections: Mapping of H2 section name to list of file entries.
+            The special ``"Optional"`` section is excluded from this dict.
+        optional: Entries from the ``## Optional`` section, or empty list.
+    """
+
+    title: str
+    description: str = ""
+    details: str = ""
+    sections: dict[str, list[FileEntry]] = dataclasses.field(default_factory=dict)
+    optional: list[FileEntry] = dataclasses.field(default_factory=list)
+
+
+# ── Regex Patterns ───────────────────────────────────────────────────────────
+
+_H1_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_H2_SPLIT_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+_BLOCKQUOTE_RE = re.compile(r"^>\s?(.*)$", re.MULTILINE)
+_LINK_RE = re.compile(r"^-\s*\[([^\]]+)\]\(([^)]+)\)(?:\s*:\s*(.*))?$", re.MULTILINE)
+
+# ── Internal Helpers ─────────────────────────────────────────────────────────
+
+
+def _parse_links(text: str) -> list[FileEntry]:
+    """Extract link entries from a section body."""
+    return [
+        FileEntry(
+            name=m.group(1).strip(),
+            url=m.group(2).strip(),
+            notes=(m.group(3) or "").strip(),
+        )
+        for m in _LINK_RE.finditer(text)
+    ]
+
+
+def _parse_preamble(text: str) -> tuple[str, str]:
+    """Extract description (blockquote) and details from preamble text.
+
+    Returns:
+        A (description, details) tuple.
+    """
+    lines = text.split("\n")
+
+    # Skip leading blank lines
+    start = 0
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+
+    # Collect consecutive blockquote lines
+    bq_lines: list[str] = []
+    pos = start
+    while pos < len(lines):
+        m = _BLOCKQUOTE_RE.match(lines[pos])
+        if m:
+            bq_lines.append(m.group(1))
+            pos += 1
+        else:
+            break
+
+    description = "\n".join(bq_lines).strip()
+
+    # Everything after blockquote block is details
+    details = "\n".join(lines[pos:]).strip()
+
+    return description, details
+
+
+def _strip_url(url: str) -> str:
+    """Remove query string and fragment from a URL, return base."""
+    parsed = urllib.parse.urlparse(url)
+    return urllib.parse.urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path, "", "", "")
+    )
+
+
+def _url_path(url: str) -> str:
+    """Extract the path component from a URL."""
+    return urllib.parse.urlparse(url).path
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def parse(text: str) -> LlmsTxt:
+    """Parse llms.txt content into structured data.
+
+    Args:
+        text: Raw text content of an llms.txt file.
+
+    Returns:
+        Parsed ``LlmsTxt`` object.
+
+    Raises:
+        LlmsTxtError: If the required H1 title is missing.
+    """
+    text = text.replace("\r\n", "\n").strip()
+    if not text:
+        raise LlmsTxtError("empty input")
+
+    # Extract H1 title
+    h1_match = _H1_RE.search(text)
+    if not h1_match:
+        raise LlmsTxtError("missing required H1 title")
+    title = h1_match.group(1).strip()
+
+    # Split on H2 headers: [preamble, name1, body1, name2, body2, ...]
+    parts = _H2_SPLIT_RE.split(text)
+    preamble = parts[0]
+
+    # Remove the H1 line from preamble before parsing description/details
+    preamble = preamble[h1_match.end() :]
+
+    description, details = _parse_preamble(preamble)
+
+    # Parse sections
+    sections: dict[str, list[FileEntry]] = {}
+    for i in range(1, len(parts), 2):
+        section_name = parts[i].strip()
+        section_body = parts[i + 1] if i + 1 < len(parts) else ""
+        sections[section_name] = _parse_links(section_body)
+
+    # Separate "Optional" section
+    optional = sections.pop("Optional", [])
+
+    return LlmsTxt(
+        title=title,
+        description=description,
+        details=details,
+        sections=sections,
+        optional=optional,
+    )
+
+
+def _candidate_md_urls(page_url: str) -> list[str]:
+    """Generate candidate per-page markdown URLs for a given page URL."""
+    base = _strip_url(page_url)
+    path = _url_path(page_url)
+
+    if path.endswith(".md"):
+        return [base]
+
+    if path.endswith("/") or path in ("", "/"):
+        stripped = base.rstrip("/")
+        return [
+            stripped + "/index.md",
+            stripped + "/index.html.md",
+        ]
+
+    return [
+        base + ".md",
+        base + "/index.md",
+        base + "/index.html.md",
+    ]
+
+
+def find_candidates(url: str, doc: LlmsTxt | None = None) -> list[FileEntry]:
+    """Find candidate markdown resources for a given URL.
+
+    When *doc* is provided, searches all sections and optional entries for
+    URLs that relate to *url* (exact match > extension variation > path
+    prefix).  If no match is found (or *doc* is ``None``), falls back to
+    heuristic URL generation based on common per-page ``.md`` conventions.
+
+    Args:
+        url: The page URL to look up.
+        doc: An optional parsed ``LlmsTxt`` object to search in.
+
+    Returns:
+        List of ``FileEntry`` candidates, ordered by match quality.
+    """
+    base = _strip_url(url)
+    base_path = _url_path(url).rstrip("/")
+
+    # ── Search llms.txt entries ──
+    if doc is not None:
+        all_entries: list[FileEntry] = []
+        for entries in doc.sections.values():
+            all_entries.extend(entries)
+        all_entries.extend(doc.optional)
+
+        exact: list[FileEntry] = []
+        extension: list[FileEntry] = []
+        prefix: list[FileEntry] = []
+
+        for entry in all_entries:
+            entry_base = _strip_url(entry.url)
+            entry_path = _url_path(entry.url).rstrip("/")
+
+            if entry_base == base:
+                exact.append(entry)
+                continue
+
+            if entry_path == base_path + ".md" or entry_path == base_path + ".html.md":
+                extension.append(entry)
+                continue
+            if base_path == entry_path + ".md" or base_path == entry_path + ".html.md":
+                extension.append(entry)
+                continue
+
+            if entry_path.startswith(base_path + "/") or base_path.startswith(
+                entry_path + "/"
+            ):
+                prefix.append(entry)
+
+        results = exact + extension + prefix
+        if results:
+            return results
+
+    # ── Fallback: heuristic URL candidates ──
+    return [FileEntry(name="", url=u) for u in _candidate_md_urls(url)]

--- a/llmstxt/test_llmstxt_benchmark.py
+++ b/llmstxt/test_llmstxt_benchmark.py
@@ -1,0 +1,105 @@
+"""Benchmark: zerodep llmstxt parser."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from llmstxt import find_candidates, parse  # noqa: E402
+
+# ── Test data ────────────────────────────────────────────────────────────────
+
+SMALL = """\
+# My Project
+
+> A brief description.
+
+## Docs
+
+- [Guide](https://example.com/guide.md): The main guide
+- [API](https://example.com/api.md): API reference
+- [FAQ](https://example.com/faq.md): Frequently asked questions
+"""
+
+MEDIUM = """\
+# FastHTML
+
+> FastHTML is a python library which brings together Starlette, Uvicorn, HTMX, and fastcore's FT FastTags into a library for creating server-rendered hypermedia applications.
+
+FastHTML apps are just Starlette apps, so can be deployed to any platform that supports ASGI or WSGI.
+
+The project is documented at https://docs.fastht.ml.
+
+## Docs
+
+- [Quick start](https://docs.fastht.ml/tutorials/quickstart.html.md): Getting started
+- [HTMX reference](https://docs.fastht.ml/explains/htmx.html.md): HTMX integration
+- [Components](https://docs.fastht.ml/explains/components.html.md): Component system
+- [Routes](https://docs.fastht.ml/explains/routes.html.md): Routing overview
+- [Forms](https://docs.fastht.ml/explains/forms.html.md): Form handling
+- [Sessions](https://docs.fastht.ml/explains/sessions.html.md): Session management
+
+## Tutorials
+
+- [Todo app](https://docs.fastht.ml/tutorials/todo.html.md): A simple todo application
+- [Chat app](https://docs.fastht.ml/tutorials/chat.html.md): Real-time chat
+- [Blog](https://docs.fastht.ml/tutorials/blog.html.md): Blog engine tutorial
+- [Dashboard](https://docs.fastht.ml/tutorials/dashboard.html.md): Data dashboard
+
+## API Reference
+
+- [Core](https://docs.fastht.ml/api/core.html.md): Core module API
+- [HTML](https://docs.fastht.ml/api/html.html.md): HTML generation
+- [HTTP](https://docs.fastht.ml/api/http.html.md): HTTP utilities
+- [CLI](https://docs.fastht.ml/api/cli.html.md): Command line interface
+
+## Optional
+
+- [Advanced deployment](https://docs.fastht.ml/explains/deploy.html.md): Deploy options
+- [Middleware](https://docs.fastht.ml/explains/middleware.html.md): Custom middleware
+- [Testing](https://docs.fastht.ml/explains/testing.html.md): Testing guide
+"""
+
+_LARGE_ENTRIES = "\n".join(
+    f"- [Entry {i}](https://example.com/section/entry-{i}.md): Description for entry {i}"
+    for i in range(50)
+)
+_LARGE_SECTIONS = "\n\n".join(f"## Section {s}\n\n{_LARGE_ENTRIES}" for s in range(10))
+LARGE = f"""\
+# Large Project
+
+> A very large llms.txt file for stress testing the parser.
+
+This is a large project with many sections and entries. It is designed to test
+the parser's performance with realistic but large inputs.
+
+{_LARGE_SECTIONS}
+
+## Optional
+
+{_LARGE_ENTRIES}
+"""
+
+# ── Benchmarks: parse() ─────────────────────────────────────────────────────
+
+
+class TestParseSmall:
+    def test_zerodep(self, benchmark):
+        benchmark(parse, SMALL)
+
+
+class TestParseMedium:
+    def test_zerodep(self, benchmark):
+        benchmark(parse, MEDIUM)
+
+
+class TestParseLarge:
+    def test_zerodep(self, benchmark):
+        benchmark(parse, LARGE)
+
+
+# ── Benchmarks: candidate_md_urls() ─────────────────────────────────────────
+
+
+class TestCandidateUrls:
+    def test_zerodep(self, benchmark):
+        benchmark(find_candidates, "https://example.com/docs/guide")

--- a/llmstxt/test_llmstxt_correctness.py
+++ b/llmstxt/test_llmstxt_correctness.py
@@ -1,0 +1,415 @@
+"""Correctness tests for zerodep llmstxt parser."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from llmstxt import (  # noqa: E402
+    LlmsTxtError,
+    find_candidates,
+    parse,
+)
+
+# ── Test data ────────────────────────────────────────────────────────────────
+
+MINIMAL = "# My Project\n"
+
+SIMPLE = """\
+# My Project
+
+> A brief description of the project.
+
+Some extra detail here.
+
+## Docs
+
+- [Guide](https://example.com/guide.md): The main guide
+- [API](https://example.com/api.md): API reference
+"""
+
+FULL = """\
+# FastHTML
+
+> FastHTML is a python library which brings together Starlette, Uvicorn, \
+HTMX, and fastcore's `FT` "FastTags" into a library for creating \
+server-rendered hypermedia applications.
+
+FastHTML apps are just Starlette apps, so can be deployed to any platform.
+
+The project is documented at https://docs.fastht.ml.
+
+## Docs
+
+- [FastHTML quick start](https://docs.fastht.ml/tutorials/quickstart.html.md): Overview
+- [HTMX reference](https://docs.fastht.ml/explains/htmx.html.md): HTMX integration
+
+## Examples
+
+- [Todo app](https://docs.fastht.ml/tutorials/todo.html.md): A simple todo app
+- [Chat app](https://docs.fastht.ml/tutorials/chat.html.md)
+
+## Optional
+
+- [Advanced deployment](https://docs.fastht.ml/explains/deploy.html.md): Deploy options
+"""
+
+NO_BLOCKQUOTE = """\
+# Bare Project
+
+Just some details, no blockquote.
+
+## Links
+
+- [Home](https://example.com/home.md): Homepage
+"""
+
+NO_DETAILS = """\
+# No Details
+
+> Has a description but no details.
+
+## Links
+
+- [Home](https://example.com/home.md)
+"""
+
+MULTI_BLOCKQUOTE = """\
+# Multi
+
+> First line of description.
+> Second line continues.
+> Third line.
+
+## Docs
+
+- [A](https://example.com/a.md)
+"""
+
+EMPTY_SECTION = """\
+# Empty
+
+> Desc
+
+## Has Entries
+
+- [A](https://example.com/a.md): a note
+
+## Empty Section
+
+## Another
+
+- [B](https://example.com/b.md)
+"""
+
+
+# ── Test: parse() — title ────────────────────────────────────────────────────
+
+
+class TestParseTitle:
+    def test_simple_title(self):
+        doc = parse(MINIMAL)
+        assert doc.title == "My Project"
+
+    def test_title_with_special_chars(self):
+        doc = parse("# My `Project` — v2.0\n")
+        assert doc.title == "My `Project` — v2.0"
+
+    def test_missing_title_raises(self):
+        with pytest.raises(LlmsTxtError, match="missing required H1"):
+            parse("No heading here\n")
+
+    def test_empty_input_raises(self):
+        with pytest.raises(LlmsTxtError, match="empty input"):
+            parse("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(LlmsTxtError, match="empty input"):
+            parse("   \n\n  ")
+
+    def test_leading_blank_lines(self):
+        doc = parse("\n\n\n# Title\n")
+        assert doc.title == "Title"
+
+
+# ── Test: parse() — description ──────────────────────────────────────────────
+
+
+class TestParseDescription:
+    def test_single_line(self):
+        doc = parse(SIMPLE)
+        assert doc.description == "A brief description of the project."
+
+    def test_multi_line(self):
+        doc = parse(MULTI_BLOCKQUOTE)
+        assert doc.description == (
+            "First line of description.\nSecond line continues.\nThird line."
+        )
+
+    def test_missing_blockquote(self):
+        doc = parse(NO_BLOCKQUOTE)
+        assert doc.description == ""
+
+    def test_full_description(self):
+        doc = parse(FULL)
+        assert "FastHTML" in doc.description
+        assert "Starlette" in doc.description
+
+
+# ── Test: parse() — details ──────────────────────────────────────────────────
+
+
+class TestParseDetails:
+    def test_single_paragraph(self):
+        doc = parse(SIMPLE)
+        assert doc.details == "Some extra detail here."
+
+    def test_multi_paragraph(self):
+        doc = parse(FULL)
+        assert "documented at" in doc.details
+        lines = doc.details.split("\n")
+        assert len(lines) >= 2
+
+    def test_missing_details(self):
+        doc = parse(NO_DETAILS)
+        assert doc.details == ""
+
+    def test_no_blockquote_details_captured(self):
+        doc = parse(NO_BLOCKQUOTE)
+        assert doc.details == "Just some details, no blockquote."
+
+
+# ── Test: parse() — sections ─────────────────────────────────────────────────
+
+
+class TestParseSections:
+    def test_single_section(self):
+        doc = parse(SIMPLE)
+        assert "Docs" in doc.sections
+        assert len(doc.sections["Docs"]) == 2
+
+    def test_multiple_sections(self):
+        doc = parse(FULL)
+        assert "Docs" in doc.sections
+        assert "Examples" in doc.sections
+
+    def test_entry_fields(self):
+        doc = parse(SIMPLE)
+        entry = doc.sections["Docs"][0]
+        assert entry.name == "Guide"
+        assert entry.url == "https://example.com/guide.md"
+        assert entry.notes == "The main guide"
+
+    def test_entry_without_notes(self):
+        doc = parse(FULL)
+        chat = doc.sections["Examples"][1]
+        assert chat.name == "Chat app"
+        assert chat.notes == ""
+
+    def test_empty_section(self):
+        doc = parse(EMPTY_SECTION)
+        assert doc.sections["Empty Section"] == []
+        assert len(doc.sections["Has Entries"]) == 1
+        assert len(doc.sections["Another"]) == 1
+
+    def test_non_link_lines_skipped(self):
+        text = """\
+# Test
+
+## Mixed
+
+Some random text here.
+
+- [Valid](https://example.com/a.md): A link
+Not a link line
+- Another non-link
+- [Also valid](https://example.com/b.md)
+"""
+        doc = parse(text)
+        assert len(doc.sections["Mixed"]) == 2
+
+
+# ── Test: parse() — optional ─────────────────────────────────────────────────
+
+
+class TestParseOptional:
+    def test_optional_populated(self):
+        doc = parse(FULL)
+        assert len(doc.optional) == 1
+        assert doc.optional[0].name == "Advanced deployment"
+        assert "Optional" not in doc.sections
+
+    def test_optional_absent(self):
+        doc = parse(SIMPLE)
+        assert doc.optional == []
+
+    def test_optional_case_sensitive(self):
+        text = """\
+# Test
+
+## optional
+
+- [A](https://example.com/a.md)
+"""
+        doc = parse(text)
+        # lowercase "optional" is treated as a regular section
+        assert "optional" in doc.sections
+        assert doc.optional == []
+
+
+# ── Test: parse() — edge cases ───────────────────────────────────────────────
+
+
+class TestParseEdgeCases:
+    def test_windows_line_endings(self):
+        text = (
+            "# Title\r\n\r\n> Desc\r\n\r\n## Docs\r\n\r\n- [A](https://a.md): note\r\n"
+        )
+        doc = parse(text)
+        assert doc.title == "Title"
+        assert doc.description == "Desc"
+        assert len(doc.sections["Docs"]) == 1
+
+    def test_minimal_file(self):
+        doc = parse(MINIMAL)
+        assert doc.title == "My Project"
+        assert doc.description == ""
+        assert doc.details == ""
+        assert doc.sections == {}
+        assert doc.optional == []
+
+    def test_multiple_h1_takes_first(self):
+        text = "# First\n\n# Second\n"
+        doc = parse(text)
+        assert doc.title == "First"
+
+    def test_result_is_frozen(self):
+        doc = parse(SIMPLE)
+        with pytest.raises(AttributeError):
+            doc.title = "new"  # type: ignore[misc]
+
+    def test_entry_is_frozen(self):
+        doc = parse(SIMPLE)
+        entry = doc.sections["Docs"][0]
+        with pytest.raises(AttributeError):
+            entry.name = "new"  # type: ignore[misc]
+
+    def test_url_with_query_in_entry(self):
+        text = "# T\n\n## S\n\n- [A](https://example.com/a?v=1#frag): note\n"
+        doc = parse(text)
+        assert doc.sections["S"][0].url == "https://example.com/a?v=1#frag"
+
+
+# ── Test: find_candidates() — heuristic fallback (no doc) ────────────────────
+
+
+class TestCandidateMdUrls:
+    def test_basic_path(self):
+        results = find_candidates("https://example.com/docs/guide")
+        urls = [r.url for r in results]
+        assert urls == [
+            "https://example.com/docs/guide.md",
+            "https://example.com/docs/guide/index.md",
+            "https://example.com/docs/guide/index.html.md",
+        ]
+
+    def test_trailing_slash(self):
+        results = find_candidates("https://example.com/docs/")
+        urls = [r.url for r in results]
+        assert urls == [
+            "https://example.com/docs/index.md",
+            "https://example.com/docs/index.html.md",
+        ]
+
+    def test_root_url(self):
+        results = find_candidates("https://example.com/")
+        urls = [r.url for r in results]
+        assert urls == [
+            "https://example.com/index.md",
+            "https://example.com/index.html.md",
+        ]
+
+    def test_root_no_slash(self):
+        results = find_candidates("https://example.com")
+        urls = [r.url for r in results]
+        assert urls == [
+            "https://example.com/index.md",
+            "https://example.com/index.html.md",
+        ]
+
+    def test_already_md(self):
+        results = find_candidates("https://example.com/guide.md")
+        assert [r.url for r in results] == ["https://example.com/guide.md"]
+
+    def test_strips_query_and_fragment(self):
+        results = find_candidates("https://example.com/docs?q=1#section")
+        assert results[0].url == "https://example.com/docs.md"
+
+    def test_html_extension(self):
+        results = find_candidates("https://example.com/guide.html")
+        urls = [r.url for r in results]
+        assert "https://example.com/guide.html.md" in urls
+
+    def test_fallback_entries_have_empty_name(self):
+        results = find_candidates("https://example.com/page")
+        assert all(r.name == "" for r in results)
+
+
+# ── Test: find_candidates() — with doc ───────────────────────────────────────
+
+
+class TestFindCandidates:
+    @pytest.fixture()
+    def doc(self):
+        return parse(FULL)
+
+    def test_exact_match(self, doc):
+        results = find_candidates(
+            "https://docs.fastht.ml/tutorials/quickstart.html.md", doc=doc
+        )
+        assert len(results) >= 1
+        assert results[0].name == "FastHTML quick start"
+
+    def test_extension_match(self, doc):
+        results = find_candidates(
+            "https://docs.fastht.ml/tutorials/quickstart.html", doc=doc
+        )
+        assert len(results) >= 1
+        assert results[0].name == "FastHTML quick start"
+
+    def test_no_extension_match(self, doc):
+        results = find_candidates(
+            "https://docs.fastht.ml/tutorials/quickstart", doc=doc
+        )
+        assert len(results) >= 1
+
+    def test_prefix_match(self, doc):
+        results = find_candidates("https://docs.fastht.ml/tutorials", doc=doc)
+        assert len(results) >= 2
+
+    def test_no_match_falls_back_to_heuristic(self, doc):
+        results = find_candidates("https://unrelated.example.com/page", doc=doc)
+        # No llms.txt match, but heuristic fallback produces candidates
+        assert len(results) >= 1
+        assert all(r.name == "" for r in results)
+
+    def test_finds_optional_entries(self, doc):
+        results = find_candidates(
+            "https://docs.fastht.ml/explains/deploy.html.md", doc=doc
+        )
+        assert len(results) == 1
+        assert results[0].name == "Advanced deployment"
+
+    def test_strips_query_fragment(self, doc):
+        results = find_candidates(
+            "https://docs.fastht.ml/tutorials/todo.html.md?v=1#top", doc=doc
+        )
+        assert len(results) >= 1
+        assert results[0].name == "Todo app"
+
+    def test_no_doc_uses_heuristic(self):
+        results = find_candidates("https://example.com/page")
+        assert len(results) == 3
+        assert results[0].url == "https://example.com/page.md"

--- a/manifest.json
+++ b/manifest.json
@@ -192,6 +192,18 @@
       "last_updated": "2026-04-25T01:35:16+08:00",
       "content_hash": "032d65945452db2276c7867f38b7233a376905258f6df085101046fe48606043"
     },
+    "llmstxt": {
+      "description": "llms.txt parser — zero dependencies, stdlib only, Python 3.10+",
+      "files": [
+        "llmstxt/llmstxt.py"
+      ],
+      "version": "0.1.0",
+      "deps": [],
+      "tier": "simple",
+      "category": "data",
+      "last_updated": null,
+      "content_hash": null
+    },
     "markdown": {
       "description": "Markdown to HTML renderer — zero dependencies, stdlib only, Python 3.10+",
       "files": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt"]
 
 [tool.ruff]
 target-version = "py310"
@@ -215,4 +215,5 @@ extra-paths = [
     "./semver",
     "./jsonschema",
     "./png",
+    "./llmstxt",
 ]


### PR DESCRIPTION
## Summary

- Add `llmstxt` module: zero-dependency parser for the [llms.txt specification](https://llmstxt.org/)
- `parse(text)` → `LlmsTxt` dataclass with title, description, details, sections, optional entries
- `find_candidates(url, doc=None)` → unified API: searches parsed llms.txt entries first, falls back to heuristic `.md` URL generation
- Frozen dataclasses (`FileEntry`, `LlmsTxt`) for immutable parse results
- Lenient parsing: only H1 title is required, everything else gracefully degrades

Closes #62

## Test plan

- [x] 49 tests passing (45 correctness + 4 benchmarks)
- [x] `ruff check` and `ruff format` clean
- [x] Registered in `manifest.json` and `pyproject.toml`