### PR TITLE
feat(lint): enable ruff ASYNC rules in pre-commit

### DIFF
--- a/cache/test_cache_correctness.py
+++ b/cache/test_cache_correctness.py
@@ -765,7 +765,7 @@ class TestConvenienceDecorators:
             return x
 
         assert await f(1) == 1
-        time.sleep(0.06)
+        await asyncio.sleep(0.06)
         assert await f(1) == 1  # recomputed after expiry
 
     @pytest.mark.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,10 @@ testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonc", "structlog", 
 
 [tool.ruff]
 target-version = "py310"
+exclude = [".claude/"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "C901"]
+select = ["E", "F", "I", "W", "C901", "ASYNC"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 20


### PR DESCRIPTION
## Summary

- Add `"ASYNC"` to `[tool.ruff.lint] select` in `pyproject.toml`, enabling asyncio anti-pattern detection (ASYNC1xx/ASYNC2xx rules) for all ruff invocations including pre-commit
- Exclude `.claude/` worktrees from ruff scan, consistent with existing `ty` config
- Fix the one ASYNC251 violation surfaced: `cache/test_cache_correctness.py` was calling `time.sleep()` inside an async test — replaced with `await asyncio.sleep()`