### PR TITLE
feat(llmstxt): add discover() for site-level llms.txt probing

### DIFF
--- a/llmstxt/llmstxt.py
+++ b/llmstxt/llmstxt.py
@@ -42,14 +42,18 @@ from __future__ import annotations
 
 import dataclasses
 import re
+import urllib.error
 import urllib.parse
+import urllib.request
 
 __all__ = [
     "LlmsTxtError",
     "FileEntry",
     "LlmsTxt",
+    "DiscoveryResult",
     "parse",
     "find_candidates",
+    "discover",
 ]
 
 # ── Exceptions ───────────────────────────────────────────────────────────────
@@ -96,6 +100,22 @@ class LlmsTxt:
     details: str = ""
     sections: dict[str, list[FileEntry]] = dataclasses.field(default_factory=dict)
     optional: list[FileEntry] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DiscoveryResult:
+    """Result of probing a site for llms.txt and llms-full.txt.
+
+    Attributes:
+        llms_txt: Raw content of ``/llms.txt``, or ``None`` if not found.
+        llms_full_txt: Raw content of ``/llms-full.txt``, or ``None`` if not
+            found.
+        source_url: The root URL (``{scheme}://{netloc}``) that was probed.
+    """
+
+    llms_txt: str | None = None
+    llms_full_txt: str | None = None
+    source_url: str = ""
 
 
 # ── Regex Patterns ───────────────────────────────────────────────────────────
@@ -295,3 +315,54 @@ def find_candidates(url: str, doc: LlmsTxt | None = None) -> list[FileEntry]:
 
     # ── Fallback: heuristic URL candidates ──
     return [FileEntry(name="", url=u) for u in _candidate_md_urls(url)]
