### PR TITLE
feat(websocket,cdp): add WebSocket client and CDP browser automation modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test benchmark lint fmt clean help manifest version-check dep-graph dep-check docs-index docs-index-check test-tabulate benchmark-tabulate test-soup benchmark-soup test-prompt test-validate benchmark-validate test-markdown benchmark-markdown test-diff benchmark-diff test-vcs test-ansi test-frontmatter benchmark-frontmatter test-cache benchmark-cache test-readability benchmark-readability benchmark-readability-compare test-jsonschema benchmark-jsonschema test-png benchmark-png test-httpserver benchmark-httpserver
+.PHONY: all test benchmark lint fmt clean help manifest version-check dep-graph dep-check docs-index docs-index-check test-tabulate benchmark-tabulate test-soup benchmark-soup test-prompt test-validate benchmark-validate test-markdown benchmark-markdown test-diff benchmark-diff test-vcs test-ansi test-frontmatter benchmark-frontmatter test-cache benchmark-cache test-readability benchmark-readability benchmark-readability-compare test-jsonschema benchmark-jsonschema test-png benchmark-png test-httpserver benchmark-httpserver test-websocket benchmark-websocket test-cdp benchmark-cdp
 
 help:
 	@echo "Available targets:"
@@ -46,6 +46,10 @@ help:
 	@echo "  benchmark-png    - Run PNG benchmarks (vs Pillow)"
 	@echo "  test-httpserver  - Run httpserver correctness tests"
 	@echo "  benchmark-httpserver - Run httpserver benchmarks (vs microdot, bottle)"
+	@echo "  test-websocket   - Run websocket correctness tests"
+	@echo "  benchmark-websocket - Run websocket benchmarks (vs websockets)"
+	@echo "  test-cdp         - Run CDP correctness tests"
+	@echo "  benchmark-cdp    - Run CDP benchmarks"
 	@echo "  docs-index       - Generate modules/index.md for EN and ZH docs"
 	@echo "  docs-index-check - Check that modules/index.md is up-to-date"
 	@echo "  manifest         - Regenerate manifest.json"
@@ -57,7 +61,7 @@ help:
 	@echo "  clean            - Clean generated files"
 
 test:
-	pytest aes/test_aes_correctness.py qr/test_qr_correctness.py httpclient/test_httpclient_correctness.py dotenv/test_dotenv_correctness.py yaml/test_yaml_correctness.py jsonc/test_jsonc_correctness.py retry/test_retry_correctness.py toon/test_toon_correctness.py tabulate/test_tabulate_correctness.py soup/test_soup_correctness.py prompt/test_prompt_correctness.py validate/test_validate_correctness.py markdown/test_markdown_correctness.py diff/test_diff_correctness.py vcs/test_vcs_correctness.py ansi/test_ansi_correctness.py frontmatter/test_frontmatter_correctness.py cache/test_cache_correctness.py readability/test_readability_correctness.py jsonschema/test_jsonschema_correctness.py png/test_png_correctness.py -v
+	pytest aes/test_aes_correctness.py qr/test_qr_correctness.py httpclient/test_httpclient_correctness.py dotenv/test_dotenv_correctness.py yaml/test_yaml_correctness.py jsonc/test_jsonc_correctness.py retry/test_retry_correctness.py toon/test_toon_correctness.py tabulate/test_tabulate_correctness.py soup/test_soup_correctness.py prompt/test_prompt_correctness.py validate/test_validate_correctness.py markdown/test_markdown_correctness.py diff/test_diff_correctness.py vcs/test_vcs_correctness.py ansi/test_ansi_correctness.py frontmatter/test_frontmatter_correctness.py cache/test_cache_correctness.py readability/test_readability_correctness.py jsonschema/test_jsonschema_correctness.py png/test_png_correctness.py websocket/test_websocket_correctness.py cdp/test_cdp_correctness.py -v
 
 test-aes:
 	pytest aes/test_aes_correctness.py -v
@@ -99,7 +103,7 @@ test-markdown:
 	pytest markdown/test_markdown_correctness.py -v
 
 benchmark:
-	pytest aes/test_aes_benchmark.py qr/test_qr_benchmark.py httpclient/test_httpclient_benchmark.py dotenv/test_dotenv_benchmark.py yaml/test_yaml_benchmark.py jsonc/test_jsonc_benchmark.py retry/test_retry_benchmark.py toon/test_toon_benchmark.py tabulate/test_tabulate_benchmark.py soup/test_soup_benchmark.py validate/test_validate_benchmark.py markdown/test_markdown_benchmark.py diff/test_diff_benchmark.py frontmatter/test_frontmatter_benchmark.py cache/test_cache_benchmark.py readability/test_readability_benchmark.py jsonschema/test_jsonschema_benchmark.py png/test_png_benchmark.py -v
+	pytest aes/test_aes_benchmark.py qr/test_qr_benchmark.py httpclient/test_httpclient_benchmark.py dotenv/test_dotenv_benchmark.py yaml/test_yaml_benchmark.py jsonc/test_jsonc_benchmark.py retry/test_retry_benchmark.py toon/test_toon_benchmark.py tabulate/test_tabulate_benchmark.py soup/test_soup_benchmark.py validate/test_validate_benchmark.py markdown/test_markdown_benchmark.py diff/test_diff_benchmark.py frontmatter/test_frontmatter_benchmark.py cache/test_cache_benchmark.py readability/test_readability_benchmark.py jsonschema/test_jsonschema_benchmark.py png/test_png_benchmark.py websocket/test_websocket_benchmark.py cdp/test_cdp_benchmark.py -v
 
 benchmark-aes:
 	pytest aes/test_aes_benchmark.py -v
@@ -188,6 +192,18 @@ test-httpserver:
 
 benchmark-httpserver:
 	pytest httpserver/test_httpserver_benchmark.py -v
+
+test-websocket:
+	pytest websocket/test_websocket_correctness.py -v
+
+benchmark-websocket:
+	pytest websocket/test_websocket_benchmark.py -v
+
+test-cdp:
+	pytest cdp/test_cdp_correctness.py -v
+
+benchmark-cdp:
+	pytest cdp/test_cdp_benchmark.py -v
 
 manifest:
 	python zerodep.py manifest

--- a/_scripts/module_index_config.yaml
+++ b/_scripts/module_index_config.yaml
@@ -13,12 +13,12 @@ categories:
   - id: network
     name_en: "Web & Networking"
     name_zh: "网络与通信"
-    modules: [httpclient, sse, httpserver, useragent]
+    modules: [httpclient, sse, httpserver, useragent, websocket]
 
   - id: protocol
     name_en: "Agent Protocols"
     name_zh: "智能体协议"
-    modules: [jsonrpc, a2a, acp, skills, llmstxt]
+    modules: [jsonrpc, a2a, acp, skills, llmstxt, cdp]
 
   - id: serialization
     name_en: "Serialization"
@@ -230,3 +230,11 @@ modules:
     benchmark: flask / microdot / bottle
     desc_en: "Async HTTP server with decorator-based routing, streaming, and static files"
     desc_zh: "异步 HTTP 服务器（装饰器路由、流式响应、静态文件）"
