### PR TITLE
fix: return HTTP error responses instead of silent disconnects

### DIFF
--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.2.0"
+# version = "0.2.1"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -908,10 +908,40 @@ class App:
                 pass
             writer.close()
             return
-        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+        except asyncio.TimeoutError:
+            logger.debug("Request read timed out from %s", client_addr)
+            response = JSONResponse(
+                {"error": "Request Timeout"},
+                status_code=408,
+            )
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except asyncio.IncompleteReadError:
+            logger.debug("Incomplete request body from %s", client_addr)
+            response = JSONResponse(
+                {"error": "Bad Request: incomplete body"},
+                status_code=400,
+            )
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
             writer.close()
             return
         except Exception:
+            logger.debug("Failed to read request from %s", client_addr, exc_info=True)
+            response = JSONResponse(
+                {"error": "Internal Server Error"},
+                status_code=500,
+            )
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
             writer.close()
             return
 

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -874,6 +874,22 @@ class App:
 
     # ── Connection Handling ───────────────────────────────────────────────
 
+    @staticmethod
+    async def _send_error_and_close(
+        writer: asyncio.StreamWriter,
+        response: Response | JSONResponse,
+    ) -> None:
+        """Write an error response to the client and close the connection.
+
+        Swallows broken-pipe / reset errors that occur when the client has
+        already disconnected.
+        """
+        try:
+            await response._write(writer)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        writer.close()
+
     async def _handle_connection(
         self,
         reader: asyncio.StreamReader,
@@ -889,60 +905,43 @@ class App:
             )
         except _BadRequest as exc:
             logger.debug("Bad request from %s: %s", client_addr, exc)
-            response = Response(
-                body=str(exc),
-                status_code=400,
-                content_type="text/plain; charset=utf-8",
+            await self._send_error_and_close(
+                writer,
+                Response(
+                    body=str(exc),
+                    status_code=400,
+                    content_type="text/plain; charset=utf-8",
+                ),
             )
-            try:
-                await response._write(writer)
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-            writer.close()
             return
         except HTTPException as exc:
-            response = JSONResponse({"error": exc.message}, status_code=exc.status_code)
-            try:
-                await response._write(writer)
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-            writer.close()
+            await self._send_error_and_close(
+                writer,
+                JSONResponse({"error": exc.message}, status_code=exc.status_code),
+            )
             return
         except asyncio.TimeoutError:
             logger.debug("Request read timed out from %s", client_addr)
-            response = JSONResponse(
-                {"error": "Request Timeout"},
-                status_code=408,
+            await self._send_error_and_close(
+                writer,
+                JSONResponse({"error": "Request Timeout"}, status_code=408),
             )
-            try:
-                await response._write(writer)
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-            writer.close()
             return
         except asyncio.IncompleteReadError:
             logger.debug("Incomplete request body from %s", client_addr)
-            response = JSONResponse(
-                {"error": "Bad Request: incomplete body"},
-                status_code=400,
+            await self._send_error_and_close(
+                writer,
+                JSONResponse(
+                    {"error": "Bad Request: incomplete body"}, status_code=400
+                ),
             )
-            try:
-                await response._write(writer)
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-            writer.close()
             return
         except Exception:
             logger.debug("Failed to read request from %s", client_addr, exc_info=True)
-            response = JSONResponse(
-                {"error": "Internal Server Error"},
-                status_code=500,
+            await self._send_error_and_close(
+                writer,
+                JSONResponse({"error": "Internal Server Error"}, status_code=500),
             )
-            try:
-                await response._write(writer)
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-            writer.close()
             return
 
         request = Request(


### PR DESCRIPTION
## Summary

- httpserver's `_handle_connection` previously silently closed TCP connections when `_read_request()` raised `TimeoutError`, `IncompleteReadError`, or any unexpected exception — no HTTP response was sent
- Clients (e.g. Claude Code via NPS tunnels) saw raw TCP disconnects, reported "Connection error", and did blind retries that also failed
- Now each failure path returns a proper HTTP status code (408/400/500) with a JSON error body before closing, so clients can make informed retry decisions

## Context

Discovered while debugging intermittent "Connection error" in llm-rosetta deployments behind NPS reverse tunnels. The tunnel layer occasionally causes `IncompleteReadError` during large request body reads (~1MB). With the old behavior, the server dropped the connection silently; the client had no way to distinguish "server rejected my request" from "network is broken", leading to cascading retry failures.

## Test plan

- [ ] Verify existing tests still pass
- [ ] Test with a slow/interrupted client to confirm 408 is returned on timeout
- [ ] Test with a truncated request body to confirm 400 is returned
- [ ] Deploy to llm-rosetta and monitor Caddy logs for proper HTTP error codes instead of "aborting with incomplete response"