### PR TITLE
chore: add pre-commit config and tune complexipy/ty settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check
+        description: Type check with ty.
+        entry: ty check
+        language: system
+        pass_filenames: false
+        require_serial: true
+        types: [python]
+
+  - repo: local
+    hooks:
+      - id: complexipy
+        name: complexipy (complexity check)
+        entry: complexipy . -mx 45
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,8 +190,30 @@ max-complexity = 20
 
 [tool.complexipy]
 paths = ["."]
-max-complexity-allowed = 20
-exclude = ["**/test_*.py", "**/test_*_benchmark.py"]
+max-complexity-allowed = 45
+exclude = ["**/test_*.py", "**/test_*_benchmark.py", "**/conftest.py", "_scripts/"]
+
+[tool.ty.src]
+exclude = [
+    ".claude/",
+    "_scripts/",
+    "**/test_*.py",
+    "**/conftest.py",
+    # Modules with type issues — fix gradually and remove from this list
+    "protobuf/",
+    "cache/",
+    "xml/",
+    "httpclient/",
+    "sparse_search/",
+    "readability/",
+    "png/",
+    "toon/",
+    "semver/",
+    "frontmatter/",
+    "depdetect/",
+    "config/",
+    "zerodep.py",
+]
 
 [tool.ty.environment]
 extra-paths = [


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with ruff, ruff-format, ty (local), and complexipy (local) hooks
- Raise complexipy `max-complexity-allowed` to 45 and expand exclude list
- Add `ty.src.exclude` for modules with known type issues to reduce noise

## Notes
Uses local hooks for ty and complexipy (`language: system`) — requires both to be installed in the active environment.