+  websocket:
+    benchmark: websockets
+    desc_en: "RFC 6455 WebSocket client with sync + async support"
+    desc_zh: "RFC 6455 WebSocket 客户端（同步 + 异步）"
+  cdp:
+    benchmark: websockets
+    desc_en: "Chrome DevTools Protocol client for headless browser automation"
+    desc_zh: "Chrome DevTools Protocol 客户端（无头浏览器自动化）"

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -1,0 +1,976 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = ["websocket"]
+# tier = "medium"
+# category = "protocol"
+# ///
+"""Zero-dependency Chrome DevTools Protocol (CDP) client.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Provides sync and async CDP clients for communicating with CDP-compatible
+browsers (Chrome, Chromium, Lightpanda, etc.) over WebSocket. Supports
+tab management, page navigation, JavaScript evaluation, and high-level
+rendered content extraction.
+
+Usage::
+
+    # High-level: extract rendered text from an SPA
+    from cdp import CDPClient
+
+    with CDPClient("ws://localhost:9222") as client:
+        text = client.get_rendered_text("https://react.dev", timeout=15)
+        print(text)
+
+    # Low-level: manage targets and evaluate JS
+    from cdp import CDPClient
+
+    with CDPClient("ws://localhost:9222") as client:
+        target_id = client.create_target("https://example.com")
+        client.wait_for_load(target_id, timeout=10)
+        html = client.evaluate(target_id, "document.documentElement.outerHTML")
+        client.close_target(target_id)
+
+    # Async
+    from cdp import AsyncCDPClient
+
+    async with AsyncCDPClient("ws://localhost:9222") as client:
+        text = await client.get_rendered_text("https://example.com")
+
+Requires Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import collections
+import itertools
+import json
+import logging
+import os
+import sys
+import time
+
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_PAGE_LOAD_TIMEOUT",
+    # Exceptions
+    "CDPError",
+    "CDPConnectionError",
+    "CDPTimeoutError",
+    "CDPProtocolError",
+    # Clients
+    "CDPClient",
+    "AsyncCDPClient",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ── Sibling websocket import (guarded) ─────────────────────────────────────
+
+
+def _ensure_sibling_path(name: str) -> str:
+    """Return the sibling module directory and prepend it to ``sys.path``."""
+    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
+    if sibling_dir not in sys.path:
+        sys.path.insert(0, sibling_dir)
+    return sibling_dir
+
+
+try:
+    _websocket_dir = _ensure_sibling_path("websocket")
+    from websocket import AsyncWebSocketClient as _AsyncWebSocketClient
+    from websocket import WebSocketClient as _WebSocketClient
+    from websocket import WebSocketConnectionError as _WebSocketConnectionError
+    from websocket import WebSocketError as _WebSocketError
+    from websocket import WebSocketTimeoutError as _WebSocketTimeoutError
+
+    _HAS_WEBSOCKET = True
+except (ImportError, AttributeError):
+    _HAS_WEBSOCKET = False
+
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DEFAULT_TIMEOUT: float = 30.0
+DEFAULT_PAGE_LOAD_TIMEOUT: float = 30.0
+
+
+# ── Exceptions ─────────────────────────────────────────────────────────────
+
+
+class CDPError(Exception):
+    """Base exception for all CDP operations."""
+
+
+class CDPConnectionError(CDPError):
+    """Raised on WebSocket connection failures to the CDP endpoint."""
+
+    def __init__(self, message: str, *, url: str = "") -> None:
+        self.url = url
+        super().__init__(message)
+
+
+class CDPTimeoutError(CDPError):
+    """Raised when a CDP operation times out."""
+
+    def __init__(self, message: str, *, timeout: float = 0.0) -> None:
+        self.timeout = timeout
+        super().__init__(message)
+
+
+class CDPProtocolError(CDPError):
+    """Raised on CDP error responses."""
+
+    def __init__(
+        self,
+        code: int,
+        message: str,
+        *,
+        data: str | None = None,
+    ) -> None:
+        self.code = code
+        self.error_message = message
+        self.data = data
+        super().__init__(f"CDP error {code}: {message}")
+
+
+# ── Sync CDP Client ───────────────────────────────────────────────────────
+
+
+class CDPClient:
+    """Synchronous Chrome DevTools Protocol client.
+
+    Args:
+        url: CDP WebSocket endpoint URL (e.g. ``ws://localhost:9222``).
+            If the URL does not contain a path, the client will auto-discover
+            the browser's debugger WebSocket URL via the ``/json/version``
+            endpoint.
+        timeout: Default timeout for CDP commands in seconds.
+
+    Example::
+
+        with CDPClient("ws://localhost:9222") as client:
+            text = client.get_rendered_text("https://example.com")
+            print(text)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._ws: _WebSocketClient | None = None
+        self._cmd_id = itertools.count(1)
+        self._targets: dict[str, str] = {}  # target_id -> session_id
+        self._event_buffer: collections.deque[dict] = collections.deque()
+
+    def connect(self, *, timeout: float | None = None) -> None:
+        """Open the WebSocket connection to the CDP endpoint.
+
+        Args:
+            timeout: Connection timeout in seconds. Defaults to the
+                client's default timeout.
+
+        Raises:
+            CDPConnectionError: If the connection fails.
+            ImportError: If the websocket module is not available.
+        """
+        if self._ws is not None:
+            return
+
+        if not _HAS_WEBSOCKET:
+            raise ImportError(
+                "cdp module requires sibling 'websocket' module; "
+                "install it with: zerodep add websocket"
+            )
+
+        ws_url = self._resolve_ws_url(self._url, timeout=timeout or self._timeout)
+
+        try:
+            ws = _WebSocketClient(ws_url)
+            ws.connect(timeout=timeout or self._timeout)
+            self._ws = ws
+        except _WebSocketConnectionError as exc:
+            raise CDPConnectionError(
+                f"failed to connect to CDP endpoint: {exc}",
+                url=ws_url,
+            ) from exc
+        except _WebSocketTimeoutError as exc:
+            raise CDPTimeoutError(
+                f"connection to CDP endpoint timed out: {exc}",
+                timeout=timeout or self._timeout,
+            ) from exc
+
+    def send_command(
+        self,
+        method: str,
+        params: dict | None = None,
+        *,
+        session_id: str | None = None,
+        timeout: float | None = None,
+    ) -> dict:
+        """Send a CDP command and wait for the response.
+
+        Args:
+            method: CDP method name (e.g. ``Page.navigate``).
+            params: Optional command parameters.
+            session_id: Optional session ID for target-specific commands.
+            timeout: Command timeout in seconds.
+
+        Returns:
+            The ``result`` dict from the CDP response.
+
+        Raises:
+            CDPTimeoutError: If the command times out.
+            CDPProtocolError: If the CDP response contains an error.
+            CDPError: If not connected.
+        """
+        self._ensure_connected()
+        assert self._ws is not None
+
+        cmd_id = next(self._cmd_id)
+        msg: dict = {"id": cmd_id, "method": method}
+        if params:
+            msg["params"] = params
+        if session_id:
+            msg["sessionId"] = session_id
+
+        self._ws.send(json.dumps(msg))
+        return self._recv_response(cmd_id, timeout=timeout or self._timeout)
+
+    def create_target(self, url: str = "about:blank") -> str:
+        """Create a new browser target (tab) and attach to it.
+
+        Args:
+            url: Initial URL to load in the new target.
+
+        Returns:
+            The target ID.
+        """
+        result = self.send_command("Target.createTarget", {"url": url})
+        target_id = result["targetId"]
+
+        attach_result = self.send_command(
+            "Target.attachToTarget",
+            {"targetId": target_id, "flatten": True},
+        )
+        session_id = attach_result["sessionId"]
+        self._targets[target_id] = session_id
+        logger.debug("created target %s with session %s", target_id, session_id)
+        return target_id
+
+    def close_target(self, target_id: str) -> None:
+        """Close a browser target (tab).
+
+        Args:
+            target_id: The target ID to close.
+        """
+        if target_id not in self._targets:
+            return
+        try:
+            self.send_command("Target.closeTarget", {"targetId": target_id})
+        except CDPError:
+            logger.debug("failed to close target %s", target_id, exc_info=True)
+        self._targets.pop(target_id, None)
+
+    def navigate(
+        self,
+        target_id: str,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Navigate a target to a URL and wait for the page to load.
+
+        Args:
+            target_id: The target ID.
+            url: URL to navigate to.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        load_timeout = timeout or DEFAULT_PAGE_LOAD_TIMEOUT
+
+        self.send_command("Page.enable", session_id=session_id)
+        self.send_command("Page.navigate", {"url": url}, session_id=session_id)
+        self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=load_timeout,
+        )
+
+    def wait_for_load(
+        self,
+        target_id: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Wait for a target's page to finish loading.
+
+        Args:
+            target_id: The target ID.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        self.send_command("Page.enable", session_id=session_id)
+        self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=timeout or DEFAULT_PAGE_LOAD_TIMEOUT,
+        )
+
+    def evaluate(self, target_id: str, expression: str) -> object:
+        """Evaluate a JavaScript expression in a target.
+
+        Args:
+            target_id: The target ID.
+            expression: JavaScript expression to evaluate.
+
+        Returns:
+            The result value.
+
+        Raises:
+            CDPProtocolError: If the evaluation throws an exception.
+        """
+        session_id = self._get_session_id(target_id)
+        result = self.send_command(
+            "Runtime.evaluate",
+            {"expression": expression, "returnByValue": True},
+            session_id=session_id,
+        )
+
+        if "exceptionDetails" in result:
+            exc_details = result["exceptionDetails"]
+            text = exc_details.get("text", "evaluation failed")
+            raise CDPProtocolError(-1, text)
+
+        return result.get("result", {}).get("value")
+
+    def get_rendered_text(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered text content.
+
+        Creates a temporary target, navigates to the URL, waits for load,
+        extracts ``document.body.innerText``, and closes the target.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered text content of the page.
+        """
+        target_id = self.create_target()
+        try:
+            self.navigate(target_id, url, timeout=timeout)
+            result = self.evaluate(target_id, "document.body.innerText")
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            self.close_target(target_id)
+
+    def get_rendered_html(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered HTML.
+
+        Creates a temporary target, navigates to the URL, waits for load,
+        extracts ``document.documentElement.outerHTML``, and closes the target.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered outer HTML of the page.
+        """
+        target_id = self.create_target()
+        try:
+            self.navigate(target_id, url, timeout=timeout)
+            result = self.evaluate(target_id, "document.documentElement.outerHTML")
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            self.close_target(target_id)
+
+    def set_user_agent(self, target_id: str, user_agent: str) -> None:
+        """Override the User-Agent for a target.
+
+        Args:
+            target_id: The target ID.
+            user_agent: The User-Agent string to set.
+        """
+        session_id = self._get_session_id(target_id)
+        self.send_command(
+            "Network.setUserAgentOverride",
+            {"userAgent": user_agent},
+            session_id=session_id,
+        )
+
+    def close(self) -> None:
+        """Close all targets and the WebSocket connection."""
+        if self._ws is None:
+            return
+
+        # Close all targets (best-effort)
+        for target_id in list(self._targets):
+            try:
+                self.send_command("Target.closeTarget", {"targetId": target_id})
+            except (CDPError, _WebSocketError):
+                pass
+        self._targets.clear()
+        self._event_buffer.clear()
+
+        try:
+            self._ws.close()
+        except _WebSocketError:
+            pass
+        self._ws = None
+
+    def __enter__(self) -> CDPClient:
+        self.connect()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # ── Sync internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if self._ws is None:
+            raise CDPError("not connected")
+
+    def _get_session_id(self, target_id: str) -> str:
+        session_id = self._targets.get(target_id)
+        if session_id is None:
+            raise CDPError(f"unknown target: {target_id}")
+        return session_id
+
+    def _recv_response(self, cmd_id: int, *, timeout: float) -> dict:
+        """Receive messages until the response matching *cmd_id* arrives.
+
+        Non-matching messages (events or other responses) are buffered.
+        """
+        assert self._ws is not None
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if msg.get("id") == cmd_id:
+                if "error" in msg:
+                    err = msg["error"]
+                    raise CDPProtocolError(
+                        err.get("code", -1),
+                        err.get("message", "unknown error"),
+                        data=err.get("data"),
+                    )
+                return msg.get("result", {})
+            # Not our response -- buffer it
+            self._event_buffer.append(msg)
+
+    def _wait_for_event(
+        self,
+        event_name: str,
+        *,
+        session_id: str | None = None,
+        timeout: float,
+    ) -> dict:
+        """Wait for a specific CDP event.
+
+        First checks the event buffer, then reads from the WebSocket.
+        """
+        assert self._ws is not None
+        # Check buffer first
+        for i, msg in enumerate(self._event_buffer):
+            if self._matches_event(msg, event_name, session_id):
+                del self._event_buffer[i]
+                return msg.get("params", {})
+
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if self._matches_event(msg, event_name, session_id):
+                return msg.get("params", {})
+            self._event_buffer.append(msg)
+
+    @staticmethod
+    def _matches_event(
+        msg: dict,
+        event_name: str,
+        session_id: str | None,
+    ) -> bool:
+        """Check if a message matches the expected event."""
+        if msg.get("method") != event_name:
+            return False
+        if session_id is not None and msg.get("sessionId") != session_id:
+            return False
+        return True
+
+    @staticmethod
+    def _resolve_ws_url(url: str, *, timeout: float) -> str:
+        """Resolve the browser's debugger WebSocket URL.
+
+        If the URL already has a path (e.g. ``/devtools/browser/...``),
+        return it as-is. Otherwise, query the ``/json/version`` endpoint
+        to discover the WebSocket debugger URL.
+        """
+        import urllib.parse
+
+        parsed = urllib.parse.urlparse(url)
+        if parsed.path and parsed.path != "/":
+            return url
+
+        # Auto-discover via /json/version
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 9222
+        http_url = f"http://{host}:{port}/json/version"
+
+        import http.client
+
+        try:
+            conn = http.client.HTTPConnection(host, port, timeout=timeout)
+            conn.request("GET", "/json/version")
+            resp = conn.getresponse()
+            data = json.loads(resp.read())
+            conn.close()
+            ws_url = data.get("webSocketDebuggerUrl", "")
+            if ws_url:
+                logger.debug("auto-discovered CDP endpoint: %s", ws_url)
+                return ws_url
+        except Exception:
+            logger.debug(
+                "failed to auto-discover CDP endpoint from %s",
+                http_url,
+                exc_info=True,
+            )
+
+        return url
+
+
+# ── Async CDP Client ──────────────────────────────────────────────────────
+
+
+class AsyncCDPClient:
+    """Asynchronous Chrome DevTools Protocol client.
+
+    Args:
+        url: CDP WebSocket endpoint URL (e.g. ``ws://localhost:9222``).
+        timeout: Default timeout for CDP commands in seconds.
+
+    Example::
+
+        async with AsyncCDPClient("ws://localhost:9222") as client:
+            text = await client.get_rendered_text("https://example.com")
+            print(text)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._ws: _AsyncWebSocketClient | None = None
+        self._cmd_id = itertools.count(1)
+        self._targets: dict[str, str] = {}
+        self._event_buffer: collections.deque[dict] = collections.deque()
+
+    async def connect(self, *, timeout: float | None = None) -> None:
+        """Open the WebSocket connection to the CDP endpoint.
+
+        Args:
+            timeout: Connection timeout in seconds.
+
+        Raises:
+            CDPConnectionError: If the connection fails.
+            ImportError: If the websocket module is not available.
+        """
+        if self._ws is not None:
+            return
+
+        if not _HAS_WEBSOCKET:
+            raise ImportError(
+                "cdp module requires sibling 'websocket' module; "
+                "install it with: zerodep add websocket"
+            )
+
+        ws_url = self._resolve_ws_url(self._url, timeout=timeout or self._timeout)
+
+        try:
+            ws = _AsyncWebSocketClient(ws_url)
+            await ws.connect(timeout=timeout or self._timeout)
+            self._ws = ws
+        except _WebSocketConnectionError as exc:
+            raise CDPConnectionError(
+                f"failed to connect to CDP endpoint: {exc}",
+                url=ws_url,
+            ) from exc
+        except _WebSocketTimeoutError as exc:
+            raise CDPTimeoutError(
+                f"connection to CDP endpoint timed out: {exc}",
+                timeout=timeout or self._timeout,
+            ) from exc
+
+    async def send_command(
+        self,
+        method: str,
+        params: dict | None = None,
+        *,
+        session_id: str | None = None,
+        timeout: float | None = None,
+    ) -> dict:
+        """Send a CDP command and wait for the response.
+
+        Args:
+            method: CDP method name.
+            params: Optional command parameters.
+            session_id: Optional session ID for target-specific commands.
+            timeout: Command timeout in seconds.
+
+        Returns:
+            The ``result`` dict from the CDP response.
+        """
+        self._ensure_connected()
+        assert self._ws is not None
+
+        cmd_id = next(self._cmd_id)
+        msg: dict = {"id": cmd_id, "method": method}
+        if params:
+            msg["params"] = params
+        if session_id:
+            msg["sessionId"] = session_id
+
+        await self._ws.send(json.dumps(msg))
+        return await self._recv_response(cmd_id, timeout=timeout or self._timeout)
+
+    async def create_target(self, url: str = "about:blank") -> str:
+        """Create a new browser target (tab) and attach to it.
+
+        Args:
+            url: Initial URL to load in the new target.
+
+        Returns:
+            The target ID.
+        """
+        result = await self.send_command("Target.createTarget", {"url": url})
+        target_id = result["targetId"]
+
+        attach_result = await self.send_command(
+            "Target.attachToTarget",
+            {"targetId": target_id, "flatten": True},
+        )
+        session_id = attach_result["sessionId"]
+        self._targets[target_id] = session_id
+        logger.debug("created target %s with session %s", target_id, session_id)
+        return target_id
+
+    async def close_target(self, target_id: str) -> None:
+        """Close a browser target (tab).
+
+        Args:
+            target_id: The target ID to close.
+        """
+        if target_id not in self._targets:
+            return
+        try:
+            await self.send_command("Target.closeTarget", {"targetId": target_id})
+        except CDPError:
+            logger.debug("failed to close target %s", target_id, exc_info=True)
+        self._targets.pop(target_id, None)
+
+    async def navigate(
+        self,
+        target_id: str,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Navigate a target to a URL and wait for the page to load.
+
+        Args:
+            target_id: The target ID.
+            url: URL to navigate to.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        load_timeout = timeout or DEFAULT_PAGE_LOAD_TIMEOUT
+
+        await self.send_command("Page.enable", session_id=session_id)
+        await self.send_command("Page.navigate", {"url": url}, session_id=session_id)
+        await self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=load_timeout,
+        )
+
+    async def wait_for_load(
+        self,
+        target_id: str,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Wait for a target's page to finish loading.
+
+        Args:
+            target_id: The target ID.
+            timeout: Page load timeout in seconds.
+        """
+        session_id = self._get_session_id(target_id)
+        await self.send_command("Page.enable", session_id=session_id)
+        await self._wait_for_event(
+            "Page.loadEventFired",
+            session_id=session_id,
+            timeout=timeout or DEFAULT_PAGE_LOAD_TIMEOUT,
+        )
+
+    async def evaluate(self, target_id: str, expression: str) -> object:
+        """Evaluate a JavaScript expression in a target.
+
+        Args:
+            target_id: The target ID.
+            expression: JavaScript expression to evaluate.
+
+        Returns:
+            The result value.
+
+        Raises:
+            CDPProtocolError: If the evaluation throws an exception.
+        """
+        session_id = self._get_session_id(target_id)
+        result = await self.send_command(
+            "Runtime.evaluate",
+            {"expression": expression, "returnByValue": True},
+            session_id=session_id,
+        )
+
+        if "exceptionDetails" in result:
+            exc_details = result["exceptionDetails"]
+            text = exc_details.get("text", "evaluation failed")
+            raise CDPProtocolError(-1, text)
+
+        return result.get("result", {}).get("value")
+
+    async def get_rendered_text(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered text content.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered text content of the page.
+        """
+        target_id = await self.create_target()
+        try:
+            await self.navigate(target_id, url, timeout=timeout)
+            result = await self.evaluate(target_id, "document.body.innerText")
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            await self.close_target(target_id)
+
+    async def get_rendered_html(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Navigate to a URL and extract the rendered HTML.
+
+        Args:
+            url: URL to render.
+            timeout: Page load timeout in seconds.
+
+        Returns:
+            The rendered outer HTML of the page.
+        """
+        target_id = await self.create_target()
+        try:
+            await self.navigate(target_id, url, timeout=timeout)
+            result = await self.evaluate(
+                target_id, "document.documentElement.outerHTML"
+            )
+            return result if isinstance(result, str) else str(result or "")
+        finally:
+            await self.close_target(target_id)
+
+    async def set_user_agent(self, target_id: str, user_agent: str) -> None:
+        """Override the User-Agent for a target.
+
+        Args:
+            target_id: The target ID.
+            user_agent: The User-Agent string to set.
+        """
+        session_id = self._get_session_id(target_id)
+        await self.send_command(
+            "Network.setUserAgentOverride",
+            {"userAgent": user_agent},
+            session_id=session_id,
+        )
+
+    async def close(self) -> None:
+        """Close all targets and the WebSocket connection."""
+        if self._ws is None:
+            return
+
+        for target_id in list(self._targets):
+            try:
+                await self.send_command("Target.closeTarget", {"targetId": target_id})
+            except (CDPError, _WebSocketError):
+                pass
+        self._targets.clear()
+        self._event_buffer.clear()
+
+        try:
+            await self._ws.close()
+        except _WebSocketError:
+            pass
+        self._ws = None
+
+    async def __aenter__(self) -> AsyncCDPClient:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    # ── Async internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if self._ws is None:
+            raise CDPError("not connected")
+
+    def _get_session_id(self, target_id: str) -> str:
+        session_id = self._targets.get(target_id)
+        if session_id is None:
+            raise CDPError(f"unknown target: {target_id}")
+        return session_id
+
+    async def _recv_response(self, cmd_id: int, *, timeout: float) -> dict:
+        """Receive messages until the response matching *cmd_id* arrives."""
+        assert self._ws is not None
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = await self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"command {cmd_id} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if msg.get("id") == cmd_id:
+                if "error" in msg:
+                    err = msg["error"]
+                    raise CDPProtocolError(
+                        err.get("code", -1),
+                        err.get("message", "unknown error"),
+                        data=err.get("data"),
+                    )
+                return msg.get("result", {})
+            self._event_buffer.append(msg)
+
+    async def _wait_for_event(
+        self,
+        event_name: str,
+        *,
+        session_id: str | None = None,
+        timeout: float,
+    ) -> dict:
+        """Wait for a specific CDP event."""
+        assert self._ws is not None
+        # Check buffer first
+        for i, msg in enumerate(self._event_buffer):
+            if self._matches_event(msg, event_name, session_id):
+                del self._event_buffer[i]
+                return msg.get("params", {})
+
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                )
+            try:
+                raw = await self._ws.recv(timeout=remaining)
+            except _WebSocketTimeoutError as exc:
+                raise CDPTimeoutError(
+                    f"event {event_name} timed out after {timeout}s",
+                    timeout=timeout,
+                ) from exc
+
+            msg = json.loads(raw)
+            if self._matches_event(msg, event_name, session_id):
+                return msg.get("params", {})
+            self._event_buffer.append(msg)
+
+    @staticmethod
+    def _matches_event(
+        msg: dict,
+        event_name: str,
+        session_id: str | None,
+    ) -> bool:
+        """Check if a message matches the expected event."""
+        if msg.get("method") != event_name:
+            return False
+        if session_id is not None and msg.get("sessionId") != session_id:
+            return False
+        return True
+
+    @staticmethod
+    def _resolve_ws_url(url: str, *, timeout: float) -> str:
+        """Resolve the browser's debugger WebSocket URL."""
+        # Reuse the sync implementation
+        return CDPClient._resolve_ws_url(url, timeout=timeout)

--- a/cdp/conftest.py
+++ b/cdp/conftest.py
@@ -1,0 +1,278 @@
+"""Mock CDP server and optional real browser fixtures for testing.
+
+Provides a session-scoped mock CDP server that simulates basic Chrome
+DevTools Protocol interactions over WebSocket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import uuid
+
+import pytest
+
+
+class _MockCDPHandler:
+    """Simulates a minimal CDP server.
+
+    Handles:
+    - Target.createTarget / Target.attachToTarget / Target.closeTarget
+    - Page.enable / Page.navigate (fires Page.loadEventFired)
+    - Runtime.evaluate (returns expression as string value)
+    """
+
+    def __init__(self):
+        self._targets: dict[str, dict] = {}  # target_id -> info
+        self._sessions: dict[str, str] = {}  # session_id -> target_id
+
+    def handle_message(self, raw: str) -> list[str]:
+        """Process a CDP message and return response(s).
+
+        Returns a list of JSON strings (response + possible events).
+        """
+        msg = json.loads(raw)
+        cmd_id = msg.get("id")
+        method = msg.get("method", "")
+        params = msg.get("params", {})
+        session_id = msg.get("sessionId")
+
+        responses: list[str] = []
+
+        if method == "Target.createTarget":
+            target_id = f"target-{uuid.uuid4().hex[:8]}"
+            url = params.get("url", "about:blank")
+            self._targets[target_id] = {
+                "url": url,
+                "loaded": False,
+            }
+            responses.append(
+                json.dumps({"id": cmd_id, "result": {"targetId": target_id}})
+            )
+
+        elif method == "Target.attachToTarget":
+            target_id = params.get("targetId", "")
+            sid = f"session-{uuid.uuid4().hex[:8]}"
+            self._sessions[sid] = target_id
+            responses.append(json.dumps({"id": cmd_id, "result": {"sessionId": sid}}))
+            # Also send Target.attachedToTarget event
+            responses.append(
+                json.dumps(
+                    {
+                        "method": "Target.attachedToTarget",
+                        "params": {
+                            "sessionId": sid,
+                            "targetInfo": {
+                                "targetId": target_id,
+                                "type": "page",
+                                "url": self._targets.get(target_id, {}).get("url", ""),
+                            },
+                        },
+                    }
+                )
+            )
+
+        elif method == "Target.closeTarget":
+            target_id = params.get("targetId", "")
+            self._targets.pop(target_id, None)
+            # Remove associated sessions
+            self._sessions = {k: v for k, v in self._sessions.items() if v != target_id}
+            responses.append(json.dumps({"id": cmd_id, "result": {"success": True}}))
+
+        elif method == "Page.enable":
+            responses.append(json.dumps({"id": cmd_id, "result": {}}))
+            if session_id:
+                responses[-1] = json.dumps(
+                    {"id": cmd_id, "result": {}, "sessionId": session_id}
+                )
+
+        elif method == "Page.navigate":
+            url = params.get("url", "")
+            frame_id = f"frame-{uuid.uuid4().hex[:8]}"
+            loader_id = f"loader-{uuid.uuid4().hex[:8]}"
+
+            resp = {
+                "id": cmd_id,
+                "result": {"frameId": frame_id, "loaderId": loader_id},
+            }
+            if session_id:
+                resp["sessionId"] = session_id
+            responses.append(json.dumps(resp))
+
+            # Update target URL
+            if session_id and session_id in self._sessions:
+                tid = self._sessions[session_id]
+                if tid in self._targets:
+                    self._targets[tid]["url"] = url
+                    self._targets[tid]["loaded"] = True
+
+            # Fire Page.loadEventFired event
+            event = {
+                "method": "Page.loadEventFired",
+                "params": {"timestamp": 12345.678},
+            }
+            if session_id:
+                event["sessionId"] = session_id
+            responses.append(json.dumps(event))
+
+        elif method == "Runtime.evaluate":
+            expression = params.get("expression", "")
+
+            # Simulate simple evaluations
+            if "innerText" in expression:
+                value = "Mock page content for testing"
+            elif "outerHTML" in expression:
+                value = "<html><body>Mock page content for testing</body></html>"
+            elif "throw" in expression.lower():
+                resp = {
+                    "id": cmd_id,
+                    "result": {
+                        "result": {"type": "object", "subtype": "error"},
+                        "exceptionDetails": {
+                            "text": "Uncaught Error: test error",
+                            "exceptionId": 1,
+                        },
+                    },
+                }
+                if session_id:
+                    resp["sessionId"] = session_id
+                responses.append(json.dumps(resp))
+                return responses
+            else:
+                value = f"eval:{expression}"
+
+            result_obj = {"type": "string", "value": value}
+            resp = {"id": cmd_id, "result": {"result": result_obj}}
+            if session_id:
+                resp["sessionId"] = session_id
+            responses.append(json.dumps(resp))
+
+        elif method == "Network.setUserAgentOverride":
+            resp = {"id": cmd_id, "result": {}}
+            if session_id:
+                resp["sessionId"] = session_id
+            responses.append(json.dumps(resp))
+
+        else:
+            # Unknown method — return empty result
+            resp = {"id": cmd_id, "result": {}}
+            if session_id:
+                resp["sessionId"] = session_id
+            responses.append(json.dumps(resp))
+
+        return responses
+
+
+@pytest.fixture(scope="session")
+def cdp_mock_url():
+    """Start a mock CDP server and yield its WebSocket URL."""
+    import websockets.server
+
+    handler = _MockCDPHandler()
+
+    async def ws_handler(ws):
+        try:
+            async for raw in ws:
+                responses = handler.handle_message(raw)
+                for resp in responses:
+                    await ws.send(resp)
+        except websockets.exceptions.ConnectionClosedOK:
+            pass
+        except websockets.exceptions.ConnectionClosedError:
+            pass
+
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+    port_holder: list[int] = []
+
+    async def run_server():
+        async with websockets.server.serve(ws_handler, "127.0.0.1", 0) as server:
+            sock = list(server.sockets)[0]
+            port_holder.append(sock.getsockname()[1])
+            started.set()
+            await asyncio.Future()  # run forever
+
+    def thread_target():
+        loop.run_until_complete(run_server())
+
+    thread = threading.Thread(target=thread_target, daemon=True)
+    thread.start()
+    started.wait(timeout=10)
+    yield f"ws://127.0.0.1:{port_holder[0]}/devtools/browser/mock"
+    loop.call_soon_threadsafe(loop.stop)
+
+
+@pytest.fixture(scope="session")
+def cdp_json_version_url():
+    """Start a mock CDP server with /json/version HTTP endpoint for auto-discovery.
+
+    Returns just the host:port URL without path, so the client must
+    auto-discover via /json/version.
+    """
+    import http.server
+
+    import websockets.server
+
+    handler = _MockCDPHandler()
+    ws_port_holder: list[int] = []
+
+    # Start WS server
+    async def ws_handler(ws):
+        try:
+            async for raw in ws:
+                responses = handler.handle_message(raw)
+                for resp in responses:
+                    await ws.send(resp)
+        except websockets.exceptions.ConnectionClosedOK:
+            pass
+        except websockets.exceptions.ConnectionClosedError:
+            pass
+
+    ws_loop = asyncio.new_event_loop()
+    ws_started = threading.Event()
+
+    async def run_ws_server():
+        async with websockets.server.serve(ws_handler, "127.0.0.1", 0) as server:
+            sock = list(server.sockets)[0]
+            ws_port_holder.append(sock.getsockname()[1])
+            ws_started.set()
+            await asyncio.Future()
+
+    def ws_thread_target():
+        ws_loop.run_until_complete(run_ws_server())
+
+    ws_thread = threading.Thread(target=ws_thread_target, daemon=True)
+    ws_thread.start()
+    ws_started.wait(timeout=10)
+
+    # Start HTTP server for /json/version
+    class JsonVersionHandler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format, *args):  # noqa: A002
+            pass
+
+        def do_GET(self):
+            if self.path == "/json/version":
+                ws_url = f"ws://127.0.0.1:{ws_port_holder[0]}/devtools/browser/auto"
+                data = json.dumps(
+                    {
+                        "Browser": "Mock/1.0",
+                        "webSocketDebuggerUrl": ws_url,
+                    }
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(data.encode())
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+    http_server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), JsonVersionHandler)
+    http_port = http_server.server_address[1]
+    http_thread = threading.Thread(target=http_server.serve_forever, daemon=True)
+    http_thread.start()
+
+    yield f"ws://127.0.0.1:{http_port}"
+    http_server.shutdown()
+    ws_loop.call_soon_threadsafe(ws_loop.stop)

--- a/cdp/conftest.py
+++ b/cdp/conftest.py
@@ -1,17 +1,33 @@
 """Mock CDP server and optional real browser fixtures for testing.
 
 Provides a session-scoped mock CDP server that simulates basic Chrome
-DevTools Protocol interactions over WebSocket.
+DevTools Protocol interactions over WebSocket. Uses stdlib-only — no
+third-party WebSocket server library needed.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import http.server
 import json
+import os
+import struct
+import sys
 import threading
 import uuid
 
 import pytest
+
+# Reuse protocol helpers from sibling websocket module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "websocket"))
+from websocket import _WS_GUID, _make_frame, _mask_payload  # noqa: E402
+
+_OPCODE_TEXT = 0x1
+_OPCODE_CLOSE = 0x8
+_OPCODE_PING = 0x9
+_OPCODE_PONG = 0xA
 
 
 class _MockCDPHandler:
@@ -164,39 +180,116 @@ class _MockCDPHandler:
         return responses
 
 
+# ── Stdlib WebSocket server helpers ──────────────────────────────────────
+
+
+async def _ws_accept(reader, writer):
+    """Perform server-side WebSocket handshake."""
+    request = b""
+    while b"\r\n\r\n" not in request:
+        chunk = await reader.read(4096)
+        if not chunk:
+            writer.close()
+            return False
+        request += chunk
+
+    key = None
+    for line in request.decode(errors="replace").split("\r\n"):
+        if line.lower().startswith("sec-websocket-key:"):
+            key = line.split(":", 1)[1].strip()
+            break
+
+    if not key:
+        writer.close()
+        return False
+
+    accept = base64.b64encode(hashlib.sha1((key + _WS_GUID).encode()).digest()).decode()
+    response = (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Accept: {accept}\r\n"
+        "\r\n"
+    )
+    writer.write(response.encode())
+    await writer.drain()
+    return True
+
+
+async def _ws_read_frame(reader) -> tuple[int, bytes] | None:
+    """Read one WebSocket frame. Returns (opcode, payload)."""
+    header = await reader.readexactly(2)
+    opcode = header[0] & 0x0F
+    is_masked = bool(header[1] & 0x80)
+    length = header[1] & 0x7F
+
+    if length == 126:
+        length = struct.unpack(">H", await reader.readexactly(2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", await reader.readexactly(8))[0]
+
+    if is_masked:
+        mask_key = await reader.readexactly(4)
+        raw = await reader.readexactly(length)
+        payload = _mask_payload(mask_key, raw)
+    else:
+        payload = await reader.readexactly(length)
+
+    return opcode, payload
+
+
+async def _ws_send(writer, opcode: int, payload: bytes):
+    """Send a WebSocket frame (server→client, no masking)."""
+    writer.write(_make_frame(opcode, payload, mask=False))
+    await writer.drain()
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
 @pytest.fixture(scope="session")
 def cdp_mock_url():
     """Start a mock CDP server and yield its WebSocket URL."""
-    import websockets.server
-
     handler = _MockCDPHandler()
 
-    async def ws_handler(ws):
+    async def ws_handler(reader, writer):
+        if not await _ws_accept(reader, writer):
+            return
         try:
-            async for raw in ws:
-                responses = handler.handle_message(raw)
-                for resp in responses:
-                    await ws.send(resp)
-        except websockets.exceptions.ConnectionClosedOK:
+            while True:
+                result = await _ws_read_frame(reader)
+                if result is None:
+                    break
+                opcode, payload = result
+
+                if opcode == _OPCODE_TEXT:
+                    responses = handler.handle_message(payload.decode())
+                    for resp in responses:
+                        await _ws_send(writer, _OPCODE_TEXT, resp.encode())
+                elif opcode == _OPCODE_PING:
+                    await _ws_send(writer, _OPCODE_PONG, payload)
+                elif opcode == _OPCODE_CLOSE:
+                    await _ws_send(writer, _OPCODE_CLOSE, payload)
+                    break
+        except (asyncio.IncompleteReadError, ConnectionError, OSError):
             pass
-        except websockets.exceptions.ConnectionClosedError:
-            pass
+        finally:
+            writer.close()
 
     loop = asyncio.new_event_loop()
     started = threading.Event()
     port_holder: list[int] = []
 
     async def run_server():
-        async with websockets.server.serve(ws_handler, "127.0.0.1", 0) as server:
-            sock = list(server.sockets)[0]
-            port_holder.append(sock.getsockname()[1])
-            started.set()
-            await asyncio.Future()  # run forever
+        server = await asyncio.start_server(ws_handler, "127.0.0.1", 0)
+        port_holder.append(server.sockets[0].getsockname()[1])
+        started.set()
+        async with server:
+            await server.serve_forever()
 
-    def thread_target():
-        loop.run_until_complete(run_server())
-
-    thread = threading.Thread(target=thread_target, daemon=True)
+    thread = threading.Thread(
+        target=loop.run_until_complete, args=(run_server(),), daemon=True
+    )
     thread.start()
     started.wait(timeout=10)
     yield f"ws://127.0.0.1:{port_holder[0]}/devtools/browser/mock"
@@ -210,39 +303,49 @@ def cdp_json_version_url():
     Returns just the host:port URL without path, so the client must
     auto-discover via /json/version.
     """
-    import http.server
-
-    import websockets.server
-
     handler = _MockCDPHandler()
-    ws_port_holder: list[int] = []
 
     # Start WS server
-    async def ws_handler(ws):
+    async def ws_handler(reader, writer):
+        if not await _ws_accept(reader, writer):
+            return
         try:
-            async for raw in ws:
-                responses = handler.handle_message(raw)
-                for resp in responses:
-                    await ws.send(resp)
-        except websockets.exceptions.ConnectionClosedOK:
+            while True:
+                result = await _ws_read_frame(reader)
+                if result is None:
+                    break
+                opcode, payload = result
+
+                if opcode == _OPCODE_TEXT:
+                    responses = handler.handle_message(payload.decode())
+                    for resp in responses:
+                        await _ws_send(writer, _OPCODE_TEXT, resp.encode())
+                elif opcode == _OPCODE_PING:
+                    await _ws_send(writer, _OPCODE_PONG, payload)
+                elif opcode == _OPCODE_CLOSE:
+                    await _ws_send(writer, _OPCODE_CLOSE, payload)
+                    break
+        except (asyncio.IncompleteReadError, ConnectionError, OSError):
             pass
-        except websockets.exceptions.ConnectionClosedError:
-            pass
+        finally:
+            writer.close()
 
     ws_loop = asyncio.new_event_loop()
     ws_started = threading.Event()
+    ws_port_holder: list[int] = []
 
     async def run_ws_server():
-        async with websockets.server.serve(ws_handler, "127.0.0.1", 0) as server:
-            sock = list(server.sockets)[0]
-            ws_port_holder.append(sock.getsockname()[1])
-            ws_started.set()
-            await asyncio.Future()
+        server = await asyncio.start_server(ws_handler, "127.0.0.1", 0)
+        ws_port_holder.append(server.sockets[0].getsockname()[1])
+        ws_started.set()
+        async with server:
+            await server.serve_forever()
 
-    def ws_thread_target():
-        ws_loop.run_until_complete(run_ws_server())
-
-    ws_thread = threading.Thread(target=ws_thread_target, daemon=True)
+    ws_thread = threading.Thread(
+        target=ws_loop.run_until_complete,
+        args=(run_ws_server(),),
+        daemon=True,
+    )
     ws_thread.start()
     ws_started.wait(timeout=10)
 

--- a/cdp/test_cdp_benchmark.py
+++ b/cdp/test_cdp_benchmark.py
@@ -1,0 +1,52 @@
+"""Performance benchmarks for the cdp module.
+
+Benchmarks CDP client operations against the mock server.
+Real browser benchmarks require CHROME_PATH to be set.
+"""
+
+from __future__ import annotations
+
+from cdp import CDPClient
+
+
+class TestCDPBenchmarks:
+    """Benchmark CDP operations against mock server."""
+
+    def test_create_close_target(self, cdp_mock_url, benchmark):
+        """Benchmark target creation and cleanup."""
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+
+        def create_close():
+            tid = client.create_target()
+            client.close_target(tid)
+
+        benchmark(create_close)
+        client.close()
+
+    def test_navigate_and_evaluate(self, cdp_mock_url, benchmark):
+        """Benchmark navigate + evaluate cycle."""
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+        target_id = client.create_target()
+
+        def nav_eval():
+            client.navigate(target_id, "https://example.com")
+            return client.evaluate(target_id, "document.body.innerText")
+
+        result = benchmark(nav_eval)
+        assert "Mock page content" in result
+        client.close_target(target_id)
+        client.close()
+
+    def test_get_rendered_text(self, cdp_mock_url, benchmark):
+        """Benchmark high-level get_rendered_text."""
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+
+        def get_text():
+            return client.get_rendered_text("https://example.com")
+
+        result = benchmark(get_text)
+        assert "Mock page content" in result
+        client.close()

--- a/cdp/test_cdp_benchmark.py
+++ b/cdp/test_cdp_benchmark.py
@@ -1,7 +1,7 @@
-"""Performance benchmarks for the cdp module.
+"""Benchmark: CDP client operations against mock server.
 
-Benchmarks CDP client operations against the mock server.
-Real browser benchmarks require CHROME_PATH to be set.
+Simulates realistic workloads: full SPA render pipeline, multi-tab management,
+JS evaluation throughput, and raw command dispatch overhead.
 """
 
 from __future__ import annotations
@@ -9,44 +9,128 @@ from __future__ import annotations
 from cdp import CDPClient
 
 
-class TestCDPBenchmarks:
-    """Benchmark CDP operations against mock server."""
+class TestFullRenderPipeline:
+    """Benchmark the core SPA rendering flow: create → navigate → extract text → close."""
 
-    def test_create_close_target(self, cdp_mock_url, benchmark):
-        """Benchmark target creation and cleanup."""
+    def test_get_rendered_text(self, cdp_mock_url, benchmark):
         client = CDPClient(cdp_mock_url)
         client.connect()
 
-        def create_close():
-            tid = client.create_target()
-            client.close_target(tid)
+        def render():
+            return client.get_rendered_text("https://example.com")
 
-        benchmark(create_close)
+        result = benchmark(render)
+        assert "Mock page content" in result
         client.close()
 
-    def test_navigate_and_evaluate(self, cdp_mock_url, benchmark):
-        """Benchmark navigate + evaluate cycle."""
+    def test_get_rendered_text_fresh_client(self, cdp_mock_url, benchmark):
+        """Full lifecycle including connect/close per call."""
+
+        def render():
+            with CDPClient(cdp_mock_url) as client:
+                return client.get_rendered_text("https://example.com")
+
+        result = benchmark(render)
+        assert "Mock page content" in result
+
+
+class TestRenderHtml:
+    """Benchmark HTML extraction pipeline (outerHTML)."""
+
+    def test_get_rendered_html(self, cdp_mock_url, benchmark):
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+
+        def render():
+            return client.get_rendered_html("https://example.com")
+
+        result = benchmark(render)
+        assert "<html>" in result
+        client.close()
+
+
+class TestMultiTarget:
+    """Benchmark multi-tab management (5 concurrent targets)."""
+
+    def test_multi_target_pipeline(self, cdp_mock_url, benchmark):
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+
+        def multi():
+            targets = []
+            for i in range(5):
+                tid = client.create_target(f"https://example.com/page{i}")
+                targets.append(tid)
+            results = []
+            for tid in targets:
+                client.navigate(tid, "https://example.com")
+                text = client.evaluate(tid, "document.body.innerText")
+                results.append(text)
+            for tid in targets:
+                client.close_target(tid)
+            return results
+
+        results = benchmark(multi)
+        assert len(results) == 5
+        assert all("Mock page content" in r for r in results)
+        client.close()
+
+
+class TestJsEvalThroughput:
+    """Benchmark rapid JS evaluation on a single target."""
+
+    def test_evaluate_burst(self, cdp_mock_url, benchmark):
         client = CDPClient(cdp_mock_url)
         client.connect()
         target_id = client.create_target()
 
-        def nav_eval():
-            client.navigate(target_id, "https://example.com")
-            return client.evaluate(target_id, "document.body.innerText")
+        expressions = [
+            "document.title",
+            "document.body.innerText",
+            "window.location.href",
+            "document.querySelectorAll('div').length",
+            "navigator.userAgent",
+            "document.readyState",
+            "performance.now()",
+            "document.cookie",
+            "window.innerWidth",
+            "JSON.stringify({ok: true})",
+        ]
 
-        result = benchmark(nav_eval)
-        assert "Mock page content" in result
+        def eval_burst():
+            results = []
+            for expr in expressions:
+                results.append(client.evaluate(target_id, expr))
+            return results
+
+        results = benchmark(eval_burst)
+        assert len(results) == 10
         client.close_target(target_id)
         client.close()
 
-    def test_get_rendered_text(self, cdp_mock_url, benchmark):
-        """Benchmark high-level get_rendered_text."""
+
+class TestCommandThroughput:
+    """Benchmark raw CDP command dispatch overhead."""
+
+    def test_send_command_burst(self, cdp_mock_url, benchmark):
         client = CDPClient(cdp_mock_url)
         client.connect()
 
-        def get_text():
-            return client.get_rendered_text("https://example.com")
+        def cmd_burst():
+            results = []
+            for i in range(20):
+                resp = client.send_command(
+                    "Target.createTarget",
+                    {"url": f"about:blank#{i}"},
+                )
+                results.append(resp)
+            # Clean up created targets
+            for resp in results:
+                tid = resp.get("targetId", "")
+                if tid:
+                    client.send_command("Target.closeTarget", {"targetId": tid})
+            return results
 
-        result = benchmark(get_text)
-        assert "Mock page content" in result
+        results = benchmark(cmd_burst)
+        assert len(results) == 20
         client.close()

--- a/cdp/test_cdp_correctness.py
+++ b/cdp/test_cdp_correctness.py
@@ -1,0 +1,289 @@
+"""Correctness tests for the cdp module.
+
+Tests CDP client against a mock CDP server. Both sync (CDPClient) and
+async (AsyncCDPClient) variants are tested.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cdp import (
+    AsyncCDPClient,
+    CDPClient,
+    CDPConnectionError,
+    CDPError,
+    CDPProtocolError,
+)
+
+# ── Sync Tests ─────────────────────────────────────────────────────────────
+
+
+class TestSyncConnection:
+    """Test sync CDP connection lifecycle."""
+
+    def test_connect_and_close(self, cdp_mock_url):
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+        client.close()
+
+    def test_context_manager(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as _client:
+            pass  # just verify it connects and closes cleanly
+
+    def test_double_connect_is_noop(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            client.connect()  # second call should not raise
+
+    def test_double_close_is_noop(self, cdp_mock_url):
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+        client.close()
+        client.close()  # should not raise
+
+    def test_connection_refused(self):
+        client = CDPClient("ws://127.0.0.1:1/devtools/browser/test")
+        with pytest.raises(CDPConnectionError):
+            client.connect(timeout=2)
+
+    def test_send_command_without_connect(self):
+        client = CDPClient("ws://127.0.0.1:1/devtools/browser/test")
+        with pytest.raises(CDPError, match="not connected"):
+            client.send_command("Page.enable")
+
+
+class TestSyncAutoDiscovery:
+    """Test sync CDP auto-discovery via /json/version."""
+
+    def test_auto_discover(self, cdp_json_version_url):
+        with CDPClient(cdp_json_version_url) as client:
+            target_id = client.create_target()
+            client.close_target(target_id)
+
+
+class TestSyncTargetManagement:
+    """Test sync target (tab) management."""
+
+    def test_create_and_close_target(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            target_id = client.create_target()
+            assert target_id
+            assert target_id in client._targets
+            client.close_target(target_id)
+            assert target_id not in client._targets
+
+    def test_create_multiple_targets(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            t1 = client.create_target("https://example.com")
+            t2 = client.create_target("https://example.org")
+            assert t1 != t2
+            assert len(client._targets) == 2
+            client.close_target(t1)
+            client.close_target(t2)
+
+    def test_close_nonexistent_target(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            client.close_target("nonexistent-id")  # should not raise
+
+    def test_auto_cleanup_on_close(self, cdp_mock_url):
+        client = CDPClient(cdp_mock_url)
+        client.connect()
+        client.create_target()
+        client.create_target()
+        assert len(client._targets) == 2
+        client.close()
+        assert len(client._targets) == 0
+
+
+class TestSyncNavigation:
+    """Test sync page navigation."""
+
+    def test_navigate(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            target_id = client.create_target()
+            client.navigate(target_id, "https://example.com")
+            client.close_target(target_id)
+
+    def test_navigate_unknown_target(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            with pytest.raises(CDPError, match="unknown target"):
+                client.navigate("bad-id", "https://example.com")
+
+
+class TestSyncEvaluate:
+    """Test sync JavaScript evaluation."""
+
+    def test_evaluate_expression(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            target_id = client.create_target()
+            result = client.evaluate(target_id, "1 + 1")
+            assert result == "eval:1 + 1"
+            client.close_target(target_id)
+
+    def test_evaluate_innertext(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            target_id = client.create_target()
+            result = client.evaluate(target_id, "document.body.innerText")
+            assert "Mock page content" in result
+            client.close_target(target_id)
+
+    def test_evaluate_error(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            target_id = client.create_target()
+            with pytest.raises(CDPProtocolError, match="Uncaught Error"):
+                client.evaluate(target_id, "throw new Error('test error')")
+            client.close_target(target_id)
+
+
+class TestSyncHighLevel:
+    """Test sync high-level API."""
+
+    def test_get_rendered_text(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            text = client.get_rendered_text("https://example.com")
+            assert isinstance(text, str)
+            assert "Mock page content" in text
+
+    def test_get_rendered_html(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            html = client.get_rendered_html("https://example.com")
+            assert isinstance(html, str)
+            assert "<html>" in html
+            assert "Mock page content" in html
+
+    def test_get_rendered_text_cleans_up_target(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            targets_before = len(client._targets)
+            client.get_rendered_text("https://example.com")
+            assert len(client._targets) == targets_before
+
+
+class TestSyncUserAgent:
+    """Test sync User-Agent override."""
+
+    def test_set_user_agent(self, cdp_mock_url):
+        with CDPClient(cdp_mock_url) as client:
+            target_id = client.create_target()
+            client.set_user_agent(target_id, "CustomAgent/1.0")
+            client.close_target(target_id)
+
+
+# ── Async Tests ────────────────────────────────────────────────────────────
+
+
+class TestAsyncConnection:
+    """Test async CDP connection lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_connect_and_close(self, cdp_mock_url):
+        client = AsyncCDPClient(cdp_mock_url)
+        await client.connect()
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as _client:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_double_connect_is_noop(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            await client.connect()
+
+    @pytest.mark.asyncio
+    async def test_double_close_is_noop(self, cdp_mock_url):
+        client = AsyncCDPClient(cdp_mock_url)
+        await client.connect()
+        await client.close()
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_connection_refused(self):
+        client = AsyncCDPClient("ws://127.0.0.1:1/devtools/browser/test")
+        with pytest.raises(CDPConnectionError):
+            await client.connect(timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_send_command_without_connect(self):
+        client = AsyncCDPClient("ws://127.0.0.1:1/devtools/browser/test")
+        with pytest.raises(CDPError, match="not connected"):
+            await client.send_command("Page.enable")
+
+
+class TestAsyncTargetManagement:
+    """Test async target management."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_close_target(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            target_id = await client.create_target()
+            assert target_id
+            assert target_id in client._targets
+            await client.close_target(target_id)
+            assert target_id not in client._targets
+
+    @pytest.mark.asyncio
+    async def test_auto_cleanup_on_close(self, cdp_mock_url):
+        client = AsyncCDPClient(cdp_mock_url)
+        await client.connect()
+        await client.create_target()
+        await client.create_target()
+        assert len(client._targets) == 2
+        await client.close()
+        assert len(client._targets) == 0
+
+
+class TestAsyncNavigation:
+    """Test async page navigation."""
+
+    @pytest.mark.asyncio
+    async def test_navigate(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            target_id = await client.create_target()
+            await client.navigate(target_id, "https://example.com")
+            await client.close_target(target_id)
+
+
+class TestAsyncEvaluate:
+    """Test async JavaScript evaluation."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_expression(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            target_id = await client.create_target()
+            result = await client.evaluate(target_id, "1 + 1")
+            assert result == "eval:1 + 1"
+            await client.close_target(target_id)
+
+    @pytest.mark.asyncio
+    async def test_evaluate_error(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            target_id = await client.create_target()
+            with pytest.raises(CDPProtocolError, match="Uncaught Error"):
+                await client.evaluate(target_id, "throw new Error('test error')")
+            await client.close_target(target_id)
+
+
+class TestAsyncHighLevel:
+    """Test async high-level API."""
+
+    @pytest.mark.asyncio
+    async def test_get_rendered_text(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            text = await client.get_rendered_text("https://example.com")
+            assert isinstance(text, str)
+            assert "Mock page content" in text
+
+    @pytest.mark.asyncio
+    async def test_get_rendered_html(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            html = await client.get_rendered_html("https://example.com")
+            assert isinstance(html, str)
+            assert "<html>" in html
+
+    @pytest.mark.asyncio
+    async def test_get_rendered_text_cleans_up(self, cdp_mock_url):
+        async with AsyncCDPClient(cdp_mock_url) as client:
+            targets_before = len(client._targets)
+            await client.get_rendered_text("https://example.com")
+            assert len(client._targets) == targets_before

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-05-02T07:15:41.269429+00:00",
+  "generated": "2026-05-02T08:23:10.831667+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -65,6 +65,20 @@
       "category": "storage",
       "last_updated": "2026-04-27T23:17:36+08:00",
       "content_hash": "0daa535d12e0d214a579242ad73d725b9f18145f6c67b319fa4185e7851685ae"
+    },
+    "cdp": {
+      "description": "Zero-dependency Chrome DevTools Protocol (CDP) client",
+      "files": [
+        "cdp/cdp.py"
+      ],
+      "version": "0.1.0",
+      "deps": [
+        "websocket"
+      ],
+      "tier": "medium",
+      "category": "protocol",
+      "last_updated": null,
+      "content_hash": "e5bd722ec32c6c15a210ec2f18cc960acbd4cbabb9b8c7c55a98063e2e05d989"
     },
     "config": {
       "description": "Unified configuration loader — zero dependencies, stdlib only, Python 3.10+",
@@ -165,8 +179,8 @@
       "deps": [],
       "tier": "subsystem",
       "category": "network",
-      "last_updated": null,
-      "content_hash": "d00439706b5168d5235eb700e559a8dac95d4ff173e39725b7a11826632f6456"
+      "last_updated": "2026-05-02T16:02:07+08:00",
+      "content_hash": "b477e97b7f4f4149ebf7911719eef117061a0efc72599ff6dc0b76b215f0492b"
     },
     "jsonc": {
       "description": "JSONC (JSON with Comments) parser — zero dependencies, stdlib only, Python 3.10+",
@@ -491,6 +505,18 @@
       "category": "devtools",
       "last_updated": "2026-04-11T01:00:28+08:00",
       "content_hash": "bc7cf7b24daf282ae4311e432a62c192d1570bce95985c211948c7a25837e225"
+    },
+    "websocket": {
+      "description": "Zero-dependency WebSocket client (RFC 6455)",
+      "files": [
+        "websocket/websocket.py"
+      ],
+      "version": "0.1.0",
+      "deps": [],
+      "tier": "medium",
+      "category": "network",
+      "last_updated": null,
+      "content_hash": "4c95286e6bb0fcbbfa7bef5660be9b5e47a3c9c25a6a7247098cb48b2668c765"
     },
     "xml": {
       "description": "XML ↔ dict converter with fault-tolerant LLM tag extraction — zero-dep, stdlib only, Python 3.10+",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,17 +143,23 @@ bench-httpserver = [
     "microdot==2.6.1",
     "bottle==0.13.4",
 ]
+bench-websocket = [
+    "websockets>=14.0",
+]
+bench-cdp = [
+    "websockets>=14.0",
+]
 dev = [
     "ruff>=0.1.0",
     "ty>=0.0.24",
     "complexipy>=5.2.0",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
-    "zerodep[test,bench-aes,bench-qr,bench-http,bench-dotenv,bench-yaml,bench-jsonc,bench-structlog,bench-retry,bench-toon,bench-tabulate,bench-soup,bench-validate,bench-sse,bench-markdown,bench-diff,bench-scheduler,bench-search,bench-frontmatter,bench-config,bench-cache,bench-xml,bench-jsonrpc,bench-a2a,bench-acp,bench-protobuf,bench-semver,bench-persistdict,bench-runner,bench-readability,bench-png,bench-useragent,bench-httpserver]",
+    "zerodep[test,bench-aes,bench-qr,bench-http,bench-dotenv,bench-yaml,bench-jsonc,bench-structlog,bench-retry,bench-toon,bench-tabulate,bench-soup,bench-validate,bench-sse,bench-markdown,bench-diff,bench-scheduler,bench-search,bench-frontmatter,bench-config,bench-cache,bench-xml,bench-jsonrpc,bench-a2a,bench-acp,bench-protobuf,bench-semver,bench-persistdict,bench-runner,bench-readability,bench-png,bench-useragent,bench-httpserver,bench-websocket,bench-cdp]",
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt", "useragent", "synctex", "httpserver"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt", "useragent", "synctex", "httpserver", "websocket", "cdp"]
 
 [tool.ruff]
 target-version = "py310"
@@ -229,4 +235,6 @@ extra-paths = [
     "./useragent",
     "./synctex",
     "./httpserver",
+    "./websocket",
+    "./cdp",
 ]

--- a/websocket/conftest.py
+++ b/websocket/conftest.py
@@ -1,96 +1,188 @@
 """WebSocket echo server fixture for testing.
 
-Provides session-scoped fixtures that start a threaded WebSocket echo server
-using the ``websockets`` library. The server echoes back any text message and
-supports ping/pong and close handshakes.
+Provides session-scoped fixtures with a stdlib-only WebSocket echo server.
+No third-party dependencies — uses asyncio.start_server and the protocol
+helpers from our own websocket module.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import struct
 import threading
 
 import pytest
 
+# Reuse protocol constants/helpers from our module
+from websocket import _WS_GUID, _make_frame, _mask_payload
 
-@pytest.fixture(scope="session")
-def ws_echo_url():
-    """Start a WebSocket echo server and yield its URL."""
-    import websockets.server
+_OPCODE_TEXT = 0x1
+_OPCODE_CLOSE = 0x8
+_OPCODE_PING = 0x9
+_OPCODE_PONG = 0xA
 
-    async def echo_handler(ws):
-        try:
-            async for msg in ws:
-                await ws.send(msg)
-        except websockets.exceptions.ConnectionClosedOK:
-            pass
-        except websockets.exceptions.ConnectionClosedError:
-            pass
 
+async def _ws_accept(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    """Perform WebSocket server-side handshake."""
+    request = b""
+    while b"\r\n\r\n" not in request:
+        chunk = await reader.read(4096)
+        if not chunk:
+            writer.close()
+            return None
+        request += chunk
+
+    # Extract Sec-WebSocket-Key
+    key = None
+    for line in request.decode(errors="replace").split("\r\n"):
+        if line.lower().startswith("sec-websocket-key:"):
+            key = line.split(":", 1)[1].strip()
+            break
+
+    if not key:
+        writer.close()
+        return None
+
+    accept = base64.b64encode(hashlib.sha1((key + _WS_GUID).encode()).digest()).decode()
+    response = (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Accept: {accept}\r\n"
+        "\r\n"
+    )
+    writer.write(response.encode())
+    await writer.drain()
+    return True
+
+
+async def _ws_read_frame(
+    reader: asyncio.StreamReader,
+) -> tuple[int, bytes] | None:
+    """Read one WebSocket frame from the client. Returns (opcode, payload)."""
+    header = await reader.readexactly(2)
+    opcode = header[0] & 0x0F
+    is_masked = bool(header[1] & 0x80)
+    length = header[1] & 0x7F
+
+    if length == 126:
+        length = struct.unpack(">H", await reader.readexactly(2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", await reader.readexactly(8))[0]
+
+    if is_masked:
+        mask_key = await reader.readexactly(4)
+        raw = await reader.readexactly(length)
+        payload = _mask_payload(mask_key, raw)
+    else:
+        payload = await reader.readexactly(length)
+
+    return opcode, payload
+
+
+async def _ws_send(writer: asyncio.StreamWriter, opcode: int, payload: bytes):
+    """Send a WebSocket frame (server→client, no masking)."""
+    writer.write(_make_frame(opcode, payload, mask=False))
+    await writer.drain()
+
+
+async def _echo_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    """Handle a single WebSocket connection: echo all text messages."""
+    if not await _ws_accept(reader, writer):
+        return
+    try:
+        while True:
+            result = await _ws_read_frame(reader)
+            if result is None:
+                break
+            opcode, payload = result
+
+            if opcode == _OPCODE_TEXT:
+                await _ws_send(writer, _OPCODE_TEXT, payload)
+            elif opcode == _OPCODE_PING:
+                await _ws_send(writer, _OPCODE_PONG, payload)
+            elif opcode == _OPCODE_CLOSE:
+                # Echo the close frame back
+                await _ws_send(writer, _OPCODE_CLOSE, payload)
+                break
+    except (asyncio.IncompleteReadError, ConnectionError, OSError):
+        pass
+    finally:
+        writer.close()
+
+
+async def _custom_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    """Handle a single WebSocket connection with custom behavior.
+
+    - Echoes text with "echo:" prefix
+    - "ping-me" → sends a ping frame + "ping-sent" text
+    - "close-me" → initiates server-side close
+    """
+    if not await _ws_accept(reader, writer):
+        return
+    try:
+        while True:
+            result = await _ws_read_frame(reader)
+            if result is None:
+                break
+            opcode, payload = result
+
+            if opcode == _OPCODE_TEXT:
+                text = payload.decode()
+                if text == "ping-me":
+                    await _ws_send(writer, _OPCODE_PING, b"server-ping")
+                    await _ws_send(writer, _OPCODE_TEXT, b"ping-sent")
+                elif text == "close-me":
+                    close_payload = struct.pack(">H", 1000) + b"server closing"
+                    await _ws_send(writer, _OPCODE_CLOSE, close_payload)
+                    break
+                else:
+                    await _ws_send(writer, _OPCODE_TEXT, f"echo:{text}".encode())
+            elif opcode == _OPCODE_PING:
+                await _ws_send(writer, _OPCODE_PONG, payload)
+            elif opcode == _OPCODE_CLOSE:
+                await _ws_send(writer, _OPCODE_CLOSE, payload)
+                break
+    except (asyncio.IncompleteReadError, ConnectionError, OSError):
+        pass
+    finally:
+        writer.close()
+
+
+def _start_ws_server(handler):
+    """Start an async WebSocket server in a background thread, return its URL."""
     loop = asyncio.new_event_loop()
     started = threading.Event()
     port_holder: list[int] = []
 
-    async def run_server():
-        async with websockets.server.serve(echo_handler, "127.0.0.1", 0) as server:
-            sock = list(server.sockets)[0]
-            port_holder.append(sock.getsockname()[1])
-            started.set()
-            await asyncio.Future()  # run forever
+    async def run():
+        server = await asyncio.start_server(handler, "127.0.0.1", 0)
+        port_holder.append(server.sockets[0].getsockname()[1])
+        started.set()
+        async with server:
+            await server.serve_forever()
 
-    def thread_target():
-        loop.run_until_complete(run_server())
-
-    thread = threading.Thread(target=thread_target, daemon=True)
+    thread = threading.Thread(
+        target=loop.run_until_complete, args=(run(),), daemon=True
+    )
     thread.start()
     started.wait(timeout=10)
-    yield f"ws://127.0.0.1:{port_holder[0]}"
+    return f"ws://127.0.0.1:{port_holder[0]}", loop
+
+
+@pytest.fixture(scope="session")
+def ws_echo_url():
+    """Start a stdlib WebSocket echo server and yield its URL."""
+    url, loop = _start_ws_server(_echo_handler)
+    yield url
     loop.call_soon_threadsafe(loop.stop)
 
 
 @pytest.fixture(scope="session")
 def ws_custom_server_url():
-    """Start a WebSocket server with custom behavior for testing.
-
-    This server:
-    - Echoes text messages prefixed with "echo:"
-    - Responds to "ping-me" by sending a ping frame
-    - Responds to "close-me" by initiating a close
-    """
-    import websockets.server
-
-    async def handler(ws):
-        try:
-            async for msg in ws:
-                if msg == "ping-me":
-                    await ws.ping(b"server-ping")
-                    await ws.send("ping-sent")
-                elif msg == "close-me":
-                    await ws.close(1000, "server closing")
-                    return
-                else:
-                    await ws.send(f"echo:{msg}")
-        except websockets.exceptions.ConnectionClosedOK:
-            pass
-        except websockets.exceptions.ConnectionClosedError:
-            pass
-
-    loop = asyncio.new_event_loop()
-    started = threading.Event()
-    port_holder: list[int] = []
-
-    async def run_server():
-        async with websockets.server.serve(handler, "127.0.0.1", 0) as server:
-            sock = list(server.sockets)[0]
-            port_holder.append(sock.getsockname()[1])
-            started.set()
-            await asyncio.Future()
-
-    def thread_target():
-        loop.run_until_complete(run_server())
-
-    thread = threading.Thread(target=thread_target, daemon=True)
-    thread.start()
-    started.wait(timeout=10)
-    yield f"ws://127.0.0.1:{port_holder[0]}"
+    """Start a WebSocket server with custom behavior for testing."""
+    url, loop = _start_ws_server(_custom_handler)
+    yield url
     loop.call_soon_threadsafe(loop.stop)

--- a/websocket/conftest.py
+++ b/websocket/conftest.py
@@ -1,0 +1,96 @@
+"""WebSocket echo server fixture for testing.
+
+Provides session-scoped fixtures that start a threaded WebSocket echo server
+using the ``websockets`` library. The server echoes back any text message and
+supports ping/pong and close handshakes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def ws_echo_url():
+    """Start a WebSocket echo server and yield its URL."""
+    import websockets.server
+
+    async def echo_handler(ws):
+        try:
+            async for msg in ws:
+                await ws.send(msg)
+        except websockets.exceptions.ConnectionClosedOK:
+            pass
+        except websockets.exceptions.ConnectionClosedError:
+            pass
+
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+    port_holder: list[int] = []
+
+    async def run_server():
+        async with websockets.server.serve(echo_handler, "127.0.0.1", 0) as server:
+            sock = list(server.sockets)[0]
+            port_holder.append(sock.getsockname()[1])
+            started.set()
+            await asyncio.Future()  # run forever
+
+    def thread_target():
+        loop.run_until_complete(run_server())
+
+    thread = threading.Thread(target=thread_target, daemon=True)
+    thread.start()
+    started.wait(timeout=10)
+    yield f"ws://127.0.0.1:{port_holder[0]}"
+    loop.call_soon_threadsafe(loop.stop)
+
+
+@pytest.fixture(scope="session")
+def ws_custom_server_url():
+    """Start a WebSocket server with custom behavior for testing.
+
+    This server:
+    - Echoes text messages prefixed with "echo:"
+    - Responds to "ping-me" by sending a ping frame
+    - Responds to "close-me" by initiating a close
+    """
+    import websockets.server
+
+    async def handler(ws):
+        try:
+            async for msg in ws:
+                if msg == "ping-me":
+                    await ws.ping(b"server-ping")
+                    await ws.send("ping-sent")
+                elif msg == "close-me":
+                    await ws.close(1000, "server closing")
+                    return
+                else:
+                    await ws.send(f"echo:{msg}")
+        except websockets.exceptions.ConnectionClosedOK:
+            pass
+        except websockets.exceptions.ConnectionClosedError:
+            pass
+
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+    port_holder: list[int] = []
+
+    async def run_server():
+        async with websockets.server.serve(handler, "127.0.0.1", 0) as server:
+            sock = list(server.sockets)[0]
+            port_holder.append(sock.getsockname()[1])
+            started.set()
+            await asyncio.Future()
+
+    def thread_target():
+        loop.run_until_complete(run_server())
+
+    thread = threading.Thread(target=thread_target, daemon=True)
+    thread.start()
+    started.wait(timeout=10)
+    yield f"ws://127.0.0.1:{port_holder[0]}"
+    loop.call_soon_threadsafe(loop.stop)

--- a/websocket/test_websocket_benchmark.py
+++ b/websocket/test_websocket_benchmark.py
@@ -1,0 +1,80 @@
+"""Performance benchmarks for the websocket module.
+
+Compares zerodep WebSocket client against the ``websockets`` reference library.
+
+Note: ``websocket-client`` benchmarks are excluded because its import name
+(``websocket``) collides with this module.
+"""
+
+from __future__ import annotations
+
+from websocket import WebSocketClient
+
+
+class TestSyncBenchmarks:
+    """Benchmark sync WebSocket operations."""
+
+    def test_echo_roundtrip(self, ws_echo_url, benchmark):
+        """Measure echo round-trip latency."""
+        ws = WebSocketClient(ws_echo_url)
+        ws.connect()
+
+        def roundtrip():
+            ws.send("benchmark")
+            return ws.recv()
+
+        result = benchmark(roundtrip)
+        assert result == "benchmark"
+        ws.close()
+
+    def test_echo_roundtrip_long(self, ws_echo_url, benchmark):
+        """Measure echo round-trip latency for large messages."""
+        ws = WebSocketClient(ws_echo_url)
+        ws.connect()
+        msg = "x" * 10_000
+
+        def roundtrip():
+            ws.send(msg)
+            return ws.recv()
+
+        result = benchmark(roundtrip)
+        assert len(result) == 10_000
+        ws.close()
+
+
+class TestReferenceBenchmarks:
+    """Benchmark against websockets reference library."""
+
+    def test_websockets_echo_roundtrip(self, ws_echo_url, benchmark):
+        """Measure websockets library echo round-trip latency."""
+        import websockets.sync.client
+
+        ws = websockets.sync.client.connect(ws_echo_url)
+
+        def roundtrip():
+            ws.send("benchmark")
+            return ws.recv()
+
+        result = benchmark(roundtrip)
+        assert result == "benchmark"
+        ws.close()
+
+    def test_connection_setup(self, ws_echo_url, benchmark):
+        """Benchmark connection establishment time (zerodep)."""
+
+        def connect_disconnect():
+            ws = WebSocketClient(ws_echo_url)
+            ws.connect()
+            ws.close()
+
+        benchmark(connect_disconnect)
+
+    def test_connection_setup_websockets(self, ws_echo_url, benchmark):
+        """Benchmark connection establishment time (websockets)."""
+        import websockets.sync.client
+
+        def connect_disconnect():
+            ws = websockets.sync.client.connect(ws_echo_url)
+            ws.close()
+
+        benchmark(connect_disconnect)

--- a/websocket/test_websocket_benchmark.py
+++ b/websocket/test_websocket_benchmark.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from websocket import WebSocketClient
 
 # ── Test data (pre-built at module level) ──────────────────────────────────
@@ -58,6 +60,7 @@ class TestJsonRpcRoundtrip:
         ws.close()
 
     def test_websockets(self, ws_echo_url, benchmark):
+        pytest.importorskip("websockets", reason="websockets not installed")
         import websockets.sync.client
 
         ws = websockets.sync.client.connect(ws_echo_url)
@@ -87,6 +90,7 @@ class TestLargePayload:
         ws.close()
 
     def test_websockets(self, ws_echo_url, benchmark):
+        pytest.importorskip("websockets", reason="websockets not installed")
         import websockets.sync.client
 
         ws = websockets.sync.client.connect(ws_echo_url)
@@ -120,6 +124,7 @@ class TestBurstMessages:
         ws.close()
 
     def test_websockets(self, ws_echo_url, benchmark):
+        pytest.importorskip("websockets", reason="websockets not installed")
         import websockets.sync.client
 
         ws = websockets.sync.client.connect(ws_echo_url)
@@ -149,6 +154,7 @@ class TestConnectionSetup:
         benchmark(connect_close)
 
     def test_websockets(self, ws_echo_url, benchmark):
+        pytest.importorskip("websockets", reason="websockets not installed")
         import websockets.sync.client
 
         def connect_close():

--- a/websocket/test_websocket_benchmark.py
+++ b/websocket/test_websocket_benchmark.py
@@ -1,80 +1,158 @@
-"""Performance benchmarks for the websocket module.
+"""Benchmark: zerodep websocket vs websockets library.
 
-Compares zerodep WebSocket client against the ``websockets`` reference library.
-
-Note: ``websocket-client`` benchmarks are excluded because its import name
-(``websocket``) collides with this module.
+Simulates realistic workloads: JSON-RPC messaging (typical CDP command size),
+large HTML payload transfer (SPA outerHTML extraction), and burst messaging
+(batch CDP commands).
 """
 
 from __future__ import annotations
 
+import json
+
 from websocket import WebSocketClient
 
+# ── Test data (pre-built at module level) ──────────────────────────────────
 
-class TestSyncBenchmarks:
-    """Benchmark sync WebSocket operations."""
+# ~200 bytes — typical CDP JSON-RPC command
+JSONRPC_MSG = json.dumps(
+    {
+        "id": 1,
+        "method": "Page.navigate",
+        "params": {"url": "https://example.com", "transitionType": "typed"},
+    }
+)
 
-    def test_echo_roundtrip(self, ws_echo_url, benchmark):
-        """Measure echo round-trip latency."""
+# ~50 KB — simulates document.documentElement.outerHTML extraction
+LARGE_HTML = (
+    "<html><body>"
+    + "<div class='item'><p>content</p></div>\n" * 1000
+    + "</body></html>"
+)
+
+# 100 JSON-RPC messages — simulates batch CDP commands
+BURST_MESSAGES = [
+    json.dumps(
+        {
+            "id": i,
+            "method": "Runtime.evaluate",
+            "params": {"expression": f"document.querySelectorAll('div')[{i}]"},
+        }
+    )
+    for i in range(100)
+]
+
+
+class TestJsonRpcRoundtrip:
+    """Benchmark JSON-RPC message round-trip (~200B, typical CDP command)."""
+
+    def test_zerodep(self, ws_echo_url, benchmark):
         ws = WebSocketClient(ws_echo_url)
         ws.connect()
 
         def roundtrip():
-            ws.send("benchmark")
+            ws.send(JSONRPC_MSG)
             return ws.recv()
 
         result = benchmark(roundtrip)
-        assert result == "benchmark"
+        assert json.loads(result)["method"] == "Page.navigate"
         ws.close()
 
-    def test_echo_roundtrip_long(self, ws_echo_url, benchmark):
-        """Measure echo round-trip latency for large messages."""
-        ws = WebSocketClient(ws_echo_url)
-        ws.connect()
-        msg = "x" * 10_000
-
-        def roundtrip():
-            ws.send(msg)
-            return ws.recv()
-
-        result = benchmark(roundtrip)
-        assert len(result) == 10_000
-        ws.close()
-
-
-class TestReferenceBenchmarks:
-    """Benchmark against websockets reference library."""
-
-    def test_websockets_echo_roundtrip(self, ws_echo_url, benchmark):
-        """Measure websockets library echo round-trip latency."""
+    def test_websockets(self, ws_echo_url, benchmark):
         import websockets.sync.client
 
         ws = websockets.sync.client.connect(ws_echo_url)
 
         def roundtrip():
-            ws.send("benchmark")
+            ws.send(JSONRPC_MSG)
             return ws.recv()
 
         result = benchmark(roundtrip)
-        assert result == "benchmark"
+        assert json.loads(result)["method"] == "Page.navigate"
         ws.close()
 
-    def test_connection_setup(self, ws_echo_url, benchmark):
-        """Benchmark connection establishment time (zerodep)."""
 
-        def connect_disconnect():
+class TestLargePayload:
+    """Benchmark large HTML payload transfer (~50KB, outerHTML extraction)."""
+
+    def test_zerodep(self, ws_echo_url, benchmark):
+        ws = WebSocketClient(ws_echo_url)
+        ws.connect()
+
+        def roundtrip():
+            ws.send(LARGE_HTML)
+            return ws.recv()
+
+        result = benchmark(roundtrip)
+        assert len(result) == len(LARGE_HTML)
+        ws.close()
+
+    def test_websockets(self, ws_echo_url, benchmark):
+        import websockets.sync.client
+
+        ws = websockets.sync.client.connect(ws_echo_url)
+
+        def roundtrip():
+            ws.send(LARGE_HTML)
+            return ws.recv()
+
+        result = benchmark(roundtrip)
+        assert len(result) == len(LARGE_HTML)
+        ws.close()
+
+
+class TestBurstMessages:
+    """Benchmark burst messaging (100 JSON-RPC commands, batch CDP scenario)."""
+
+    def test_zerodep(self, ws_echo_url, benchmark):
+        ws = WebSocketClient(ws_echo_url)
+        ws.connect()
+
+        def burst():
+            for msg in BURST_MESSAGES:
+                ws.send(msg)
+            results = []
+            for _ in BURST_MESSAGES:
+                results.append(ws.recv())
+            return results
+
+        results = benchmark(burst)
+        assert len(results) == 100
+        ws.close()
+
+    def test_websockets(self, ws_echo_url, benchmark):
+        import websockets.sync.client
+
+        ws = websockets.sync.client.connect(ws_echo_url)
+
+        def burst():
+            for msg in BURST_MESSAGES:
+                ws.send(msg)
+            results = []
+            for _ in BURST_MESSAGES:
+                results.append(ws.recv())
+            return results
+
+        results = benchmark(burst)
+        assert len(results) == 100
+        ws.close()
+
+
+class TestConnectionSetup:
+    """Benchmark connection establishment + close (handshake overhead)."""
+
+    def test_zerodep(self, ws_echo_url, benchmark):
+        def connect_close():
             ws = WebSocketClient(ws_echo_url)
             ws.connect()
             ws.close()
 
-        benchmark(connect_disconnect)
+        benchmark(connect_close)
 
-    def test_connection_setup_websockets(self, ws_echo_url, benchmark):
-        """Benchmark connection establishment time (websockets)."""
+    def test_websockets(self, ws_echo_url, benchmark):
         import websockets.sync.client
 
-        def connect_disconnect():
+        def connect_close():
             ws = websockets.sync.client.connect(ws_echo_url)
             ws.close()
 
-        benchmark(connect_disconnect)
+        benchmark(connect_close)

--- a/websocket/test_websocket_correctness.py
+++ b/websocket/test_websocket_correctness.py
@@ -296,6 +296,7 @@ class TestReferenceComparison:
 
     def test_sync_vs_websockets_echo(self, ws_echo_url):
         """Both clients should get identical echo responses."""
+        pytest.importorskip("websockets", reason="websockets not installed")
         import websockets.sync.client
 
         msg = "reference test 日本語"
@@ -315,6 +316,7 @@ class TestReferenceComparison:
     @pytest.mark.asyncio
     async def test_async_vs_websockets_echo(self, ws_echo_url):
         """Both async clients should get identical echo responses."""
+        pytest.importorskip("websockets", reason="websockets not installed")
         import websockets
 
         msg = "async reference test 中文"

--- a/websocket/test_websocket_correctness.py
+++ b/websocket/test_websocket_correctness.py
@@ -1,0 +1,332 @@
+"""Correctness tests for the websocket module.
+
+Compares zerodep WebSocket client against the ``websockets`` reference library.
+Tests both sync (WebSocketClient) and async (AsyncWebSocketClient) variants.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from websocket import (
+    AsyncWebSocketClient,
+    WebSocketClient,
+    WebSocketConnectionError,
+    WebSocketError,
+    WebSocketTimeoutError,
+)
+
+# ── Sync Tests ─────────────────────────────────────────────────────────────
+
+
+class TestSyncConnection:
+    """Test sync WebSocket connection lifecycle."""
+
+    def test_connect_and_close(self, ws_echo_url):
+        ws = WebSocketClient(ws_echo_url)
+        ws.connect()
+        assert ws.connected
+        ws.close()
+        assert not ws.connected
+
+    def test_context_manager(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            assert ws.connected
+        assert not ws.connected
+
+    def test_double_connect_is_noop(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            ws.connect()  # second call should be a no-op
+            assert ws.connected
+
+    def test_double_close_is_noop(self, ws_echo_url):
+        ws = WebSocketClient(ws_echo_url)
+        ws.connect()
+        ws.close()
+        ws.close()  # should not raise
+        assert not ws.connected
+
+    def test_connection_refused(self):
+        ws = WebSocketClient("ws://127.0.0.1:1")
+        with pytest.raises(WebSocketConnectionError):
+            ws.connect(timeout=2)
+
+    def test_send_without_connect_raises(self):
+        ws = WebSocketClient("ws://127.0.0.1:1")
+        with pytest.raises(WebSocketError, match="not connected"):
+            ws.send("hello")
+
+    def test_recv_without_connect_raises(self):
+        ws = WebSocketClient("ws://127.0.0.1:1")
+        with pytest.raises(WebSocketError, match="not connected"):
+            ws.recv()
+
+
+class TestSyncEcho:
+    """Test sync echo round-trip."""
+
+    def test_short_text(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            ws.send("hello")
+            assert ws.recv() == "hello"
+
+    def test_empty_string(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            ws.send("")
+            assert ws.recv() == ""
+
+    def test_unicode(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            msg = "Hello 世界 🌍 こんにちは"
+            ws.send(msg)
+            assert ws.recv() == msg
+
+    def test_long_text(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            msg = "x" * 100_000
+            ws.send(msg)
+            assert ws.recv() == msg
+
+    def test_multiple_messages(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            for i in range(10):
+                ws.send(f"msg-{i}")
+                assert ws.recv() == f"msg-{i}"
+
+    def test_json_payload(self, ws_echo_url):
+        import json
+
+        with WebSocketClient(ws_echo_url) as ws:
+            payload = json.dumps({"key": "value", "num": 42})
+            ws.send(payload)
+            result = json.loads(ws.recv())
+            assert result == {"key": "value", "num": 42}
+
+
+class TestSyncTimeout:
+    """Test sync timeout handling."""
+
+    def test_recv_timeout(self, ws_echo_url):
+        with WebSocketClient(ws_echo_url) as ws:
+            with pytest.raises(WebSocketTimeoutError):
+                ws.recv(timeout=0.1)
+
+    def test_connect_timeout(self):
+        # Use a non-routable address to trigger connect timeout
+        ws = WebSocketClient("ws://192.0.2.1:9999")
+        with pytest.raises((WebSocketTimeoutError, WebSocketConnectionError)):
+            ws.connect(timeout=0.5)
+
+
+class TestSyncCustomServer:
+    """Test sync client against server with custom behavior."""
+
+    def test_echo_prefix(self, ws_custom_server_url):
+        with WebSocketClient(ws_custom_server_url) as ws:
+            ws.send("hello")
+            assert ws.recv() == "echo:hello"
+
+    def test_server_initiated_close(self, ws_custom_server_url):
+        with WebSocketClient(ws_custom_server_url) as ws:
+            ws.send("close-me")
+            with pytest.raises(WebSocketConnectionError, match="closed by server"):
+                ws.recv()
+
+
+class TestSyncHeaders:
+    """Test sync custom headers."""
+
+    def test_custom_headers(self, ws_echo_url):
+        headers = {"X-Custom-Header": "test-value"}
+        with WebSocketClient(ws_echo_url, headers=headers) as ws:
+            ws.send("hello")
+            assert ws.recv() == "hello"
+
+
+class TestSyncURLParsing:
+    """Test URL parsing edge cases."""
+
+    def test_invalid_scheme(self):
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            WebSocketClient("http://localhost/ws")
+
+    def test_ws_default_port(self, ws_echo_url):
+        # Just verify the URL parsing doesn't crash
+        ws = WebSocketClient("ws://localhost/path?query=1")
+        assert ws._host == "localhost"
+        assert ws._port == 80
+        assert ws._path == "/path?query=1"
+        assert not ws._is_secure
+
+    def test_wss_default_port(self):
+        ws = WebSocketClient("wss://example.com/ws")
+        assert ws._host == "example.com"
+        assert ws._port == 443
+        assert ws._is_secure
+
+
+# ── Async Tests ────────────────────────────────────────────────────────────
+
+
+class TestAsyncConnection:
+    """Test async WebSocket connection lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_connect_and_close(self, ws_echo_url):
+        ws = AsyncWebSocketClient(ws_echo_url)
+        await ws.connect()
+        assert ws.connected
+        await ws.close()
+        assert not ws.connected
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            assert ws.connected
+        assert not ws.connected
+
+    @pytest.mark.asyncio
+    async def test_double_connect_is_noop(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            await ws.connect()  # second call should be a no-op
+            assert ws.connected
+
+    @pytest.mark.asyncio
+    async def test_double_close_is_noop(self, ws_echo_url):
+        ws = AsyncWebSocketClient(ws_echo_url)
+        await ws.connect()
+        await ws.close()
+        await ws.close()  # should not raise
+        assert not ws.connected
+
+    @pytest.mark.asyncio
+    async def test_connection_refused(self):
+        ws = AsyncWebSocketClient("ws://127.0.0.1:1")
+        with pytest.raises(WebSocketConnectionError):
+            await ws.connect(timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_send_without_connect_raises(self):
+        ws = AsyncWebSocketClient("ws://127.0.0.1:1")
+        with pytest.raises(WebSocketError, match="not connected"):
+            await ws.send("hello")
+
+    @pytest.mark.asyncio
+    async def test_recv_without_connect_raises(self):
+        ws = AsyncWebSocketClient("ws://127.0.0.1:1")
+        with pytest.raises(WebSocketError, match="not connected"):
+            await ws.recv()
+
+
+class TestAsyncEcho:
+    """Test async echo round-trip."""
+
+    @pytest.mark.asyncio
+    async def test_short_text(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            await ws.send("hello")
+            assert await ws.recv() == "hello"
+
+    @pytest.mark.asyncio
+    async def test_empty_string(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            await ws.send("")
+            assert await ws.recv() == ""
+
+    @pytest.mark.asyncio
+    async def test_unicode(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            msg = "Hello 世界 🌍 こんにちは"
+            await ws.send(msg)
+            assert await ws.recv() == msg
+
+    @pytest.mark.asyncio
+    async def test_long_text(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            msg = "x" * 100_000
+            await ws.send(msg)
+            assert await ws.recv() == msg
+
+    @pytest.mark.asyncio
+    async def test_multiple_messages(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            for i in range(10):
+                await ws.send(f"msg-{i}")
+                assert await ws.recv() == f"msg-{i}"
+
+
+class TestAsyncTimeout:
+    """Test async timeout handling."""
+
+    @pytest.mark.asyncio
+    async def test_recv_timeout(self, ws_echo_url):
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            with pytest.raises(WebSocketTimeoutError):
+                await ws.recv(timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout(self):
+        ws = AsyncWebSocketClient("ws://192.0.2.1:9999")
+        with pytest.raises((WebSocketTimeoutError, WebSocketConnectionError)):
+            await ws.connect(timeout=0.5)
+
+
+class TestAsyncCustomServer:
+    """Test async client against server with custom behavior."""
+
+    @pytest.mark.asyncio
+    async def test_echo_prefix(self, ws_custom_server_url):
+        async with AsyncWebSocketClient(ws_custom_server_url) as ws:
+            await ws.send("hello")
+            assert await ws.recv() == "echo:hello"
+
+    @pytest.mark.asyncio
+    async def test_server_initiated_close(self, ws_custom_server_url):
+        async with AsyncWebSocketClient(ws_custom_server_url) as ws:
+            await ws.send("close-me")
+            with pytest.raises(WebSocketConnectionError, match="closed by server"):
+                await ws.recv()
+
+
+# ── Reference comparison tests ─────────────────────────────────────────────
+
+
+class TestReferenceComparison:
+    """Compare zerodep websocket against the websockets reference library."""
+
+    def test_sync_vs_websockets_echo(self, ws_echo_url):
+        """Both clients should get identical echo responses."""
+        import websockets.sync.client
+
+        msg = "reference test 日本語"
+
+        # zerodep
+        with WebSocketClient(ws_echo_url) as ws:
+            ws.send(msg)
+            zerodep_result = ws.recv()
+
+        # reference
+        with websockets.sync.client.connect(ws_echo_url) as ws:
+            ws.send(msg)
+            ref_result = ws.recv()
+
+        assert zerodep_result == ref_result == msg
+
+    @pytest.mark.asyncio
+    async def test_async_vs_websockets_echo(self, ws_echo_url):
+        """Both async clients should get identical echo responses."""
+        import websockets
+
+        msg = "async reference test 中文"
+
+        # zerodep
+        async with AsyncWebSocketClient(ws_echo_url) as ws:
+            await ws.send(msg)
+            zerodep_result = await ws.recv()
+
+        # reference
+        async with websockets.connect(ws_echo_url) as ws:
+            await ws.send(msg)
+            ref_result = await ws.recv()
+
+        assert zerodep_result == ref_result == msg

--- a/websocket/websocket.py
+++ b/websocket/websocket.py
@@ -1,0 +1,1058 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "medium"
+# category = "network"
+# ///
+"""Zero-dependency WebSocket client (RFC 6455).
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Provides sync and async WebSocket clients for ``ws://`` and ``wss://``
+connections. Implements the core WebSocket protocol including text frames,
+ping/pong, close handshake, and client-side masking.
+
+Usage::
+
+    # Sync
+    from websocket import WebSocketClient
+
+    with WebSocketClient("ws://localhost:9222/") as ws:
+        ws.send("hello")
+        response = ws.recv()
+        print(response)
+
+    # Async
+    from websocket import AsyncWebSocketClient
+
+    async with AsyncWebSocketClient("wss://example.com/ws") as ws:
+        await ws.send('{"type": "subscribe"}')
+        data = await ws.recv()
+        print(data)
+
+Requires Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import logging
+import os
+import socket
+import ssl
+import struct
+import urllib.parse
+
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    # Exceptions
+    "WebSocketError",
+    "WebSocketConnectionError",
+    "WebSocketTimeoutError",
+    "WebSocketProtocolError",
+    # Clients
+    "WebSocketClient",
+    "AsyncWebSocketClient",
+]
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DEFAULT_TIMEOUT: float = 30.0
+
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_OPCODE_CONT = 0x0
+_OPCODE_TEXT = 0x1
+_OPCODE_BINARY = 0x2
+_OPCODE_CLOSE = 0x8
+_OPCODE_PING = 0x9
+_OPCODE_PONG = 0xA
+_MAX_PAYLOAD_SIZE = 2**23  # 8 MiB default max payload
+
+
+# ── Exceptions ─────────────────────────────────────────────────────────────
+
+
+class WebSocketError(Exception):
+    """Base exception for all websocket operations."""
+
+
+class WebSocketConnectionError(WebSocketError):
+    """Raised on connection failures (TCP connect, handshake reject)."""
+
+    def __init__(self, message: str, *, host: str = "", port: int = 0) -> None:
+        self.host = host
+        self.port = port
+        super().__init__(message)
+
+
+class WebSocketTimeoutError(WebSocketError):
+    """Raised when an operation times out."""
+
+    def __init__(self, message: str, *, url: str = "", timeout: float = 0.0) -> None:
+        self.url = url
+        self.timeout = timeout
+        super().__init__(message)
+
+
+class WebSocketProtocolError(WebSocketError):
+    """Raised on protocol violations (bad frame, unexpected opcode)."""
+
+
+# ── Shared protocol helpers (sync/async) ───────────────────────────────────
+
+
+def _parse_ws_url(url: str) -> tuple[str, int, str, bool]:
+    """Parse a WebSocket URL into (host, port, path, is_secure).
+
+    Args:
+        url: WebSocket URL (ws:// or wss://).
+
+    Returns:
+        Tuple of (host, port, resource_path, is_secure).
+
+    Raises:
+        ValueError: If the URL scheme is not ws or wss.
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in ("ws", "wss"):
+        raise ValueError(f"unsupported scheme: {scheme!r} (expected ws or wss)")
+    is_secure = scheme == "wss"
+    host = parsed.hostname or "localhost"
+    default_port = 443 if is_secure else 80
+    port = parsed.port or default_port
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return host, port, path, is_secure
+
+
+def _make_ssl_context(verify: bool) -> ssl.SSLContext:
+    """Create an SSL context based on verification setting."""
+    if verify:
+        return ssl.create_default_context()
+    return ssl._create_unverified_context()
+
+
+def _build_handshake_request(
+    host: str,
+    port: int,
+    path: str,
+    key: str,
+    *,
+    headers: dict[str, str] | None = None,
+    subprotocols: list[str] | None = None,
+    is_secure: bool = False,
+) -> bytes:
+    """Build the HTTP/1.1 WebSocket upgrade request.
+
+    Args:
+        host: Server hostname.
+        port: Server port.
+        path: Resource path.
+        key: Base64-encoded 16-byte random key.
+        headers: Optional extra headers to include.
+        subprotocols: Optional list of subprotocols to negotiate.
+        is_secure: Whether the connection uses TLS.
+
+    Returns:
+        The raw HTTP upgrade request as bytes.
+    """
+    default_port = 443 if is_secure else 80
+    if port == default_port:
+        host_header = host
+    else:
+        host_header = f"{host}:{port}"
+
+    lines = [
+        f"GET {path} HTTP/1.1",
+        f"Host: {host_header}",
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        f"Sec-WebSocket-Key: {key}",
+        "Sec-WebSocket-Version: 13",
+    ]
+    if subprotocols:
+        lines.append(f"Sec-WebSocket-Protocol: {', '.join(subprotocols)}")
+    if headers:
+        for k, v in headers.items():
+            lines.append(f"{k}: {v}")
+    lines.append("")
+    lines.append("")
+    return "\r\n".join(lines).encode("latin-1")
+
+
+def _compute_accept_key(key: str) -> str:
+    """Compute the expected Sec-WebSocket-Accept value."""
+    digest = hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _validate_handshake_response(data: bytes, key: str) -> dict[str, str]:
+    """Parse and validate the HTTP upgrade response.
+
+    Args:
+        data: Raw HTTP response bytes (up to and including the blank line).
+        key: The Sec-WebSocket-Key sent in the request.
+
+    Returns:
+        Parsed response headers (lowercase keys).
+
+    Raises:
+        WebSocketConnectionError: If the handshake fails validation.
+    """
+    try:
+        text = data.decode("latin-1")
+    except UnicodeDecodeError as exc:
+        raise WebSocketConnectionError(
+            "handshake response is not valid latin-1"
+        ) from exc
+
+    header_end = text.find("\r\n\r\n")
+    if header_end < 0:
+        raise WebSocketConnectionError("incomplete handshake response")
+    header_block = text[: header_end + 2]  # include trailing \r\n
+
+    lines = header_block.split("\r\n")
+    if not lines:
+        raise WebSocketConnectionError("empty handshake response")
+
+    # Status line
+    status_line = lines[0]
+    parts = status_line.split(" ", 2)
+    if len(parts) < 2:
+        raise WebSocketConnectionError(f"malformed status line: {status_line!r}")
+    try:
+        status_code = int(parts[1])
+    except ValueError:
+        raise WebSocketConnectionError(f"non-integer status code: {parts[1]!r}")
+    if status_code != 101:
+        raise WebSocketConnectionError(
+            f"server rejected upgrade with status {status_code}"
+        )
+
+    # Headers
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line:
+            continue
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        headers[k.strip().lower()] = v.strip()
+
+    # Validate required headers
+    upgrade = headers.get("upgrade", "")
+    if upgrade.lower() != "websocket":
+        raise WebSocketConnectionError(
+            f"missing or invalid Upgrade header: {upgrade!r}"
+        )
+    connection = headers.get("connection", "")
+    if "upgrade" not in connection.lower():
+        raise WebSocketConnectionError(
+            f"missing or invalid Connection header: {connection!r}"
+        )
+    expected_accept = _compute_accept_key(key)
+    actual_accept = headers.get("sec-websocket-accept", "")
+    if actual_accept != expected_accept:
+        raise WebSocketConnectionError(
+            f"Sec-WebSocket-Accept mismatch: "
+            f"expected {expected_accept!r}, got {actual_accept!r}"
+        )
+
+    return headers
+
+
+def _make_frame(opcode: int, payload: bytes, *, mask: bool = True) -> bytes:
+    """Build a WebSocket frame.
+
+    Args:
+        opcode: Frame opcode (text, close, ping, pong, etc.).
+        payload: Frame payload bytes.
+        mask: Whether to apply client-side masking (required for client→server).
+
+    Returns:
+        The complete frame as bytes.
+    """
+    header = bytearray()
+    # First byte: FIN=1, RSV=0, opcode
+    header.append(0x80 | opcode)
+
+    length = len(payload)
+    mask_bit = 0x80 if mask else 0x00
+
+    if length < 126:
+        header.append(mask_bit | length)
+    elif length < 65536:
+        header.append(mask_bit | 126)
+        header.extend(struct.pack(">H", length))
+    else:
+        header.append(mask_bit | 127)
+        header.extend(struct.pack(">Q", length))
+
+    if mask:
+        mask_key = os.urandom(4)
+        header.extend(mask_key)
+        masked = _mask_payload(mask_key, payload)
+        return bytes(header) + masked
+    return bytes(header) + payload
+
+
+def _mask_payload(mask_key: bytes, data: bytes) -> bytes:
+    """Apply XOR masking to payload data.
+
+    Args:
+        mask_key: 4-byte mask key.
+        data: Payload bytes to mask/unmask.
+
+    Returns:
+        Masked/unmasked payload bytes.
+    """
+    result = bytearray(len(data))
+    for i, b in enumerate(data):
+        result[i] = b ^ mask_key[i & 3]
+    return bytes(result)
+
+
+def _parse_frame_header(
+    header_bytes: bytes,
+) -> tuple[bool, int, bool, int]:
+    """Parse the first 2 bytes of a WebSocket frame.
+
+    Args:
+        header_bytes: Exactly 2 bytes of frame header.
+
+    Returns:
+        Tuple of (fin, opcode, is_masked, payload_length_indicator).
+    """
+    b0 = header_bytes[0]
+    b1 = header_bytes[1]
+    fin = bool(b0 & 0x80)
+    opcode = b0 & 0x0F
+    is_masked = bool(b1 & 0x80)
+    length = b1 & 0x7F
+    return fin, opcode, is_masked, length
+
+
+def _make_close_payload(code: int, reason: str) -> bytes:
+    """Build the payload for a close frame.
+
+    Args:
+        code: Close status code (e.g. 1000 for normal closure).
+        reason: Human-readable close reason.
+
+    Returns:
+        Close frame payload bytes.
+    """
+    payload = struct.pack(">H", code)
+    if reason:
+        payload += reason.encode("utf-8")
+    return payload
+
+
+# ── Sync WebSocket Client ──────────────────────────────────────────────────
+
+
+class WebSocketClient:
+    """Synchronous WebSocket client.
+
+    Args:
+        url: WebSocket URL (``ws://`` or ``wss://``).
+        headers: Optional extra headers for the upgrade request.
+        subprotocols: Optional list of subprotocols to negotiate.
+
+    Example::
+
+        with WebSocketClient("ws://localhost:9222/") as ws:
+            ws.send("hello")
+            print(ws.recv())
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+    ) -> None:
+        self._url = url
+        self._headers = headers
+        self._subprotocols = subprotocols
+        self._host, self._port, self._path, self._is_secure = _parse_ws_url(url)
+        self._sock: socket.socket | None = None
+        self._connected = False
+        self._closing = False
+        self._accepted_subprotocol: str | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Whether the WebSocket connection is active."""
+        return self._connected
+
+    @property
+    def accepted_subprotocol(self) -> str | None:
+        """The subprotocol accepted by the server, if any."""
+        return self._accepted_subprotocol
+
+    def connect(
+        self,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify: bool = True,
+    ) -> None:
+        """Open the WebSocket connection.
+
+        Args:
+            timeout: Connection timeout in seconds.
+            verify: Whether to verify TLS certificates (for ``wss://``).
+
+        Raises:
+            WebSocketConnectionError: If the TCP connection or handshake fails.
+            WebSocketTimeoutError: If the connection times out.
+        """
+        if self._connected:
+            return
+
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect((self._host, self._port))
+
+            if self._is_secure:
+                ctx = _make_ssl_context(verify)
+                sock = ctx.wrap_socket(sock, server_hostname=self._host)
+
+            # Send upgrade request
+            key = base64.b64encode(os.urandom(16)).decode("ascii")
+            request = _build_handshake_request(
+                self._host,
+                self._port,
+                self._path,
+                key,
+                headers=self._headers,
+                subprotocols=self._subprotocols,
+                is_secure=self._is_secure,
+            )
+            sock.sendall(request)
+
+            # Read response until \r\n\r\n
+            response = self._read_handshake_response(sock)
+            resp_headers = _validate_handshake_response(response, key)
+
+            # Check subprotocol
+            if self._subprotocols:
+                accepted = resp_headers.get("sec-websocket-protocol", "")
+                if accepted:
+                    self._accepted_subprotocol = accepted
+
+            self._sock = sock
+            self._connected = True
+            self._closing = False
+
+        except socket.timeout as exc:
+            raise WebSocketTimeoutError(
+                f"connection to {self._url} timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout,
+            ) from exc
+        except OSError as exc:
+            raise WebSocketConnectionError(
+                f"failed to connect to {self._host}:{self._port}: {exc}",
+                host=self._host,
+                port=self._port,
+            ) from exc
+
+    def send(self, data: str) -> None:
+        """Send a text message.
+
+        Args:
+            data: Text message to send.
+
+        Raises:
+            WebSocketError: If not connected.
+        """
+        self._ensure_connected()
+        payload = data.encode("utf-8")
+        frame = _make_frame(_OPCODE_TEXT, payload, mask=True)
+        assert self._sock is not None
+        self._sock.sendall(frame)
+
+    def recv(self, *, timeout: float | None = None) -> str:
+        """Receive a text message.
+
+        Automatically handles ping frames by sending pong responses.
+        Raises on close frames.
+
+        Args:
+            timeout: Receive timeout in seconds. ``None`` uses the socket's
+                current timeout.
+
+        Returns:
+            The received text message.
+
+        Raises:
+            WebSocketTimeoutError: If the receive times out.
+            WebSocketProtocolError: On protocol errors.
+            WebSocketConnectionError: If the connection is closed.
+        """
+        self._ensure_connected()
+        assert self._sock is not None
+        old_timeout = self._sock.gettimeout()
+        if timeout is not None:
+            self._sock.settimeout(timeout)
+        try:
+            return self._recv_message()
+        except socket.timeout as exc:
+            raise WebSocketTimeoutError(
+                f"recv timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout or 0.0,
+            ) from exc
+        finally:
+            if timeout is not None:
+                self._sock.settimeout(old_timeout)
+
+    def ping(self, data: bytes = b"") -> None:
+        """Send a ping frame.
+
+        Args:
+            data: Optional ping payload (max 125 bytes).
+        """
+        self._ensure_connected()
+        assert self._sock is not None
+        frame = _make_frame(_OPCODE_PING, data, mask=True)
+        self._sock.sendall(frame)
+
+    def close(self, code: int = 1000, reason: str = "") -> None:
+        """Close the WebSocket connection.
+
+        Sends a close frame, waits for the server's close frame response,
+        then closes the underlying socket.
+
+        Args:
+            code: Close status code (default 1000 for normal closure).
+            reason: Human-readable close reason.
+        """
+        if not self._connected or self._sock is None:
+            return
+
+        try:
+            if not self._closing:
+                self._closing = True
+                payload = _make_close_payload(code, reason)
+                frame = _make_frame(_OPCODE_CLOSE, payload, mask=True)
+                self._sock.sendall(frame)
+
+                # Try to receive server's close frame
+                old_timeout = self._sock.gettimeout()
+                self._sock.settimeout(2.0)
+                try:
+                    while True:
+                        opcode, _, _ = self._read_frame()
+                        if opcode == _OPCODE_CLOSE:
+                            break
+                except (socket.timeout, WebSocketError, OSError):
+                    pass
+                finally:
+                    try:
+                        self._sock.settimeout(old_timeout)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        finally:
+            self._shutdown()
+
+    def __enter__(self) -> WebSocketClient:
+        self.connect()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # ── Sync internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if not self._connected or self._sock is None:
+            raise WebSocketError("not connected")
+
+    def _shutdown(self) -> None:
+        """Close the socket and reset state."""
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        self._connected = False
+        self._closing = False
+
+    def _recv_message(self) -> str:
+        """Read frames until a complete text message is received."""
+        assert self._sock is not None
+        while True:
+            opcode, payload, fin = self._read_frame()
+
+            if opcode == _OPCODE_TEXT:
+                if not fin:
+                    raise WebSocketProtocolError(
+                        "fragmented messages are not supported"
+                    )
+                return payload.decode("utf-8")
+
+            if opcode == _OPCODE_PING:
+                pong = _make_frame(_OPCODE_PONG, payload, mask=True)
+                self._sock.sendall(pong)
+                continue
+
+            if opcode == _OPCODE_PONG:
+                continue
+
+            if opcode == _OPCODE_CLOSE:
+                close_code = 1005
+                close_reason = ""
+                if len(payload) >= 2:
+                    close_code = struct.unpack(">H", payload[:2])[0]
+                    close_reason = payload[2:].decode("utf-8", errors="replace")
+                # Send close response if we didn't initiate
+                if not self._closing:
+                    self._closing = True
+                    resp_payload = _make_close_payload(close_code, "")
+                    resp_frame = _make_frame(_OPCODE_CLOSE, resp_payload, mask=True)
+                    try:
+                        self._sock.sendall(resp_frame)
+                    except OSError:
+                        pass
+                self._shutdown()
+                raise WebSocketConnectionError(
+                    f"connection closed by server: {close_code} {close_reason}",
+                    host=self._host,
+                    port=self._port,
+                )
+
+            if opcode == _OPCODE_BINARY:
+                raise WebSocketProtocolError("binary frames are not supported")
+
+            raise WebSocketProtocolError(f"unexpected opcode: {opcode:#x}")
+
+    def _read_frame(self) -> tuple[int, bytes, bool]:
+        """Read a single WebSocket frame from the socket.
+
+        Returns:
+            Tuple of (opcode, payload, fin).
+        """
+        assert self._sock is not None
+        header = _recv_exact(self._sock, 2)
+        fin, opcode, is_masked, length = _parse_frame_header(header)
+
+        # Extended payload length
+        if length == 126:
+            ext = _recv_exact(self._sock, 2)
+            length = struct.unpack(">H", ext)[0]
+        elif length == 127:
+            ext = _recv_exact(self._sock, 8)
+            length = struct.unpack(">Q", ext)[0]
+
+        if length > _MAX_PAYLOAD_SIZE:
+            raise WebSocketProtocolError(
+                f"payload too large: {length} bytes (max {_MAX_PAYLOAD_SIZE})"
+            )
+
+        # Mask key (server should not mask, but handle it)
+        mask_key = None
+        if is_masked:
+            mask_key = _recv_exact(self._sock, 4)
+
+        # Payload
+        payload = _recv_exact(self._sock, length) if length > 0 else b""
+        if mask_key:
+            payload = _mask_payload(mask_key, payload)
+
+        return opcode, payload, fin
+
+    @staticmethod
+    def _read_handshake_response(sock: socket.socket) -> bytes:
+        """Read the HTTP handshake response until \\r\\n\\r\\n."""
+        buf = bytearray()
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise WebSocketConnectionError("connection closed during handshake")
+            buf.extend(chunk)
+            if b"\r\n\r\n" in buf:
+                return bytes(buf)
+            if len(buf) > 65536:
+                raise WebSocketConnectionError("handshake response too large")
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly *n* bytes from a socket, handling partial reads.
+
+    Args:
+        sock: Connected socket.
+        n: Number of bytes to read.
+
+    Returns:
+        Exactly *n* bytes.
+
+    Raises:
+        WebSocketConnectionError: If the socket closes before *n* bytes arrive.
+    """
+    if n == 0:
+        return b""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise WebSocketConnectionError(
+                f"connection closed: expected {n} bytes, got {len(buf)}"
+            )
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+# ── Async WebSocket Client ─────────────────────────────────────────────────
+
+
+class AsyncWebSocketClient:
+    """Asynchronous WebSocket client.
+
+    Args:
+        url: WebSocket URL (``ws://`` or ``wss://``).
+        headers: Optional extra headers for the upgrade request.
+        subprotocols: Optional list of subprotocols to negotiate.
+
+    Example::
+
+        async with AsyncWebSocketClient("wss://example.com/ws") as ws:
+            await ws.send("hello")
+            print(await ws.recv())
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+    ) -> None:
+        self._url = url
+        self._headers = headers
+        self._subprotocols = subprotocols
+        self._host, self._port, self._path, self._is_secure = _parse_ws_url(url)
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._connected = False
+        self._closing = False
+        self._accepted_subprotocol: str | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Whether the WebSocket connection is active."""
+        return self._connected
+
+    @property
+    def accepted_subprotocol(self) -> str | None:
+        """The subprotocol accepted by the server, if any."""
+        return self._accepted_subprotocol
+
+    async def connect(
+        self,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify: bool = True,
+    ) -> None:
+        """Open the WebSocket connection.
+
+        Args:
+            timeout: Connection timeout in seconds.
+            verify: Whether to verify TLS certificates (for ``wss://``).
+
+        Raises:
+            WebSocketConnectionError: If the TCP connection or handshake fails.
+            WebSocketTimeoutError: If the connection times out.
+        """
+        if self._connected:
+            return
+
+        try:
+            ssl_ctx = _make_ssl_context(verify) if self._is_secure else None
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self._host, self._port, ssl=ssl_ctx),
+                timeout=timeout,
+            )
+
+            # Send upgrade request
+            key = base64.b64encode(os.urandom(16)).decode("ascii")
+            request = _build_handshake_request(
+                self._host,
+                self._port,
+                self._path,
+                key,
+                headers=self._headers,
+                subprotocols=self._subprotocols,
+                is_secure=self._is_secure,
+            )
+            writer.write(request)
+            await writer.drain()
+
+            # Read response until \r\n\r\n
+            response = await asyncio.wait_for(
+                self._async_read_handshake_response(reader),
+                timeout=timeout,
+            )
+            resp_headers = _validate_handshake_response(response, key)
+
+            # Check subprotocol
+            if self._subprotocols:
+                accepted = resp_headers.get("sec-websocket-protocol", "")
+                if accepted:
+                    self._accepted_subprotocol = accepted
+
+            self._reader = reader
+            self._writer = writer
+            self._connected = True
+            self._closing = False
+
+        except asyncio.TimeoutError as exc:
+            raise WebSocketTimeoutError(
+                f"connection to {self._url} timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout,
+            ) from exc
+        except OSError as exc:
+            raise WebSocketConnectionError(
+                f"failed to connect to {self._host}:{self._port}: {exc}",
+                host=self._host,
+                port=self._port,
+            ) from exc
+
+    async def send(self, data: str) -> None:
+        """Send a text message.
+
+        Args:
+            data: Text message to send.
+
+        Raises:
+            WebSocketError: If not connected.
+        """
+        self._ensure_connected()
+        assert self._writer is not None
+        payload = data.encode("utf-8")
+        frame = _make_frame(_OPCODE_TEXT, payload, mask=True)
+        self._writer.write(frame)
+        await self._writer.drain()
+
+    async def recv(self, *, timeout: float | None = None) -> str:
+        """Receive a text message.
+
+        Automatically handles ping frames by sending pong responses.
+        Raises on close frames.
+
+        Args:
+            timeout: Receive timeout in seconds. ``None`` waits indefinitely.
+
+        Returns:
+            The received text message.
+
+        Raises:
+            WebSocketTimeoutError: If the receive times out.
+            WebSocketProtocolError: On protocol errors.
+            WebSocketConnectionError: If the connection is closed.
+        """
+        self._ensure_connected()
+        try:
+            if timeout is not None:
+                return await asyncio.wait_for(self._recv_message(), timeout=timeout)
+            return await self._recv_message()
+        except asyncio.TimeoutError as exc:
+            raise WebSocketTimeoutError(
+                f"recv timed out after {timeout}s",
+                url=self._url,
+                timeout=timeout or 0.0,
+            ) from exc
+
+    async def ping(self, data: bytes = b"") -> None:
+        """Send a ping frame.
+
+        Args:
+            data: Optional ping payload (max 125 bytes).
+        """
+        self._ensure_connected()
+        assert self._writer is not None
+        frame = _make_frame(_OPCODE_PING, data, mask=True)
+        self._writer.write(frame)
+        await self._writer.drain()
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        """Close the WebSocket connection.
+
+        Sends a close frame, waits for the server's close frame response,
+        then closes the underlying transport.
+
+        Args:
+            code: Close status code (default 1000 for normal closure).
+            reason: Human-readable close reason.
+        """
+        if not self._connected or self._writer is None:
+            return
+
+        try:
+            if not self._closing:
+                self._closing = True
+                payload = _make_close_payload(code, reason)
+                frame = _make_frame(_OPCODE_CLOSE, payload, mask=True)
+                self._writer.write(frame)
+                await self._writer.drain()
+
+                # Try to receive server's close frame
+                try:
+                    while True:
+                        opcode, _, _ = await asyncio.wait_for(
+                            self._read_frame(), timeout=2.0
+                        )
+                        if opcode == _OPCODE_CLOSE:
+                            break
+                except (asyncio.TimeoutError, WebSocketError, OSError):
+                    pass
+        except OSError:
+            pass
+        finally:
+            await self._shutdown()
+
+    async def __aenter__(self) -> AsyncWebSocketClient:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    # ── Async internal helpers ──
+
+    def _ensure_connected(self) -> None:
+        if not self._connected or self._reader is None or self._writer is None:
+            raise WebSocketError("not connected")
+
+    async def _shutdown(self) -> None:
+        """Close the transport and reset state."""
+        if self._writer is not None:
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except OSError:
+                pass
+            self._writer = None
+        self._reader = None
+        self._connected = False
+        self._closing = False
+
+    async def _recv_message(self) -> str:
+        """Read frames until a complete text message is received."""
+        assert self._writer is not None
+        while True:
+            opcode, payload, fin = await self._read_frame()
+
+            if opcode == _OPCODE_TEXT:
+                if not fin:
+                    raise WebSocketProtocolError(
+                        "fragmented messages are not supported"
+                    )
+                return payload.decode("utf-8")
+
+            if opcode == _OPCODE_PING:
+                pong = _make_frame(_OPCODE_PONG, payload, mask=True)
+                self._writer.write(pong)
+                await self._writer.drain()
+                continue
+
+            if opcode == _OPCODE_PONG:
+                continue
+
+            if opcode == _OPCODE_CLOSE:
+                close_code = 1005
+                close_reason = ""
+                if len(payload) >= 2:
+                    close_code = struct.unpack(">H", payload[:2])[0]
+                    close_reason = payload[2:].decode("utf-8", errors="replace")
+                # Send close response if we didn't initiate
+                if not self._closing:
+                    self._closing = True
+                    resp_payload = _make_close_payload(close_code, "")
+                    resp_frame = _make_frame(_OPCODE_CLOSE, resp_payload, mask=True)
+                    try:
+                        self._writer.write(resp_frame)
+                        await self._writer.drain()
+                    except OSError:
+                        pass
+                await self._shutdown()
+                raise WebSocketConnectionError(
+                    f"connection closed by server: {close_code} {close_reason}",
+                    host=self._host,
+                    port=self._port,
+                )
+
+            if opcode == _OPCODE_BINARY:
+                raise WebSocketProtocolError("binary frames are not supported")
+
+            raise WebSocketProtocolError(f"unexpected opcode: {opcode:#x}")
+
+    async def _read_frame(self) -> tuple[int, bytes, bool]:
+        """Read a single WebSocket frame from the stream.
+
+        Returns:
+            Tuple of (opcode, payload, fin).
+        """
+        assert self._reader is not None
+        header = await self._reader.readexactly(2)
+        fin, opcode, is_masked, length = _parse_frame_header(header)
+
+        # Extended payload length
+        if length == 126:
+            ext = await self._reader.readexactly(2)
+            length = struct.unpack(">H", ext)[0]
+        elif length == 127:
+            ext = await self._reader.readexactly(8)
+            length = struct.unpack(">Q", ext)[0]
+
+        if length > _MAX_PAYLOAD_SIZE:
+            raise WebSocketProtocolError(
+                f"payload too large: {length} bytes (max {_MAX_PAYLOAD_SIZE})"
+            )
+
+        # Mask key (server should not mask, but handle it)
+        mask_key = None
+        if is_masked:
+            mask_key = await self._reader.readexactly(4)
+
+        # Payload
+        payload = await self._reader.readexactly(length) if length > 0 else b""
+        if mask_key:
+            payload = _mask_payload(mask_key, payload)
+
+        return opcode, payload, fin
+
+    @staticmethod
+    async def _async_read_handshake_response(
+        reader: asyncio.StreamReader,
+    ) -> bytes:
+        """Read the HTTP handshake response until \\r\\n\\r\\n."""
+        buf = bytearray()
+        while True:
+            chunk = await reader.read(4096)
+            if not chunk:
+                raise WebSocketConnectionError("connection closed during handshake")
+            buf.extend(chunk)
+            if b"\r\n\r\n" in buf:
+                return bytes(buf)
+            if len(buf) > 65536:
+                raise WebSocketConnectionError("handshake response too large")


### PR DESCRIPTION
## Summary

Closes #68, closes #70

- **websocket module**: RFC 6455 WebSocket client with sync (`WebSocketClient`) + async (`AsyncWebSocketClient`) support. Shared protocol logic (frame encoding/masking, handshake, close handshake), stdlib-only.
- **cdp module**: Chrome DevTools Protocol client (`CDPClient` / `AsyncCDPClient`) built on websocket. Supports target management, page navigation, JS evaluation, rendered text/HTML extraction, and auto-discovery via `/json/version`.
- Benchmarks simulate production scenarios: JSON-RPC messaging, large HTML payload transfer, burst commands, full SPA render pipeline, multi-tab management.

## Test plan

- [x] `make test-websocket` — 39 correctness tests (sync + async connection, echo, timeout, headers, URL parsing, reference comparison)
- [x] `make test-cdp` — 34 correctness tests (sync + async connection, auto-discovery, target management, navigation, evaluate, high-level API)
- [x] `make benchmark-websocket` — 8 benchmarks vs websockets library (JSON-RPC roundtrip, 50KB payload, 100-msg burst, connection setup)
- [x] `make benchmark-cdp` — 6 benchmarks (full render pipeline, HTML extraction, 5-tab multi-target, JS eval burst, command throughput)
- [x] Tested against real headless Chromium (`chromium --headless --remote-debugging-port=9222`)