+
+
+# ── Discovery ──────────────────────────────────────────────────────────────
+
+_USER_AGENT = "zerodep-llmstxt/0.1 (https://github.com/Oaklight/zerodep)"
+
+
+def _fetch_text(url: str, timeout: int) -> str | None:
+    """Fetch a URL and return decoded text, or ``None`` on any failure."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+
+def discover(url: str, *, timeout: int = 10) -> DiscoveryResult:
+    """Probe a site for ``/llms.txt`` and ``/llms-full.txt``.
+
+    Given any URL, extracts the root (``{scheme}://{netloc}``) and attempts to
+    fetch both ``/llms.txt`` and ``/llms-full.txt``.  If the input URL already
+    points to one of these files, it is still fetched (along with its sibling).
+
+    Args:
+        url: Any URL belonging to the target site.
+        timeout: HTTP request timeout in seconds (per request).
+
+    Returns:
+        A ``DiscoveryResult`` with the raw content of whichever files were
+        found (fields are ``None`` when the file does not exist or could not
+        be fetched).
+
+    Example::
+
+        result = discover("https://example.com/docs/guide")
+        content = result.llms_full_txt or result.llms_txt
+        if content:
+            doc = parse(content)
+    """
+    parsed = urllib.parse.urlparse(url)
+    root = f"{parsed.scheme}://{parsed.netloc}"
+
+    llms_txt = _fetch_text(f"{root}/llms.txt", timeout)
+    llms_full_txt = _fetch_text(f"{root}/llms-full.txt", timeout)
+
+    return DiscoveryResult(
+        llms_txt=llms_txt,
+        llms_full_txt=llms_full_txt,
+        source_url=root,
+    )

--- a/llmstxt/test_llmstxt_correctness.py
+++ b/llmstxt/test_llmstxt_correctness.py
@@ -1,14 +1,18 @@
 """Correctness tests for zerodep llmstxt parser."""
 
+import http.server
 import os
 import sys
+import threading
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 
 from llmstxt import (  # noqa: E402
+    DiscoveryResult,
     LlmsTxtError,
+    discover,
     find_candidates,
     parse,
 )
@@ -413,3 +417,162 @@ class TestFindCandidates:
         results = find_candidates("https://example.com/page")
         assert len(results) == 3
         assert results[0].url == "https://example.com/page.md"
+
+
+# ── Local HTTP server for discover() tests ──────────────────────────────────
+
+LLMS_TXT_CONTENT = """\
+# Test Site
+
+> A test site for discovery.
+
+## Docs
+
+- [Guide](https://example.com/guide.md): The main guide
+"""
+
+LLMS_FULL_TXT_CONTENT = """\
+# Test Site
+
+> A test site for discovery.
+
+Full detailed content here.
+
+## Docs
+
+- [Guide](https://example.com/guide.md): The main guide
+- [API](https://example.com/api.md): API reference
+
+## Optional
+
+- [Advanced](https://example.com/advanced.md): Advanced topics
+"""
+
+
+class _DiscoveryHandler(http.server.BaseHTTPRequestHandler):
+    """Handler that serves llms.txt and/or llms-full.txt based on class flags."""
+
+    serve_llms_txt = True
+    serve_llms_full_txt = True
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/llms.txt" and self.serve_llms_txt:
+            self._respond(200, LLMS_TXT_CONTENT)
+        elif self.path == "/llms-full.txt" and self.serve_llms_full_txt:
+            self._respond(200, LLMS_FULL_TXT_CONTENT)
+        else:
+            self._respond(404, "Not Found")
+
+    def _respond(self, code: int, body: str):
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, format, *args):  # noqa: A002
+        pass  # suppress log output during tests
+
+
+def _make_server(handler_cls):
+    """Start a local HTTP server with the given handler, return (url, server)."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler_cls)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{port}", server
+
+
+# ── Test: discover() ───────────────────────────────────────────────────────
+
+
+class TestDiscover:
+    @pytest.fixture()
+    def both_server(self):
+        """Server that serves both llms.txt and llms-full.txt."""
+        url, server = _make_server(_DiscoveryHandler)
+        yield url
+        server.shutdown()
+
+    @pytest.fixture()
+    def llms_only_server(self):
+        """Server that serves only llms.txt."""
+
+        class Handler(_DiscoveryHandler):
+            serve_llms_full_txt = False
+
+        url, server = _make_server(Handler)
+        yield url
+        server.shutdown()
+
+    @pytest.fixture()
+    def full_only_server(self):
+        """Server that serves only llms-full.txt."""
+
+        class Handler(_DiscoveryHandler):
+            serve_llms_txt = False
+
+        url, server = _make_server(Handler)
+        yield url
+        server.shutdown()
+
+    @pytest.fixture()
+    def empty_server(self):
+        """Server that serves neither file."""
+
+        class Handler(_DiscoveryHandler):
+            serve_llms_txt = False
+            serve_llms_full_txt = False
+
+        url, server = _make_server(Handler)
+        yield url
+        server.shutdown()
+
+    def test_both_found(self, both_server):
+        result = discover(both_server)
+        assert result.llms_txt is not None
+        assert result.llms_full_txt is not None
+        assert "# Test Site" in result.llms_txt
+        assert "Full detailed content" in result.llms_full_txt
+
+    def test_only_llms_txt(self, llms_only_server):
+        result = discover(llms_only_server)
+        assert result.llms_txt is not None
+        assert result.llms_full_txt is None
+
+    def test_only_llms_full_txt(self, full_only_server):
+        result = discover(full_only_server)
+        assert result.llms_txt is None
+        assert result.llms_full_txt is not None
+
+    def test_neither_found(self, empty_server):
+        result = discover(empty_server)
+        assert result.llms_txt is None
+        assert result.llms_full_txt is None
+
+    def test_deep_path_extracts_root(self, both_server):
+        result = discover(f"{both_server}/docs/guide/page.html?q=1#frag")
+        assert result.llms_txt is not None
+        assert result.source_url == both_server
+
+    def test_input_is_llms_txt_url(self, both_server):
+        result = discover(f"{both_server}/llms.txt")
+        assert result.llms_txt is not None
+        assert result.llms_full_txt is not None
+
+    def test_source_url(self, both_server):
+        result = discover(both_server)
+        assert result.source_url == both_server
+
+    def test_result_is_frozen(self, both_server):
+        result = discover(both_server)
+        with pytest.raises(AttributeError):
+            result.llms_txt = "new"  # type: ignore[misc]
+
+    def test_unreachable_host(self):
+        result = discover("http://127.0.0.1:1", timeout=1)
+        assert result.llms_txt is None
+        assert result.llms_full_txt is None
+
+    def test_result_is_discovery_result(self, both_server):
+        result = discover(both_server)
+        assert isinstance(result, DiscoveryResult)


### PR DESCRIPTION
## Summary

- Add `DiscoveryResult` dataclass and `discover()` function that probes any URL's root for `/llms.txt` and `/llms-full.txt`, returning raw content
- Uses stdlib `urllib.request` to maintain zero-dependency principle
- 10 new test cases using local HTTP server fixture (consistent with httpclient test patterns)

## Test plan

- [x] All 55 tests pass (`pytest llmstxt/test_llmstxt_correctness.py`)
- [x] `ruff check` and `ruff format` clean