### PR TITLE
feat(httpserver): add async HTTP server module with decorator-based routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test benchmark lint fmt clean help manifest version-check dep-graph dep-check docs-index docs-index-check test-tabulate benchmark-tabulate test-soup benchmark-soup test-prompt test-validate benchmark-validate test-markdown benchmark-markdown test-diff benchmark-diff test-vcs test-ansi test-frontmatter benchmark-frontmatter test-cache benchmark-cache test-readability benchmark-readability benchmark-readability-compare test-jsonschema benchmark-jsonschema test-png benchmark-png
+.PHONY: all test benchmark lint fmt clean help manifest version-check dep-graph dep-check docs-index docs-index-check test-tabulate benchmark-tabulate test-soup benchmark-soup test-prompt test-validate benchmark-validate test-markdown benchmark-markdown test-diff benchmark-diff test-vcs test-ansi test-frontmatter benchmark-frontmatter test-cache benchmark-cache test-readability benchmark-readability benchmark-readability-compare test-jsonschema benchmark-jsonschema test-png benchmark-png test-httpserver benchmark-httpserver
 
 help:
 	@echo "Available targets:"
@@ -44,6 +44,8 @@ help:
 	@echo "  benchmark-jsonschema - Run jsonschema benchmarks (vs allof-merge JS)"
 	@echo "  test-png         - Run PNG correctness tests"
 	@echo "  benchmark-png    - Run PNG benchmarks (vs Pillow)"
+	@echo "  test-httpserver  - Run httpserver correctness tests"
+	@echo "  benchmark-httpserver - Run httpserver benchmarks (vs microdot, bottle)"
 	@echo "  docs-index       - Generate modules/index.md for EN and ZH docs"
 	@echo "  docs-index-check - Check that modules/index.md is up-to-date"
 	@echo "  manifest         - Regenerate manifest.json"
@@ -180,6 +182,12 @@ test-png:
 
 benchmark-png:
 	pytest png/test_png_benchmark.py -v
+
+test-httpserver:
+	pytest httpserver/test_httpserver_correctness.py -v
+
+benchmark-httpserver:
+	pytest httpserver/test_httpserver_benchmark.py -v
 
 manifest:
 	python zerodep.py manifest

--- a/_scripts/module_index_config.yaml
+++ b/_scripts/module_index_config.yaml
@@ -13,7 +13,7 @@ categories:
   - id: network
     name_en: "Web & Networking"
     name_zh: "网络与通信"
-    modules: [httpclient, sse, useragent]
+    modules: [httpclient, sse, httpserver, useragent]
 
   - id: protocol
     name_en: "Agent Protocols"
@@ -226,3 +226,7 @@ modules:
   synctex:
     desc_en: "SyncTeX inverse-search parser (PDF position → source location)"
     desc_zh: "SyncTeX 反向搜索解析器（PDF 位置 → 源代码位置）"
+  httpserver:
+    benchmark: microdot / bottle
+    desc_en: "Async HTTP server with decorator-based routing, streaming, and static files"
+    desc_zh: "异步 HTTP 服务器（装饰器路由、流式响应、静态文件）"

--- a/httpserver/conftest.py
+++ b/httpserver/conftest.py
@@ -96,9 +96,7 @@ def _build_test_app(static_dir=None):
             for i in range(3):
                 yield f"data: event-{i}\n\n"
 
-        return StreamingResponse(
-            generate(), content_type="text/event-stream"
-        )
+        return StreamingResponse(generate(), content_type="text/event-stream")
 
     @app.get("/stream-chunked")
     async def stream_chunked(request):
@@ -142,9 +140,7 @@ def server_url(static_dir):
 
         async def _start():
             app._shutdown_event = asyncio.Event()
-            server = await asyncio.start_server(
-                app._handle_connection, "127.0.0.1", 0
-            )
+            server = await asyncio.start_server(app._handle_connection, "127.0.0.1", 0)
             app._server = server
             addrs = server.sockets[0].getsockname()
             app.host = addrs[0]

