### PR TITLE
fix(httpclient): remove global lock that serialises concurrent requests

### DIFF
--- a/httpclient/conftest.py
+++ b/httpclient/conftest.py
@@ -16,6 +16,7 @@ import socket
 import socketserver
 import struct
 import threading
+import time
 import zlib
 from http.client import HTTPConnection
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -288,6 +289,10 @@ class _HttpBinHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+        elif path.startswith("/delay/"):
+            seconds = float(path.rsplit("/", 1)[1])
+            time.sleep(seconds)
+            self._send_json({"delay": seconds})
         else:
             self.send_response(404)
             self.send_header("Content-Length", "0")

--- a/httpclient/httpclient.py
+++ b/httpclient/httpclient.py
@@ -2437,7 +2437,8 @@ async def async_options(url: str, **kwargs: Any) -> Response | StreamingResponse
 class Client:
     """Synchronous HTTP client session with connection pooling.
 
-    Thread-safe: uses a threading.Lock internally.
+    Thread-safe: the underlying connection pool uses its own
+    ``threading.Lock`` to protect shared state.
 
     Usage::
 
@@ -2463,7 +2464,6 @@ class Client:
         self._auth = auth
         self._proxy = proxy
         self._pool = _SyncConnectionPool(pool_size)
-        self._lock = threading.Lock()
 
     def request(
         self,
@@ -2479,10 +2479,7 @@ class Client:
         kwargs.setdefault("proxy", self._proxy)
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
-        if kwargs.get("stream"):
-            return _sync_request(method, url, **kwargs)
-        with self._lock:
-            return _sync_request(method, url, **kwargs)
+        return _sync_request(method, url, **kwargs)
 
     def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
         return self.request("GET", url, **kwargs)
@@ -2519,8 +2516,8 @@ class Client:
 class AsyncClient:
     """Asynchronous HTTP client session with connection pooling.
 
-    Safe to use from a single asyncio task; for concurrent requests
-    from the same client, use asyncio.Lock internally.
+    Safe for concurrent use from multiple asyncio tasks.  The underlying
+    connection pool uses its own ``asyncio.Lock`` to protect shared state.
 
     Usage::
 
@@ -2546,7 +2543,6 @@ class AsyncClient:
         self._auth = auth
         self._proxy = proxy
         self._pool = _AsyncConnectionPool(pool_size)
-        self._lock = asyncio.Lock()
 
     async def request(
         self,
@@ -2562,10 +2558,7 @@ class AsyncClient:
         kwargs.setdefault("proxy", self._proxy)
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
-        if kwargs.get("stream"):
-            return await _async_request(method, url, **kwargs)
-        async with self._lock:
-            return await _async_request(method, url, **kwargs)
+        return await _async_request(method, url, **kwargs)
 
     async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
         return await self.request("GET", url, **kwargs)

--- a/httpclient/test_httpclient_correctness.py
+++ b/httpclient/test_httpclient_correctness.py
@@ -1,7 +1,10 @@
 """Correctness tests: zerodep HTTP client vs httpx."""
 
+import asyncio
 import os
 import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -780,3 +783,56 @@ class TestAsyncSocks5:
         async with AsyncClient(proxy=socks5_url) as c:
             r = await c.get(f"{httpbin_url}/get")
             assert r.status_code == 200
+
+
+# ── Concurrency ──
+
+
+class TestAsyncConcurrency:
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_not_serialized(self, httpbin_url):
+        """Multiple async requests via the same client run concurrently."""
+        async with AsyncClient() as c:
+            start = time.monotonic()
+            results = await asyncio.gather(
+                *[c.get(f"{httpbin_url}/delay/0.3") for _ in range(5)]
+            )
+            elapsed = time.monotonic() - start
+
+        assert all(r.status_code == 200 for r in results)
+        # Concurrent: ~0.3s.  Serialized (old behavior): >= 1.5s.
+        assert elapsed < 1.0, f"Requests appear serialized: {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_no_deadlock_on_concurrent_use(self, httpbin_url):
+        """Concurrent requests must not deadlock (regression for #76)."""
+        async with AsyncClient() as c:
+            results = await asyncio.wait_for(
+                asyncio.gather(
+                    c.get(f"{httpbin_url}/get"),
+                    c.get(f"{httpbin_url}/json"),
+                    c.get(f"{httpbin_url}/get"),
+                ),
+                timeout=5.0,
+            )
+        assert all(r.status_code == 200 for r in results)
+
+
+class TestSyncConcurrency:
+    def test_concurrent_requests_from_threads(self, httpbin_url):
+        """Sync Client handles concurrent requests from multiple threads."""
+        client = Client()
+        errors = []
+
+        def do_request(i):
+            try:
+                r = client.get(f"{httpbin_url}/get")
+                assert r.status_code == 200
+            except Exception as exc:
+                errors.append((i, exc))
+
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            list(pool.map(do_request, range(10)))
+
+        client.close()
+        assert not errors, f"Thread errors: {errors}"


### PR DESCRIPTION
## Summary

- Remove the redundant client-level `Lock` from both `AsyncClient` and `Client` — the connection pools (`_AsyncConnectionPool` / `_SyncConnectionPool`) already protect shared state with their own fine-grained locks
- The global lock serialised all non-streaming requests through the same client instance and caused deadlock in self-call / loopback scenarios
- Add `/delay/<seconds>` endpoint to the test server for concurrency testing
- Add concurrency tests: async gather (verifies parallel execution), deadlock regression, and multi-thread sync client

Closes #76

## Test plan

- [x] All 107 existing + new tests pass (`make test-http`)
- [x] `test_concurrent_requests_not_serialized` — 5 × 0.3s delay requests complete in < 1s (would take ≥ 1.5s if serialised)
- [x] `test_no_deadlock_on_concurrent_use` — concurrent requests complete within timeout
- [x] `test_concurrent_requests_from_threads` — 10 requests from 5 threads, no crash or data corruption
- [x] Lint passes