### PR TITLE
fix(httpclient): URL-encode dict data without files

### DIFF
--- a/httpclient/httpclient.py
+++ b/httpclient/httpclient.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.1"
+# version = "0.4.2"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -2230,7 +2230,8 @@ def _prepare_body(
 
     Priority: json > files > data.
     When files is provided and data is a dict, data fields are included
-    as text parts in the multipart body.
+    as text parts in the multipart body. When data is a dict without files,
+    it is URL-encoded as application/x-www-form-urlencoded.
 
     Returns:
         (body_bytes, content_type) tuple.
@@ -2240,6 +2241,8 @@ def _prepare_body(
     if files is not None:
         form_data = data if isinstance(data, dict) else None
         return _encode_multipart(form_data, files)
+    if isinstance(data, dict):
+        return urlencode(data).encode("utf-8"), "application/x-www-form-urlencoded"
     if isinstance(data, str):
         return data.encode("utf-8"), "application/x-www-form-urlencoded"
     if isinstance(data, bytes):

--- a/httpclient/test_httpclient_edge.py
+++ b/httpclient/test_httpclient_edge.py
@@ -13,6 +13,7 @@ from httpclient import (
     HTTPError,
     HttpTimeoutError,
     StreamingResponse,
+    _prepare_body,
     _SyncConnectionPool,
     get,
 )
@@ -164,3 +165,50 @@ class TestTimeoutBehavior:
         assert err.url == "http://example.com/missing"
         assert "404" in str(err)
         assert "http://example.com/missing" in str(err)
+
+
+# ── _prepare_body ───────────────────────────────────────────────────────────
+
+
+class TestPrepareBody:
+    """Tests for _prepare_body dict-data handling."""
+
+    def test_dict_data_urlencoded(self):
+        """Dict data without files should be URL-encoded."""
+        body, content_type = _prepare_body(data={"key": "value", "foo": "bar"})
+        assert content_type == "application/x-www-form-urlencoded"
+        assert body is not None
+        decoded = body.decode("utf-8")
+        assert "key=value" in decoded
+        assert "foo=bar" in decoded
+
+    def test_dict_data_special_chars(self):
+        """Dict data with special characters should be percent-encoded."""
+        body, content_type = _prepare_body(data={"q": "hello world", "x": "a&b=c"})
+        assert content_type == "application/x-www-form-urlencoded"
+        decoded = body.decode("utf-8")
+        assert "hello+world" in decoded or "hello%20world" in decoded
+        assert "a%26b%3Dc" in decoded
+
+    def test_dict_data_empty(self):
+        """Empty dict should produce empty URL-encoded body."""
+        body, content_type = _prepare_body(data={})
+        assert content_type == "application/x-www-form-urlencoded"
+        assert body == b""
+
+    def test_json_takes_priority_over_dict_data(self):
+        """json parameter should take priority over dict data."""
+        body, content_type = _prepare_body(data={"key": "value"}, json={"j": 1})
+        assert content_type == "application/json"
+
+    def test_str_data_still_works(self):
+        """String data should still work as before."""
+        body, content_type = _prepare_body(data="key=value")
+        assert content_type == "application/x-www-form-urlencoded"
+        assert body == b"key=value"
+
+    def test_none_data_returns_none(self):
+        """None data should return (None, None)."""
+        body, content_type = _prepare_body()
+        assert body is None
+        assert content_type is None

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-05-16T17:42:55.129994+00:00",
+  "generated": "2026-06-01T19:07:41.741652+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -163,12 +163,12 @@
       "files": [
         "httpclient/httpclient.py"
       ],
-      "version": "0.4.1",
+      "version": "0.4.2",
       "deps": [],
       "tier": "subsystem",
       "category": "network",
       "last_updated": "2026-05-16T11:04:23-05:00",
-      "content_hash": "2cad662d7af2f0e799d4924d2cb0868ca3a16a54d9a23424bb8449b53e8723a0"
+      "content_hash": "4878a4c5f1659b2dfd91cdc22e9276671e249c6cbe250dc576898c32a9b82877"
     },
     "httpserver": {
       "description": "Zero-dependency async HTTP server with decorator-based routing",
@@ -251,7 +251,7 @@
       "deps": [],
       "tier": "medium",
       "category": "serialization",
-      "last_updated": null,
+      "last_updated": "2026-05-16T12:57:30-05:00",
       "content_hash": "a1e3112a90c16b78c18917c58a96620eefd3c7f1085d89347d5f846b2b567cd0"
     },
     "persistdict": {


### PR DESCRIPTION
## Summary

- `_prepare_body(data={"key": "value"})` silently returned `(None, None)` when `files` was not provided — the dict fell through all branches
- Added a `dict` branch that URL-encodes the data as `application/x-www-form-urlencoded`, matching `httpx`/`requests` behavior
- `urlencode` was already imported, so no new imports needed

Closes #93

## Test plan

- [x] Unit tests added in `TestPrepareBody` (6 cases: basic dict, special chars, empty dict, json priority, str data, None data)
- [x] All existing edge tests still pass
- [x] Pre-commit hooks pass (ruff, ruff-format, ty, complexipy)