--- a/httpserver/conftest.py
+++ b/httpserver/conftest.py
@@ -1,0 +1,163 @@
+"""Fixtures for httpserver tests."""
+
+import os
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "httpclient"))
+
+from httpserver import App, JSONResponse, Response, StreamingResponse, abort
+
+
+def _build_test_app(static_dir=None):
+    """Create a test app with standard routes."""
+    app = App()
+
+    @app.get("/status")
+    async def status(request):
+        return JSONResponse({"status": "ok"})
+
+    @app.get("/text")
+    async def text(request):
+        return "Hello, World!"
+
+    @app.get("/bytes")
+    async def raw_bytes(request):
+        return b"\x00\x01\x02"
+
+    @app.get("/none")
+    async def no_content(request):
+        return None
+
+    @app.get("/tuple2")
+    async def tuple2(request):
+        return {"created": True}, 201
+
+    @app.get("/tuple3")
+    async def tuple3(request):
+        return {"ok": True}, 200, {"X-Custom": "test-value"}
+
+    @app.post("/echo")
+    async def echo(request):
+        return JSONResponse({"body": request.json(), "method": "POST"})
+
+    @app.put("/echo")
+    async def echo_put(request):
+        return JSONResponse({"body": request.json(), "method": "PUT"})
+
+    @app.delete("/echo")
+    async def echo_delete(request):
+        return JSONResponse({"method": "DELETE"})
+
+    @app.patch("/echo")
+    async def echo_patch(request):
+        return JSONResponse({"body": request.json(), "method": "PATCH"})
+
+    @app.get("/users/<int:id>")
+    async def get_user(request, id):
+        return JSONResponse({"id": id})
+
+    @app.get("/files/<path:filepath>")
+    async def get_file(request, filepath):
+        return JSONResponse({"path": filepath})
+
+    @app.get("/query")
+    async def query(request):
+        return JSONResponse({"params": request.query_params})
+
+    @app.get("/headers")
+    async def headers(request):
+        ua = request.headers.get("user-agent", "")
+        custom = request.headers.get("x-test", "")
+        return JSONResponse({"user-agent": ua, "x-test": custom})
+
+    @app.get("/error/404")
+    async def not_found_error(request):
+        abort(404, "Custom not found")
+
+    @app.get("/error/500")
+    async def server_error(request):
+        raise RuntimeError("boom")
+
+    @app.post("/form")
+    async def form_handler(request):
+        return JSONResponse({"form": request.form()})
+
+    @app.get("/sync")
+    def sync_handler(request):
+        return JSONResponse({"sync": True})
+
+    @app.get("/sse")
+    async def sse(request):
+        async def generate():
+            for i in range(3):
+                yield f"data: event-{i}\n\n"
+
+        return StreamingResponse(
+            generate(), content_type="text/event-stream"
+        )
+
+    @app.get("/stream-chunked")
+    async def stream_chunked(request):
+        async def generate():
+            for i in range(3):
+                yield f"chunk-{i}"
+
+        return StreamingResponse(generate(), content_type="text/plain")
+
+    @app.get("/response-obj")
+    async def response_obj(request):
+        return Response(body="custom", status_code=200, content_type="text/html")
+
+    if static_dir:
+        app.static("/static", static_dir)
+
+    return app
+
+
+@pytest.fixture(scope="session")
+def static_dir(tmp_path_factory):
+    """Create a temporary directory with static files."""
+    d = tmp_path_factory.mktemp("static")
+    (d / "hello.txt").write_text("hello world")
+    (d / "data.json").write_text('{"key": "value"}')
+    sub = d / "sub"
+    sub.mkdir()
+    (sub / "nested.txt").write_text("nested content")
+    return str(d)
+
+
+@pytest.fixture(scope="session")
+def server_url(static_dir):
+    """Start the httpserver in a background thread and yield its URL."""
+    app = _build_test_app(static_dir=static_dir)
+
+    ready = threading.Event()
+
+    def _run():
+        import asyncio
+
+        async def _start():
+            app._shutdown_event = asyncio.Event()
+            server = await asyncio.start_server(
+                app._handle_connection, "127.0.0.1", 0
+            )
+            app._server = server
+            addrs = server.sockets[0].getsockname()
+            app.host = addrs[0]
+            app.port = addrs[1]
+            ready.set()
+            async with server:
+                await app._shutdown_event.wait()
+
+        asyncio.run(_start())
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    ready.wait(timeout=5)
+    yield f"http://127.0.0.1:{app.port}"
+    app.shutdown()
+    thread.join(timeout=2)

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -1,0 +1,978 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+
+"""Zero-dependency async HTTP server with decorator-based routing.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Async HTTP/1.1 server built on ``asyncio.start_server()``.  Supports
+decorator-based routing, JSON request/response, static file serving,
+streaming responses (SSE), and graceful shutdown.
+
+Usage::
+
+    from httpserver import App, JSONResponse
+
+    app = App()
+
+    @app.route("GET", "/status")
+    async def status(request):
+        return JSONResponse({"state": "idle"})
+
+    @app.route("POST", "/echo")
+    def echo(request):
+        return JSONResponse(request.json())
+
+    app.run(host="127.0.0.1", port=8000)
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────────
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import inspect
+import json as _json
+import logging
+import mimetypes
+import os
+import re
+import signal
+import sys
+from collections.abc import AsyncIterator, Callable
+from email.utils import formatdate
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+__all__ = [
+    # Application
+    "App",
+    # Request / Response
+    "Request",
+    "Response",
+    "JSONResponse",
+    "StreamingResponse",
+    "FileResponse",
+    # Exceptions
+    "HTTPException",
+    # Utilities
+    "abort",
+]
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_MAX_BODY_SIZE = 1_048_576  # 1 MB
+DEFAULT_READ_TIMEOUT = 30.0  # seconds
+
+_STATUS_REASONS: dict[int, str] = {
+    100: "Continue",
+    101: "Switching Protocols",
+    200: "OK",
+    201: "Created",
+    202: "Accepted",
+    204: "No Content",
+    301: "Moved Permanently",
+    302: "Found",
+    303: "See Other",
+    304: "Not Modified",
+    307: "Temporary Redirect",
+    308: "Permanent Redirect",
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    408: "Request Timeout",
+    409: "Conflict",
+    413: "Content Too Large",
+    415: "Unsupported Media Type",
+    422: "Unprocessable Entity",
+    429: "Too Many Requests",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+}
+
+# Type converters for path parameters
+_PARAM_CONVERTERS: dict[str, tuple[str, Callable[[str], Any]]] = {
+    "str": (r"([^/]+)", str),
+    "int": (r"(-?\d+)", int),
+    "float": (r"(-?[0-9]+(?:\.[0-9]+)?)", float),
+    "path": (r"(.+)", str),
+}
+
+# Regex to find <type:name> or <name> segments in route patterns
+_PARAM_RE = re.compile(r"<(?:(\w+):)?(\w+)>")
+
+_SENTINEL = object()
+
+
+# ── Exceptions ───────────────────────────────────────────────────────────────
+
+
+class HTTPException(Exception):
+    """HTTP error that maps to a specific status code.
+
+    Raise directly or via :func:`abort` to short-circuit request handling.
+
+    Args:
+        status_code: HTTP status code (e.g. 404, 500).
+        message: Optional human-readable error message.
+    """
+
+    __slots__ = ("status_code", "message")
+
+    def __init__(self, status_code: int, message: str | None = None):
+        self.status_code = status_code
+        self.message = message or _STATUS_REASONS.get(status_code, "Error")
+        super().__init__(self.message)
+
+
+class _BadRequest(Exception):
+    """Internal: malformed HTTP request from client."""
+
+
+def abort(status_code: int, message: str | None = None) -> None:
+    """Raise an :class:`HTTPException` with the given status code.
+
+    Args:
+        status_code: HTTP status code.
+        message: Optional error message.
+    """
+    raise HTTPException(status_code, message)
+
+
+# ── Request ──────────────────────────────────────────────────────────────────
+
+
+class Request:
+    """Parsed HTTP request.
+
+    Attributes:
+        method: Uppercase HTTP method (GET, POST, ...).
+        path: URL path, percent-decoded.
+        query_string: Raw query string (without leading ``?``).
+        query_params: Parsed query string as ``{key: [values]}``.
+        headers: Case-insensitive header dict (keys stored lowercase).
+        body: Raw request body bytes.
+        path_params: Parameters extracted from the route pattern.
+        client_addr: Client ``(host, port)`` tuple.
+        app: Reference to the :class:`App` instance handling this request.
+    """
+
+    __slots__ = (
+        "method",
+        "path",
+        "query_string",
+        "query_params",
+        "headers",
+        "body",
+        "path_params",
+        "client_addr",
+        "app",
+        "_json",
+    )
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        query_string: str,
+        headers: dict[str, str],
+        body: bytes,
+        client_addr: tuple[str, int],
+        app: App | None = None,
+    ):
+        self.method = method
+        self.path = path
+        self.query_string = query_string
+        self.query_params: dict[str, list[str]] = parse_qs(query_string)
+        self.headers = headers
+        self.body = body
+        self.path_params: dict[str, Any] = {}
+        self.client_addr = client_addr
+        self.app = app
+        self._json: Any = _SENTINEL
+
+    def json(self) -> Any:
+        """Parse body as JSON (cached)."""
+        if self._json is _SENTINEL:
+            self._json = _json.loads(self.body)
+        return self._json
+
+    def text(self) -> str:
+        """Decode body as UTF-8."""
+        return self.body.decode("utf-8")
+
+    def form(self) -> dict[str, list[str]]:
+        """Parse URL-encoded form body."""
+        return parse_qs(self.body.decode("utf-8"))
+
+
+# ── Response Classes ─────────────────────────────────────────────────────────
+
+
+class Response:
+    """HTTP response with a fixed body.
+
+    Args:
+        body: Response body (bytes or str).
+        status_code: HTTP status code.
+        headers: Extra response headers.
+        content_type: Shorthand for ``Content-Type`` header.
+    """
+
+    __slots__ = ("status_code", "headers", "body")
+
+    def __init__(
+        self,
+        body: bytes | str = b"",
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        content_type: str | None = None,
+    ):
+        self.status_code = status_code
+        self.headers: dict[str, str] = headers.copy() if headers else {}
+        if isinstance(body, str):
+            self.body = body.encode("utf-8")
+        else:
+            self.body = body
+        if content_type is not None:
+            self.headers["Content-Type"] = content_type
+
+    async def _write(self, writer: asyncio.StreamWriter) -> None:
+        """Serialize and write the full HTTP response."""
+        reason = _STATUS_REASONS.get(self.status_code, "Unknown")
+        self.headers.setdefault("Content-Length", str(len(self.body)))
+        self.headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+        self.headers.setdefault("Date", _http_date())
+        self.headers.setdefault("Connection", "close")
+
+        buf = bytearray()
+        buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
+        for k, v in self.headers.items():
+            buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        buf.extend(b"\r\n")
+        buf.extend(self.body)
+        writer.write(bytes(buf))
+        await writer.drain()
+
+
+class JSONResponse(Response):
+    """Response serialized as JSON.
+
+    Args:
+        data: Python object to serialize.
+        status_code: HTTP status code.
+        headers: Extra response headers.
+    """
+
+    def __init__(
+        self,
+        data: Any,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ):
+        body = _json.dumps(data, ensure_ascii=False).encode("utf-8")
+        super().__init__(
+            body=body,
+            status_code=status_code,
+            headers=headers,
+            content_type="application/json; charset=utf-8",
+        )
+
+
+class StreamingResponse:
+    """HTTP response streamed from an async generator.
+
+    Writes chunks using ``Transfer-Encoding: chunked`` unless
+    ``content_type`` is ``text/event-stream`` (SSE), in which case raw
+    bytes are flushed directly for maximum compatibility with SSE clients.
+
+    Args:
+        generator: Async iterator yielding ``bytes`` or ``str`` chunks.
+        status_code: HTTP status code.
+        headers: Extra response headers.
+        content_type: MIME type (default ``application/octet-stream``).
+    """
+
+    __slots__ = ("_generator", "status_code", "headers", "content_type")
+
+    def __init__(
+        self,
+        generator: AsyncIterator[bytes | str],
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        content_type: str = "application/octet-stream",
+    ):
+        self._generator = generator
+        self.status_code = status_code
+        self.headers: dict[str, str] = headers.copy() if headers else {}
+        self.content_type = content_type
+
+    async def _write(self, writer: asyncio.StreamWriter) -> None:
+        """Write status line, headers, then stream the body."""
+        reason = _STATUS_REASONS.get(self.status_code, "Unknown")
+        is_sse = self.content_type.startswith("text/event-stream")
+
+        self.headers["Content-Type"] = self.content_type
+        if not is_sse:
+            self.headers.setdefault("Transfer-Encoding", "chunked")
+        else:
+            self.headers.setdefault("Cache-Control", "no-cache")
+        self.headers.setdefault("Date", _http_date())
+        self.headers.setdefault("Connection", "close")
+
+        buf = bytearray()
+        buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
+        for k, v in self.headers.items():
+            buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        buf.extend(b"\r\n")
+        writer.write(bytes(buf))
+        await writer.drain()
+
+        try:
+            async for chunk in self._generator:
+                if isinstance(chunk, str):
+                    chunk = chunk.encode("utf-8")
+                if is_sse:
+                    writer.write(chunk)
+                else:
+                    writer.write(f"{len(chunk):x}\r\n".encode("latin-1"))
+                    writer.write(chunk)
+                    writer.write(b"\r\n")
+                await writer.drain()
+            if not is_sse:
+                writer.write(b"0\r\n\r\n")
+                await writer.drain()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            logger.debug("Client disconnected during streaming")
+        finally:
+            if hasattr(self._generator, "aclose"):
+                await self._generator.aclose()
+
+
+class FileResponse(Response):
+    """Response serving a file from disk.
+
+    Args:
+        path: Path to the file.
+        content_type: MIME type (auto-detected from extension if ``None``).
+        status_code: HTTP status code.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        content_type: str | None = None,
+        status_code: int = 200,
+    ):
+        file_path = Path(path)
+        body = file_path.read_bytes()
+        if content_type is None:
+            guessed, _ = mimetypes.guess_type(str(file_path))
+            content_type = guessed or "application/octet-stream"
+        headers = {
+            "Last-Modified": _http_date(os.path.getmtime(file_path)),
+        }
+        super().__init__(
+            body=body,
+            status_code=status_code,
+            headers=headers,
+            content_type=content_type,
+        )
+
+
+# ── Routing ──────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Route:
+    """Internal route entry."""
+
+    method: str  # uppercase or "*"
+    pattern: re.Pattern[str]
+    handler: Callable[..., Any]
+    is_async: bool
+    param_names: list[str]
+    param_converters: list[Callable[[str], Any]]
+
+
+def _compile_route(
+    path: str,
+) -> tuple[re.Pattern[str], list[str], list[Callable[[str], Any]]]:
+    """Compile a path pattern into a regex and parameter metadata.
+
+    Supports ``<name>``, ``<int:name>``, ``<float:name>``, ``<path:name>``.
+
+    Args:
+        path: URL path pattern (e.g. ``/users/<int:id>``).
+
+    Returns:
+        Tuple of (compiled regex, param names, param converters).
+    """
+    param_names: list[str] = []
+    param_converters: list[Callable[[str], Any]] = []
+    regex_parts: list[str] = []
+    last_end = 0
+
+    for m in _PARAM_RE.finditer(path):
+        regex_parts.append(re.escape(path[last_end : m.start()]))
+        type_name = m.group(1) or "str"
+        name = m.group(2)
+        if type_name not in _PARAM_CONVERTERS:
+            raise ValueError(f"Unknown path parameter type: {type_name!r}")
+        regex_fragment, converter = _PARAM_CONVERTERS[type_name]
+        regex_parts.append(regex_fragment)
+        param_names.append(name)
+        param_converters.append(converter)
+        last_end = m.end()
+
+    regex_parts.append(re.escape(path[last_end:]))
+    full_regex = "^" + "".join(regex_parts) + "$"
+    return re.compile(full_regex), param_names, param_converters
+
+
+# ── HTTP Parsing ─────────────────────────────────────────────────────────────
+
+
+async def _read_request(
+    reader: asyncio.StreamReader,
+    timeout: float,
+    max_body_size: int,
+) -> tuple[str, str, str, dict[str, str], bytes]:
+    """Read and parse an HTTP request from a stream.
+
+    Returns:
+        Tuple of (method, path, query_string, headers, body).
+
+    Raises:
+        _BadRequest: If the request is malformed.
+        asyncio.TimeoutError: If reading times out.
+    """
+    # -- Request line --
+    raw_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    if not raw_line:
+        raise _BadRequest("Empty request")
+    request_line = raw_line.decode("latin-1").rstrip("\r\n")
+    parts = request_line.split(" ", 2)
+    if len(parts) != 3:
+        raise _BadRequest(f"Malformed request line: {request_line!r}")
+    method, raw_url, _version = parts
+
+    # -- URL --
+    parsed = urlparse(raw_url)
+    path = unquote(parsed.path)
+    query_string = parsed.query
+
+    # -- Headers --
+    headers: dict[str, str] = {}
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        decoded = line.decode("latin-1").rstrip("\r\n")
+        if not decoded:
+            break
+        if ":" in decoded:
+            k, v = decoded.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+
+    # -- Body --
+    body = b""
+    cl = headers.get("content-length")
+    if cl is not None:
+        length = int(cl)
+        if length > max_body_size:
+            raise HTTPException(413, f"Request body too large ({length} bytes)")
+        if length > 0:
+            body = await asyncio.wait_for(reader.readexactly(length), timeout=timeout)
+    elif headers.get("transfer-encoding", "").lower() == "chunked":
+        body = await _read_chunked_body(reader, timeout, max_body_size)
+
+    return method.upper(), path, query_string, headers, body
+
+
+async def _read_chunked_body(
+    reader: asyncio.StreamReader,
+    timeout: float,
+    max_body_size: int,
+) -> bytes:
+    """Read a chunked transfer-encoded body."""
+    parts: list[bytes] = []
+    total = 0
+    while True:
+        size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        size_str = size_line.decode("latin-1").split(";")[0].strip()
+        if not size_str:
+            break
+        chunk_size = int(size_str, 16)
+        if chunk_size == 0:
+            await asyncio.wait_for(reader.readline(), timeout=timeout)
+            break
+        total += chunk_size
+        if total > max_body_size:
+            raise HTTPException(413, "Request body too large")
+        data = await asyncio.wait_for(reader.readexactly(chunk_size), timeout=timeout)
+        await asyncio.wait_for(reader.readline(), timeout=timeout)
+        parts.append(data)
+    return b"".join(parts)
+
+
+# ── Utilities ────────────────────────────────────────────────────────────────
+
+
+def _http_date(timestamp: float | None = None) -> str:
+    """Format a timestamp as an HTTP-date (RFC 7231)."""
+    return formatdate(timeval=timestamp, localtime=False, usegmt=True)
+
+
+def _coerce_response(result: Any) -> Response | StreamingResponse:
+    """Convert a handler return value into a Response object."""
+    if isinstance(result, (Response, StreamingResponse)):
+        return result
+
+    if result is None:
+        return Response(status_code=204)
+
+    if isinstance(result, dict):
+        return JSONResponse(result)
+
+    if isinstance(result, tuple):
+        if len(result) == 2:
+            body, status = result
+            resp = _coerce_response(body)
+            resp.status_code = status
+            return resp
+        if len(result) == 3:
+            body, status, extra_headers = result
+            resp = _coerce_response(body)
+            resp.status_code = status
+            resp.headers.update(extra_headers)
+            return resp
+        raise ValueError(f"Unsupported tuple length: {len(result)}")
+
+    if isinstance(result, bytes):
+        return Response(body=result, content_type="application/octet-stream")
+
+    if isinstance(result, str):
+        return Response(body=result, content_type="text/plain; charset=utf-8")
+
+    raise TypeError(
+        f"Cannot coerce handler return type {type(result).__name__} to Response"
+    )
+
+
+# ── Static File Resolution ───────────────────────────────────────────────────
+
+
+def _resolve_static_file(
+    request_path: str,
+    url_prefix: str,
+    directory: str,
+) -> FileResponse | None:
+    """Try to resolve a static file request.
+
+    Returns a FileResponse if the file exists and the path is safe,
+    otherwise None.
+    """
+    if not request_path.startswith(url_prefix):
+        return None
+
+    relative = request_path[len(url_prefix) :].lstrip("/")
+    if not relative:
+        return None
+
+    base = Path(directory).resolve()
+    target = (base / relative).resolve()
+
+    # Prevent directory traversal
+    if not str(target).startswith(str(base)):
+        return None
+
+    if not target.is_file():
+        return None
+
+    return FileResponse(target)
+
+
+# ── App ──────────────────────────────────────────────────────────────────────
+
+
+class App:
+    """Async HTTP server application.
+
+    Args:
+        max_body_size: Maximum request body size in bytes.
+        read_timeout: Timeout for reading a single request (seconds).
+
+    Example::
+
+        app = App()
+
+        @app.get("/hello")
+        async def hello(request):
+            return {"message": "Hello, world!"}
+
+        app.run()
+    """
+
+    def __init__(
+        self,
+        *,
+        max_body_size: int = DEFAULT_MAX_BODY_SIZE,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+    ):
+        self._routes: list[_Route] = []
+        self._static_routes: list[tuple[str, str]] = []
+        self._before_request_handlers: list[Callable[..., Any]] = []
+        self._after_request_handlers: list[Callable[..., Any]] = []
+        self._error_handlers: dict[int | type, Callable[..., Any]] = {}
+        self._server: asyncio.Server | None = None
+        self._shutdown_event: asyncio.Event | None = None
+        self.max_body_size = max_body_size
+        self.read_timeout = read_timeout
+        self.port: int | None = None
+        self.host: str | None = None
+
+    # ── Route Registration ───────────────────────────────────────────────
+
+    def route(self, method: str, path: str) -> Callable[..., Any]:
+        """Register a route handler.
+
+        Args:
+            method: HTTP method (GET, POST, etc.) or ``"*"`` for any.
+            path: URL pattern with optional parameters.
+
+        Example::
+
+            @app.route("GET", "/users/<int:id>")
+            async def get_user(request, id):
+                return {"id": id}
+        """
+
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            pattern, param_names, converters = _compile_route(path)
+            is_async = inspect.iscoroutinefunction(handler)
+            self._routes.append(
+                _Route(
+                    method=method.upper(),
+                    pattern=pattern,
+                    handler=handler,
+                    is_async=is_async,
+                    param_names=param_names,
+                    param_converters=converters,
+                )
+            )
+            return handler
+
+        return decorator
+
+    def get(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route("GET", path)``."""
+        return self.route("GET", path)
+
+    def post(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route("POST", path)``."""
+        return self.route("POST", path)
+
+    def put(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route("PUT", path)``."""
+        return self.route("PUT", path)
+
+    def delete(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route("DELETE", path)``."""
+        return self.route("DELETE", path)
+
+    def patch(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route("PATCH", path)``."""
+        return self.route("PATCH", path)
+
+    def static(self, url_prefix: str, directory: str) -> None:
+        """Register a directory for static file serving.
+
+        Args:
+            url_prefix: URL prefix (e.g. ``"/static"``).
+            directory: Filesystem path to the directory.
+
+        Example::
+
+            app.static("/assets", "./public")
+        """
+        url_prefix = url_prefix.rstrip("/")
+        abs_dir = os.path.abspath(directory)
+        self._static_routes.append((url_prefix, abs_dir))
+
+    # ── Middleware ────────────────────────────────────────────────────────
+
+    def before_request(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register a before-request hook.
+
+        The hook receives ``(request)`` and may return a ``Response`` to
+        short-circuit the route handler.
+        """
+        self._before_request_handlers.append(handler)
+        return handler
+
+    def after_request(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register an after-request hook.
+
+        The hook receives ``(request, response)`` and may return a new
+        or modified ``Response``.
+        """
+        self._after_request_handlers.append(handler)
+        return handler
+
+    def errorhandler(self, code_or_exc: int | type) -> Callable[..., Any]:
+        """Register an error handler.
+
+        Args:
+            code_or_exc: HTTP status code (int) or exception class.
+
+        The handler receives ``(request, exception)`` and must return a
+        ``Response``.
+        """
+
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            self._error_handlers[code_or_exc] = handler
+            return handler
+
+        return decorator
+
+    # ── Request Dispatch ─────────────────────────────────────────────────
+
+    async def _dispatch(self, request: Request) -> Response | StreamingResponse:
+        """Match a request to a route and invoke the handler."""
+        # -- before_request hooks --
+        for hook in self._before_request_handlers:
+            result = await _invoke(hook, request)
+            if result is not None:
+                return _coerce_response(result)
+
+        # -- Static file check --
+        for prefix, directory in self._static_routes:
+            file_resp = _resolve_static_file(request.path, prefix, directory)
+            if file_resp is not None:
+                return file_resp
+
+        # -- Route matching --
+        matched_path = False
+        for route in self._routes:
+            m = route.pattern.match(request.path)
+            if m is None:
+                continue
+            matched_path = True
+            if route.method != "*" and route.method != request.method:
+                continue
+
+            # Extract path params
+            groups = m.groups()
+            for name, converter, value in zip(
+                route.param_names, route.param_converters, groups
+            ):
+                request.path_params[name] = converter(value)
+
+            # Invoke handler
+            try:
+                result = await _invoke(route.handler, request, **request.path_params)
+                response = _coerce_response(result)
+            except HTTPException as exc:
+                response = await self._handle_error(request, exc)
+            except Exception as exc:
+                logger.exception(
+                    "Unhandled exception in handler %s", route.handler.__name__
+                )
+                response = await self._handle_error(request, exc)
+
+            # -- after_request hooks --
+            for hook in self._after_request_handlers:
+                hook_result = await _invoke(hook, request, response)
+                if hook_result is not None:
+                    response = _coerce_response(hook_result)
+
+            return response
+
+        # -- No route matched --
+        if matched_path:
+            allowed = sorted(
+                {
+                    r.method
+                    for r in self._routes
+                    if r.pattern.match(request.path) and r.method != "*"
+                }
+            )
+            exc = HTTPException(405, "Method Not Allowed")
+            response = await self._handle_error(request, exc)
+            if isinstance(response, Response):
+                response.headers["Allow"] = ", ".join(allowed)
+            return response
+
+        exc = HTTPException(404, "Not Found")
+        return await self._handle_error(request, exc)
+
+    async def _handle_error(
+        self, request: Request, exc: Exception
+    ) -> Response | StreamingResponse:
+        """Resolve an error into a response, consulting registered handlers."""
+        if isinstance(exc, HTTPException):
+            handler = self._error_handlers.get(exc.status_code)
+            if handler is not None:
+                result = await _invoke(handler, request, exc)
+                return _coerce_response(result)
+
+        for exc_cls, handler in self._error_handlers.items():
+            if isinstance(exc_cls, type) and isinstance(exc, exc_cls):
+                result = await _invoke(handler, request, exc)
+                return _coerce_response(result)
+
+        if isinstance(exc, HTTPException):
+            return JSONResponse(
+                {"error": exc.message},
+                status_code=exc.status_code,
+            )
+        return JSONResponse(
+            {"error": "Internal Server Error"},
+            status_code=500,
+        )
+
+    # ── Connection Handling ───────────────────────────────────────────────
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Handle a single client connection."""
+        peer = writer.get_extra_info("peername")
+        client_addr = (peer[0], peer[1]) if peer else ("unknown", 0)
+
+        try:
+            method, path, qs, headers, body = await _read_request(
+                reader, self.read_timeout, self.max_body_size
+            )
+        except _BadRequest as exc:
+            logger.debug("Bad request from %s: %s", client_addr, exc)
+            response = Response(
+                body=str(exc),
+                status_code=400,
+                content_type="text/plain; charset=utf-8",
+            )
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except HTTPException as exc:
+            response = JSONResponse({"error": exc.message}, status_code=exc.status_code)
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+            writer.close()
+            return
+        except Exception:
+            writer.close()
+            return
+
+        request = Request(
+            method=method,
+            path=path,
+            query_string=qs,
+            headers=headers,
+            body=body,
+            client_addr=client_addr,
+            app=self,
+        )
+
+        logger.debug("%s %s from %s", method, path, client_addr)
+
+        try:
+            response = await self._dispatch(request)
+            await response._write(writer)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            logger.debug("Connection reset by %s during response", client_addr)
+        except Exception:
+            logger.exception("Error writing response to %s", client_addr)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    # ── Server Lifecycle ─────────────────────────────────────────────────
+
+    def run(
+        self,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+    ) -> None:
+        """Start the server (blocking).
+
+        Args:
+            host: Bind address.
+            port: Bind port. Use ``0`` for OS-assigned port.
+        """
+        try:
+            asyncio.run(self._serve(host, port))
+        except KeyboardInterrupt:
+            pass
+
+    async def _serve(self, host: str, port: int) -> None:
+        """Internal async server loop."""
+        self._shutdown_event = asyncio.Event()
+
+        server = await asyncio.start_server(
+            self._handle_connection,
+            host,
+            port,
+        )
+
+        self._server = server
+        addrs = server.sockets[0].getsockname() if server.sockets else (host, port)
+        self.host = addrs[0]
+        self.port = addrs[1]
+        logger.info("Serving on %s:%d", self.host, self.port)
+
+        loop = asyncio.get_running_loop()
+        if sys.platform != "win32":
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, self._shutdown_event.set)
+
+        async with server:
+            await self._shutdown_event.wait()
+            logger.info("Shutting down server")
+
+    def shutdown(self) -> None:
+        """Request a graceful server shutdown.
+
+        Safe to call from a request handler.
+        """
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+
+
+# ── Handler Invocation ───────────────────────────────────────────────────────
+
+
+async def _invoke(handler: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Invoke a handler, wrapping sync functions with ``asyncio.to_thread``."""
+    if inspect.iscoroutinefunction(handler):
+        return await handler(*args, **kwargs)
+    return await asyncio.to_thread(handler, *args, **kwargs)

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -21,11 +21,11 @@ Usage::
 
     app = App()
 
-    @app.route("GET", "/status")
+    @app.route("/status")
     async def status(request):
         return JSONResponse({"state": "idle"})
 
-    @app.route("POST", "/echo")
+    @app.route("/echo", methods=["POST"])
     def echo(request):
         return JSONResponse(request.json())
 
@@ -405,7 +405,7 @@ class FileResponse(Response):
 class _Route:
     """Internal route entry."""
 
-    method: str  # uppercase or "*"
+    methods: list[str]  # uppercase, e.g. ["GET", "POST"], or ["*"]
     pattern: re.Pattern[str]
     handler: Callable[..., Any]
     is_async: bool
@@ -650,26 +650,31 @@ class App:
 
     # ── Route Registration ───────────────────────────────────────────────
 
-    def route(self, method: str, path: str) -> Callable[..., Any]:
+    def route(
+        self, url_pattern: str, methods: list[str] | None = None
+    ) -> Callable[..., Any]:
         """Register a route handler.
 
         Args:
-            method: HTTP method (GET, POST, etc.) or ``"*"`` for any.
-            path: URL pattern with optional parameters.
+            url_pattern: URL pattern with optional parameters.
+            methods: HTTP methods to handle (e.g. ``["GET", "POST"]``).
+                Defaults to ``["GET"]``.
 
         Example::
 
-            @app.route("GET", "/users/<int:id>")
-            async def get_user(request, id):
+            @app.route("/users/<int:id>", methods=["GET", "POST"])
+            async def user(request, id):
                 return {"id": id}
         """
+        if methods is None:
+            methods = ["GET"]
 
         def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
-            pattern, param_names, converters = _compile_route(path)
+            pattern, param_names, converters = _compile_route(url_pattern)
             is_async = inspect.iscoroutinefunction(handler)
             self._routes.append(
                 _Route(
-                    method=method.upper(),
+                    methods=[m.upper() for m in methods],
                     pattern=pattern,
                     handler=handler,
                     is_async=is_async,
@@ -682,24 +687,24 @@ class App:
         return decorator
 
     def get(self, path: str) -> Callable[..., Any]:
-        """Shorthand for ``@app.route("GET", path)``."""
-        return self.route("GET", path)
+        """Shorthand for ``@app.route(path, methods=["GET"])``."""
+        return self.route(path, methods=["GET"])
 
     def post(self, path: str) -> Callable[..., Any]:
-        """Shorthand for ``@app.route("POST", path)``."""
-        return self.route("POST", path)
+        """Shorthand for ``@app.route(path, methods=["POST"])``."""
+        return self.route(path, methods=["POST"])
 
     def put(self, path: str) -> Callable[..., Any]:
-        """Shorthand for ``@app.route("PUT", path)``."""
-        return self.route("PUT", path)
+        """Shorthand for ``@app.route(path, methods=["PUT"])``."""
+        return self.route(path, methods=["PUT"])
 
     def delete(self, path: str) -> Callable[..., Any]:
-        """Shorthand for ``@app.route("DELETE", path)``."""
-        return self.route("DELETE", path)
+        """Shorthand for ``@app.route(path, methods=["DELETE"])``."""
+        return self.route(path, methods=["DELETE"])
 
     def patch(self, path: str) -> Callable[..., Any]:
-        """Shorthand for ``@app.route("PATCH", path)``."""
-        return self.route("PATCH", path)
+        """Shorthand for ``@app.route(path, methods=["PATCH"])``."""
+        return self.route(path, methods=["PATCH"])
 
     def static(self, url_prefix: str, directory: str) -> None:
         """Register a directory for static file serving.
@@ -769,7 +774,7 @@ class App:
             if m is None:
                 continue
             path_existed = True
-            if route.method != "*" and route.method != request.method:
+            if "*" not in route.methods and request.method not in route.methods:
                 continue
             return route, m, True
         return None, None, path_existed
@@ -830,9 +835,11 @@ class App:
         if path_existed:
             allowed = sorted(
                 {
-                    r.method
+                    m
                     for r in self._routes
-                    if r.pattern.match(request.path) and r.method != "*"
+                    if r.pattern.match(request.path)
+                    for m in r.methods
+                    if m != "*"
                 }
             )
             exc = HTTPException(405, "Method Not Allowed")

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -362,8 +362,9 @@ class StreamingResponse:
         except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
             logger.debug("Client disconnected during streaming")
         finally:
-            if hasattr(self._generator, "aclose"):
-                await self._generator.aclose()
+            aclose = getattr(self._generator, "aclose", None)
+            if aclose is not None:
+                await aclose()
 
 
 class FileResponse(Response):
@@ -753,6 +754,57 @@ class App:
 
     # ── Request Dispatch ─────────────────────────────────────────────────
 
+    def _match_route(
+        self, request: Request
+    ) -> tuple[_Route | None, re.Match[str] | None, bool]:
+        """Find the first route matching the request path and method.
+
+        Returns:
+            (matched_route, regex_match, path_existed).  *path_existed* is
+            True when a route matched the path but not the HTTP method.
+        """
+        path_existed = False
+        for route in self._routes:
+            m = route.pattern.match(request.path)
+            if m is None:
+                continue
+            path_existed = True
+            if route.method != "*" and route.method != request.method:
+                continue
+            return route, m, True
+        return None, None, path_existed
+
+    async def _invoke_route(
+        self, route: _Route, match: re.Match[str], request: Request
+    ) -> Response | StreamingResponse:
+        """Extract path params, call the handler, return a response."""
+        for name, converter, value in zip(
+            route.param_names, route.param_converters, match.groups()
+        ):
+            request.path_params[name] = converter(value)
+
+        try:
+            result = await _invoke(route.handler, request, **request.path_params)
+            return _coerce_response(result)
+        except HTTPException as exc:
+            return await self._handle_error(request, exc)
+        except Exception as exc:
+            logger.exception(
+                "Unhandled exception in handler %s",
+                getattr(route.handler, "__name__", repr(route.handler)),
+            )
+            return await self._handle_error(request, exc)
+
+    async def _run_after_hooks(
+        self, request: Request, response: Response | StreamingResponse
+    ) -> Response | StreamingResponse:
+        """Run after-request hooks, allowing them to replace the response."""
+        for hook in self._after_request_handlers:
+            hook_result = await _invoke(hook, request, response)
+            if hook_result is not None:
+                response = _coerce_response(hook_result)
+        return response
+
     async def _dispatch(self, request: Request) -> Response | StreamingResponse:
         """Match a request to a route and invoke the handler."""
         # -- before_request hooks --
@@ -768,44 +820,14 @@ class App:
                 return file_resp
 
         # -- Route matching --
-        matched_path = False
-        for route in self._routes:
-            m = route.pattern.match(request.path)
-            if m is None:
-                continue
-            matched_path = True
-            if route.method != "*" and route.method != request.method:
-                continue
+        route, match, path_existed = self._match_route(request)
 
-            # Extract path params
-            groups = m.groups()
-            for name, converter, value in zip(
-                route.param_names, route.param_converters, groups
-            ):
-                request.path_params[name] = converter(value)
-
-            # Invoke handler
-            try:
-                result = await _invoke(route.handler, request, **request.path_params)
-                response = _coerce_response(result)
-            except HTTPException as exc:
-                response = await self._handle_error(request, exc)
-            except Exception as exc:
-                logger.exception(
-                    "Unhandled exception in handler %s", route.handler.__name__
-                )
-                response = await self._handle_error(request, exc)
-
-            # -- after_request hooks --
-            for hook in self._after_request_handlers:
-                hook_result = await _invoke(hook, request, response)
-                if hook_result is not None:
-                    response = _coerce_response(hook_result)
-
-            return response
+        if route is not None and match is not None:
+            response = await self._invoke_route(route, match, request)
+            return await self._run_after_hooks(request, response)
 
         # -- No route matched --
-        if matched_path:
+        if path_existed:
             allowed = sorted(
                 {
                     r.method

--- a/httpserver/test_httpserver_benchmark.py
+++ b/httpserver/test_httpserver_benchmark.py
@@ -1,0 +1,202 @@
+"""Benchmark: zerodep httpserver vs microdot vs bottle."""
+
+import json
+import os
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "httpclient"))
+
+from httpclient import get, post
+
+# ── zerodep httpserver setup ──
+from httpserver import App, JSONResponse
+
+microdot = pytest.importorskip("microdot", reason="microdot not installed")
+bottle = pytest.importorskip("bottle", reason="bottle not installed")
+
+
+def _make_zerodep_app():
+    app = App()
+
+    @app.get("/ping")
+    async def ping(request):
+        return JSONResponse({"pong": True})
+
+    @app.post("/echo")
+    async def echo(request):
+        return JSONResponse(request.json())
+
+    @app.get("/text")
+    async def text(request):
+        return "Hello, World!"
+
+    return app
+
+
+def _start_zerodep(app):
+    import asyncio
+
+    ready = threading.Event()
+
+    def _run():
+        async def _start():
+            app._shutdown_event = asyncio.Event()
+            server = await asyncio.start_server(app._handle_connection, "127.0.0.1", 0)
+            app._server = server
+            addrs = server.sockets[0].getsockname()
+            app.host = addrs[0]
+            app.port = addrs[1]
+            ready.set()
+            async with server:
+                await app._shutdown_event.wait()
+
+        asyncio.run(_start())
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    ready.wait(timeout=5)
+    return f"http://127.0.0.1:{app.port}"
+
+
+# ── microdot setup ──
+
+
+def _make_microdot_app():
+    app = microdot.Microdot()
+
+    @app.get("/ping")
+    async def ping(request):
+        return {"pong": True}
+
+    @app.post("/echo")
+    async def echo(request):
+        return request.json
+
+    @app.get("/text")
+    async def text(request):
+        return "Hello, World!"
+
+    return app
+
+
+def _start_microdot(app):
+    import asyncio
+
+    ready = threading.Event()
+
+    def _run():
+        async def _start():
+            server = await app.start_server(
+                host="127.0.0.1", port=0, start_serving=False
+            )
+            addrs = server.sockets[0].getsockname()
+            app._port = addrs[1]
+            ready.set()
+            await server.serve_forever()
+
+        try:
+            asyncio.run(_start())
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            pass
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    ready.wait(timeout=5)
+    return f"http://127.0.0.1:{app._port}"
+
+
+# ── bottle setup ──
+
+
+def _make_bottle_app():
+    app = bottle.Bottle()
+
+    @app.get("/ping")
+    def ping():
+        bottle.response.content_type = "application/json"
+        return json.dumps({"pong": True})
+
+    @app.post("/echo")
+    def echo():
+        body = json.loads(bottle.request.body.read())
+        bottle.response.content_type = "application/json"
+        return json.dumps(body)
+
+    @app.get("/text")
+    def text():
+        return "Hello, World!"
+
+    return app
+
+
+def _start_bottle(app):
+    from wsgiref.simple_server import make_server
+
+    server = make_server("127.0.0.1", 0, app)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{port}"
+
+
+# ── fixtures ──
+
+
+@pytest.fixture(scope="module")
+def zerodep_url():
+    app = _make_zerodep_app()
+    return _start_zerodep(app)
+
+
+@pytest.fixture(scope="module")
+def microdot_url():
+    app = _make_microdot_app()
+    return _start_microdot(app)
+
+
+@pytest.fixture(scope="module")
+def bottle_url():
+    app = _make_bottle_app()
+    return _start_bottle(app)
+
+
+# ── Benchmarks ──
+
+PAYLOAD = {"key": "value", "nested": {"a": 1, "b": [1, 2, 3]}}
+
+
+class TestGetJSON:
+    def test_zerodep(self, benchmark, zerodep_url):
+        benchmark(get, f"{zerodep_url}/ping")
+
+    def test_microdot(self, benchmark, microdot_url):
+        benchmark(get, f"{microdot_url}/ping")
+
+    def test_bottle(self, benchmark, bottle_url):
+        benchmark(get, f"{bottle_url}/ping")
+
+
+class TestPostJSON:
+    def test_zerodep(self, benchmark, zerodep_url):
+        benchmark(post, f"{zerodep_url}/echo", json=PAYLOAD)
+
+    def test_microdot(self, benchmark, microdot_url):
+        benchmark(post, f"{microdot_url}/echo", json=PAYLOAD)
+
+    def test_bottle(self, benchmark, bottle_url):
+        benchmark(post, f"{bottle_url}/echo", json=PAYLOAD)
+
+
+class TestGetText:
+    def test_zerodep(self, benchmark, zerodep_url):
+        benchmark(get, f"{zerodep_url}/text")
+
+    def test_microdot(self, benchmark, microdot_url):
+        benchmark(get, f"{microdot_url}/text")
+
+    def test_bottle(self, benchmark, bottle_url):
+        benchmark(get, f"{bottle_url}/text")

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -1,0 +1,433 @@
+"""Correctness tests for zerodep httpserver module."""
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "httpclient"))
+
+from httpclient import delete, get, patch, post, put
+from httpserver import (
+    App,
+    HTTPException,
+    JSONResponse,
+    Request,
+    Response,
+    _coerce_response,
+    _compile_route,
+    abort,
+)
+
+# ── Unit Tests ───────────────────────────────────────────────────────────────
+
+
+class TestRequest:
+    """Request parsing and accessors."""
+
+    def test_json(self):
+        req = Request("POST", "/", "", {}, b'{"key": "val"}', ("127.0.0.1", 0))
+        assert req.json() == {"key": "val"}
+        # cached
+        assert req.json() is req.json()
+
+    def test_text(self):
+        req = Request("GET", "/", "", {}, b"hello", ("127.0.0.1", 0))
+        assert req.text() == "hello"
+
+    def test_form(self):
+        req = Request("POST", "/", "", {}, b"a=1&b=2&b=3", ("127.0.0.1", 0))
+        form = req.form()
+        assert form["a"] == ["1"]
+        assert form["b"] == ["2", "3"]
+
+    def test_query_params(self):
+        req = Request("GET", "/", "x=1&y=2&y=3", {}, b"", ("127.0.0.1", 0))
+        assert req.query_params["x"] == ["1"]
+        assert req.query_params["y"] == ["2", "3"]
+
+
+class TestResponse:
+    """Response construction."""
+
+    def test_str_body(self):
+        r = Response(body="hello")
+        assert r.body == b"hello"
+
+    def test_bytes_body(self):
+        r = Response(body=b"\x00\x01")
+        assert r.body == b"\x00\x01"
+
+    def test_content_type(self):
+        r = Response(body="x", content_type="text/html")
+        assert r.headers["Content-Type"] == "text/html"
+
+    def test_json_response(self):
+        r = JSONResponse({"a": 1})
+        data = json.loads(r.body)
+        assert data == {"a": 1}
+        assert "application/json" in r.headers["Content-Type"]
+
+    def test_json_response_unicode(self):
+        r = JSONResponse({"msg": "你好"})
+        assert "你好" in r.body.decode("utf-8")
+
+
+class TestCoerceResponse:
+    """Handler return value coercion."""
+
+    def test_none(self):
+        r = _coerce_response(None)
+        assert r.status_code == 204
+
+    def test_dict(self):
+        r = _coerce_response({"a": 1})
+        assert isinstance(r, JSONResponse)
+        assert json.loads(r.body) == {"a": 1}
+
+    def test_str(self):
+        r = _coerce_response("hello")
+        assert r.body == b"hello"
+
+    def test_bytes(self):
+        r = _coerce_response(b"\x00")
+        assert r.body == b"\x00"
+
+    def test_tuple2(self):
+        r = _coerce_response(({"ok": True}, 201))
+        assert r.status_code == 201
+
+    def test_tuple3(self):
+        r = _coerce_response(("ok", 200, {"X-Custom": "val"}))
+        assert r.headers["X-Custom"] == "val"
+
+    def test_response_passthrough(self):
+        orig = Response(body="x")
+        assert _coerce_response(orig) is orig
+
+    def test_invalid_type(self):
+        with pytest.raises(TypeError):
+            _coerce_response(12345)
+
+
+class TestRouteCompilation:
+    """Path pattern to regex compilation."""
+
+    def test_static_path(self):
+        pattern, names, _ = _compile_route("/hello")
+        assert names == []
+        assert pattern.match("/hello")
+        assert not pattern.match("/other")
+
+    def test_str_param(self):
+        pattern, names, converters = _compile_route("/users/<name>")
+        assert names == ["name"]
+        m = pattern.match("/users/alice")
+        assert m
+        assert converters[0](m.group(1)) == "alice"
+
+    def test_int_param(self):
+        pattern, names, converters = _compile_route("/users/<int:id>")
+        assert names == ["id"]
+        m = pattern.match("/users/42")
+        assert m
+        assert converters[0](m.group(1)) == 42
+
+    def test_float_param(self):
+        pattern, names, converters = _compile_route("/price/<float:amount>")
+        m = pattern.match("/price/3.14")
+        assert m
+        assert converters[0](m.group(1)) == pytest.approx(3.14)
+
+    def test_path_param(self):
+        pattern, names, converters = _compile_route("/files/<path:filepath>")
+        m = pattern.match("/files/a/b/c.txt")
+        assert m
+        assert converters[0](m.group(1)) == "a/b/c.txt"
+
+    def test_multiple_params(self):
+        pattern, names, _ = _compile_route("/users/<int:uid>/posts/<int:pid>")
+        assert names == ["uid", "pid"]
+        m = pattern.match("/users/1/posts/99")
+        assert m
+        assert m.groups() == ("1", "99")
+
+    def test_unknown_type(self):
+        with pytest.raises(ValueError, match="Unknown"):
+            _compile_route("/x/<badtype:y>")
+
+
+class TestHTTPException:
+    """Exception and abort helper."""
+
+    def test_exception_message(self):
+        exc = HTTPException(404)
+        assert exc.status_code == 404
+        assert exc.message == "Not Found"
+
+    def test_custom_message(self):
+        exc = HTTPException(400, "Invalid input")
+        assert exc.message == "Invalid input"
+
+    def test_abort(self):
+        with pytest.raises(HTTPException) as exc_info:
+            abort(403, "Forbidden")
+        assert exc_info.value.status_code == 403
+
+
+# ── Integration Tests (require running server) ──────────────────────────────
+
+
+class TestBasicRouting:
+    """Basic GET/POST/PUT/DELETE/PATCH routing."""
+
+    def test_get_json(self, server_url):
+        r = get(f"{server_url}/status")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+
+    def test_get_text(self, server_url):
+        r = get(f"{server_url}/text")
+        assert r.status_code == 200
+        assert r.text == "Hello, World!"
+
+    def test_get_bytes(self, server_url):
+        r = get(f"{server_url}/bytes")
+        assert r.status_code == 200
+        assert r.content == b"\x00\x01\x02"
+
+    def test_none_204(self, server_url):
+        r = get(f"{server_url}/none")
+        assert r.status_code == 204
+
+    def test_tuple2_status(self, server_url):
+        r = get(f"{server_url}/tuple2")
+        assert r.status_code == 201
+        assert r.json()["created"] is True
+
+    def test_tuple3_headers(self, server_url):
+        r = get(f"{server_url}/tuple3")
+        assert r.status_code == 200
+        assert r.headers.get("x-custom") == "test-value"
+
+    def test_post_json(self, server_url):
+        r = post(f"{server_url}/echo", json={"msg": "hi"})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["body"] == {"msg": "hi"}
+        assert data["method"] == "POST"
+
+    def test_put_json(self, server_url):
+        r = put(f"{server_url}/echo", json={"msg": "updated"})
+        assert r.status_code == 200
+        assert r.json()["method"] == "PUT"
+
+    def test_delete(self, server_url):
+        r = delete(f"{server_url}/echo")
+        assert r.status_code == 200
+        assert r.json()["method"] == "DELETE"
+
+    def test_patch_json(self, server_url):
+        r = patch(f"{server_url}/echo", json={"field": "val"})
+        assert r.status_code == 200
+        assert r.json()["method"] == "PATCH"
+
+    def test_response_obj(self, server_url):
+        r = get(f"{server_url}/response-obj")
+        assert r.status_code == 200
+        assert r.text == "custom"
+        assert "text/html" in r.headers.get("content-type", "")
+
+
+class TestPathParams:
+    """Dynamic path parameter extraction."""
+
+    def test_int_param(self, server_url):
+        r = get(f"{server_url}/users/42")
+        assert r.json() == {"id": 42}
+
+    def test_path_param(self, server_url):
+        r = get(f"{server_url}/files/a/b/c.txt")
+        assert r.json() == {"path": "a/b/c.txt"}
+
+
+class TestQueryParams:
+    """Query string parsing."""
+
+    def test_query(self, server_url):
+        r = get(f"{server_url}/query?x=1&y=2&y=3")
+        params = r.json()["params"]
+        assert params["x"] == ["1"]
+        assert params["y"] == ["2", "3"]
+
+
+class TestHeaders:
+    """Request header handling."""
+
+    def test_custom_header(self, server_url):
+        r = get(f"{server_url}/headers", headers={"X-Test": "hello"})
+        assert r.json()["x-test"] == "hello"
+
+
+class TestFormData:
+    """URL-encoded form body."""
+
+    def test_form(self, server_url):
+        r = post(
+            f"{server_url}/form",
+            data="a=1&b=2",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        form = r.json()["form"]
+        assert form["a"] == ["1"]
+        assert form["b"] == ["2"]
+
+
+class TestSyncHandler:
+    """Sync (non-async) handler support."""
+
+    def test_sync(self, server_url):
+        r = get(f"{server_url}/sync")
+        assert r.json() == {"sync": True}
+
+
+class TestErrorHandling:
+    """Error responses."""
+
+    def test_404(self, server_url):
+        r = get(f"{server_url}/nonexistent")
+        assert r.status_code == 404
+
+    def test_405(self, server_url):
+        r = post(f"{server_url}/status")
+        assert r.status_code == 405
+        assert "Allow" in r.headers or "allow" in r.headers
+
+    def test_abort_404(self, server_url):
+        r = get(f"{server_url}/error/404")
+        assert r.status_code == 404
+        assert r.json()["error"] == "Custom not found"
+
+    def test_500(self, server_url):
+        r = get(f"{server_url}/error/500")
+        assert r.status_code == 500
+        assert "error" in r.json()
+
+
+class TestStaticFiles:
+    """Static file serving."""
+
+    def test_text_file(self, server_url):
+        r = get(f"{server_url}/static/hello.txt")
+        assert r.status_code == 200
+        assert r.text == "hello world"
+        assert "text/plain" in r.headers.get("content-type", "")
+
+    def test_json_file(self, server_url):
+        r = get(f"{server_url}/static/data.json")
+        assert r.status_code == 200
+        assert r.json() == {"key": "value"}
+
+    def test_nested_file(self, server_url):
+        r = get(f"{server_url}/static/sub/nested.txt")
+        assert r.status_code == 200
+        assert r.text == "nested content"
+
+    def test_missing_file(self, server_url):
+        r = get(f"{server_url}/static/nope.txt")
+        assert r.status_code == 404
+
+    def test_traversal(self, server_url):
+        r = get(f"{server_url}/static/../../../etc/passwd")
+        assert r.status_code == 404
+
+
+class TestStreaming:
+    """Streaming responses (SSE and chunked)."""
+
+    def test_sse_stream(self, server_url):
+        r = get(f"{server_url}/sse")
+        assert r.status_code == 200
+        assert "text/event-stream" in r.headers.get("content-type", "")
+        text = r.text
+        for i in range(3):
+            assert f"data: event-{i}" in text
+
+    def test_chunked_stream(self, server_url):
+        r = get(f"{server_url}/stream-chunked")
+        assert r.status_code == 200
+        text = r.text
+        for i in range(3):
+            assert f"chunk-{i}" in text
+
+
+class TestMiddleware:
+    """Before/after request middleware hooks."""
+
+    def test_before_after_request(self):
+        """Test middleware hooks with a fresh app."""
+        app = App()
+        log = []
+
+        @app.before_request
+        async def before(request):
+            log.append("before")
+
+        @app.get("/mid")
+        async def handler(request):
+            log.append("handler")
+            return {"ok": True}
+
+        @app.after_request
+        async def after(request, response):
+            log.append("after")
+            if isinstance(response, Response):
+                response.headers["X-After"] = "yes"
+            return response
+
+        async def _test():
+            req = Request("GET", "/mid", "", {}, b"", ("127.0.0.1", 0), app=app)
+            resp = await app._dispatch(req)
+            assert log == ["before", "handler", "after"]
+            assert isinstance(resp, Response)
+            assert resp.headers["X-After"] == "yes"
+
+        asyncio.run(_test())
+
+    def test_before_request_shortcircuit(self):
+        """before_request returning a Response skips the handler."""
+        app = App()
+
+        @app.before_request
+        async def auth_check(request):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+        @app.get("/protected")
+        async def protected(request):
+            return {"secret": True}
+
+        async def _test():
+            req = Request("GET", "/protected", "", {}, b"", ("127.0.0.1", 0), app=app)
+            resp = await app._dispatch(req)
+            assert resp.status_code == 401
+
+        asyncio.run(_test())
+
+    def test_errorhandler(self):
+        """Custom error handler."""
+        app = App()
+
+        @app.errorhandler(404)
+        async def custom_404(request, exc):
+            return JSONResponse({"custom": "not found"}, status_code=404)
+
+        async def _test():
+            req = Request("GET", "/nope", "", {}, b"", ("127.0.0.1", 0), app=app)
+            resp = await app._dispatch(req)
+            assert resp.status_code == 404
+            assert json.loads(resp.body)["custom"] == "not found"
+
+        asyncio.run(_test())

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-04-29T02:59:19.219795+00:00",
+  "generated": "2026-05-02T07:15:41.269429+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -155,6 +155,18 @@
       "category": "network",
       "last_updated": "2026-04-15T09:45:45Z",
       "content_hash": "368292df96dffcbf07bde26a7a7c2f15c90639e3b0f73bdf4dbc3443cd4347fc"
+    },
+    "httpserver": {
+      "description": "Zero-dependency async HTTP server with decorator-based routing",
+      "files": [
+        "httpserver/httpserver.py"
+      ],
+      "version": "0.1.0",
+      "deps": [],
+      "tier": "subsystem",
+      "category": "network",
+      "last_updated": null,
+      "content_hash": "d00439706b5168d5235eb700e559a8dac95d4ff173e39725b7a11826632f6456"
     },
     "jsonc": {
       "description": "JSONC (JSON with Comments) parser — zero dependencies, stdlib only, Python 3.10+",
@@ -415,7 +427,7 @@
       "deps": [],
       "tier": "simple",
       "category": "text",
-      "last_updated": "2026-04-29T02:10:32+08:00",
+      "last_updated": "2026-04-29T10:59:26+08:00",
       "content_hash": "2373a0036723d65ddb14deb3aec0d0fa1c9038264e25e3b8c5fd015e7b2e2ff2"
     },
     "tabulate": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,17 +138,21 @@ bench-png = [
 bench-useragent = [
     "ua-generator>=2.0.0",
 ]
+bench-httpserver = [
+    "microdot==2.6.1",
+    "bottle==0.13.4",
+]
 dev = [
     "ruff>=0.1.0",
     "ty>=0.0.24",
     "complexipy>=5.2.0",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
-    "zerodep[test,bench-aes,bench-qr,bench-http,bench-dotenv,bench-yaml,bench-jsonc,bench-structlog,bench-retry,bench-toon,bench-tabulate,bench-soup,bench-validate,bench-sse,bench-markdown,bench-diff,bench-scheduler,bench-search,bench-frontmatter,bench-config,bench-cache,bench-xml,bench-jsonrpc,bench-a2a,bench-acp,bench-protobuf,bench-semver,bench-persistdict,bench-runner,bench-readability,bench-png,bench-useragent]",
+    "zerodep[test,bench-aes,bench-qr,bench-http,bench-dotenv,bench-yaml,bench-jsonc,bench-structlog,bench-retry,bench-toon,bench-tabulate,bench-soup,bench-validate,bench-sse,bench-markdown,bench-diff,bench-scheduler,bench-search,bench-frontmatter,bench-config,bench-cache,bench-xml,bench-jsonrpc,bench-a2a,bench-acp,bench-protobuf,bench-semver,bench-persistdict,bench-runner,bench-readability,bench-png,bench-useragent,bench-httpserver]",
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt", "useragent", "synctex"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt", "useragent", "synctex", "httpserver"]
 
 [tool.ruff]
 target-version = "py310"
@@ -172,6 +176,7 @@ max-complexity = 20
 "acp/acp.py" = ["E501"]
 "jsonschema/jsonschema.py" = ["E501"]
 "png/png.py" = ["E501", "C901"]
+"httpserver/httpserver.py" = ["E501"]
 "**/test_*.py" = ["E402"]
 "**/test_*_benchmark.py" = ["E501"]
 "**/conftest.py" = ["C901"]
@@ -222,4 +227,5 @@ extra-paths = [
     "./llmstxt",
     "./useragent",
     "./synctex",
+    "./httpserver",
 ]


### PR DESCRIPTION
## Summary

- Add `httpserver` module: zero-dependency async HTTP/1.1 server built on `asyncio.start_server()`
- Decorator-based routing, JSON request/response, streaming (SSE), static file serving, middleware, graceful shutdown
- Sync handlers auto-wrapped with `asyncio.to_thread()`
- 58 correctness tests, 9 benchmarks vs microdot + bottle

## Known Issues (will fix in follow-up commits)

- `complexipy`: `App._dispatch` complexity 24 exceeds max 20 — needs refactoring
- `ty`: 2 type diagnostics (`call-non-callable` on generator aclose, `unresolved-attribute` on handler `__name__`)

## Benchmark Results

| Operation | zerodep | microdot | bottle |
|-----------|---------|----------|--------|
| GET JSON  | ~320μs  | ~295μs   | ~271μs |
| POST JSON | ~333μs  | ~491μs   | ~311μs |
| GET text  | ~440μs  | ~770μs   | ~351μs |

## Test plan

- [x] `make test-httpserver` — 58 tests pass
- [x] `make benchmark-httpserver` — 9 benchmarks pass
- [x] `ruff check` — clean
- [ ] `ty check` — 2 diagnostics to fix
- [ ] `complexipy` — 1 function to refactor

Closes #66.