### PR TITLE
feat(ratelimit): add multi-algorithm rate limiter module

### DIFF
--- a/_scripts/module_index_config.yaml
+++ b/_scripts/module_index_config.yaml
@@ -13,7 +13,7 @@ categories:
   - id: network
     name_en: "Web & Networking"
     name_zh: "网络与通信"
-    modules: [httpclient, sse, httpserver, useragent, websocket]
+    modules: [httpclient, sse, httpserver, useragent, websocket, ratelimit]
 
   - id: protocol
     name_en: "Agent Protocols"
@@ -324,3 +324,9 @@ modules:
     replaces_zh: "pychrome、pycdp"
     desc_en: "Chrome DevTools Protocol client for headless browser automation"
     desc_zh: "Chrome DevTools Protocol 客户端（无头浏览器自动化）"
+  ratelimit:
+    benchmark: limits
+    replaces: "limits, pyrate-limiter, aiolimiter, limiter"
+    replaces_zh: "limits、pyrate-limiter、aiolimiter、limiter"
+    desc_en: "Multi-algorithm rate limiter (token bucket, fixed/sliding window, GCRA)"
+    desc_zh: "多算法限流器（令牌桶、固定/滑动窗口、GCRA）"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-07-20T10:17:59.443787+00:00",
+  "generated": "2026-08-24T17:03:19.974281+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -315,6 +315,18 @@
       "category": "image",
       "last_updated": "2026-04-27T19:31:53Z",
       "content_hash": "992def53fe2e34c3031a112906b9f4ce5a7b7523f43cdf070415d17117f3e37d"
+    },
+    "ratelimit": {
+      "description": "Multi-algorithm rate limiter with zero dependencies",
+      "files": [
+        "ratelimit/ratelimit.py"
+      ],
+      "version": "0.1.0",
+      "deps": [],
+      "tier": "subsystem",
+      "category": "network",
+      "last_updated": null,
+      "content_hash": "68f189765331997eeebbff5bb96c81f8bac64b3e1407745dc7e8c43cbdb4f8be"
     },
     "readability": {
       "description": "HTML readability content extractor — zero-dep, stdlib only, Python 3.10+",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,17 +158,20 @@ bench-s3 = [
     "boto3==1.43.40",
     "minio==7.2.20",
 ]
+bench-ratelimit = [
+    "limits==5.8.0",
+]
 dev = [
     "ruff==0.15.20",
     "ty==0.0.54",
     "complexipy==5.6.1",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
-    "zerodep[test,bench-aes,bench-qr,bench-http,bench-dotenv,bench-yaml,bench-jsonx,bench-structlog,bench-retry,bench-toon,bench-tabulate,bench-soup,bench-validate,bench-sse,bench-markdown,bench-diff,bench-scheduler,bench-search,bench-frontmatter,bench-config,bench-cache,bench-xml,bench-jsonrpc,bench-a2a,bench-acp,bench-protobuf,bench-semver,bench-persistdict,bench-runner,bench-readability,bench-png,bench-useragent,bench-httpserver,bench-websocket,bench-cdp,bench-multipart,bench-s3]",
+    "zerodep[test,bench-aes,bench-qr,bench-http,bench-dotenv,bench-yaml,bench-jsonx,bench-structlog,bench-retry,bench-toon,bench-tabulate,bench-soup,bench-validate,bench-sse,bench-markdown,bench-diff,bench-scheduler,bench-search,bench-frontmatter,bench-config,bench-cache,bench-xml,bench-jsonrpc,bench-a2a,bench-acp,bench-protobuf,bench-semver,bench-persistdict,bench-runner,bench-readability,bench-png,bench-useragent,bench-httpserver,bench-websocket,bench-cdp,bench-multipart,bench-s3,bench-ratelimit]",
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonx", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt", "useragent", "synctex", "httpserver", "websocket", "cdp", "multipart", "s3"]
+testpaths = ["aes", "qr", "httpclient", "dotenv", "yaml", "jsonx", "structlog", "retry", "toon", "tabulate", "soup", "prompt", "validate", "sse", "markdown", "diff", "vcs", "ansi", "scheduler", "sparse_search", "frontmatter", "config", "cache", "runner", "xml", "jsonrpc", "a2a", "acp", "skills", "filelock", "persistdict", "protobuf", "depdetect", "semver", "readability", "jsonschema", "png", "llmstxt", "useragent", "synctex", "httpserver", "websocket", "cdp", "multipart", "s3", "ratelimit"]
 
 [tool.ruff]
 target-version = "py310"
@@ -272,4 +275,5 @@ extra-paths = [
     "./websocket",
     "./cdp",
     "./s3",
+    "./ratelimit",
 ]

--- a/ratelimit/ratelimit.py
+++ b/ratelimit/ratelimit.py
@@ -46,6 +46,7 @@ import math
 import re
 import threading
 import time
+from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
@@ -108,6 +109,14 @@ class RateLimiter(Protocol):
         """Return current quota state for *key* without consuming."""
         ...
 
+    async def aacquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        """Async version of :meth:`acquire`."""
+        ...
+
+    async def apeek(self, key: str) -> RateLimitResult:
+        """Async version of :meth:`peek`."""
+        ...
+
 
 # ---------------------------------------------------------------------------
 # Eviction mixin
@@ -115,6 +124,29 @@ class RateLimiter(Protocol):
 
 _EVICT_INTERVAL = 128
 _DEFAULT_RETRY_WAIT = 0.1  # fallback wait (seconds) when retry_after is None
+
+
+class _AsyncMixin:
+    """Adds ``aacquire`` and ``apeek`` coroutines that delegate to sync methods.
+
+    The sync methods are pure in-memory computation (no I/O), so the
+    async wrappers yield to the event loop once before calling them.
+    This ensures the coroutine is a proper awaitable with a real
+    suspension point, avoiding starvation in tight loops.
+    """
+
+    @abstractmethod
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult: ...
+    @abstractmethod
+    def peek(self, key: str) -> RateLimitResult: ...
+
+    async def aacquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        await asyncio.sleep(0)
+        return self.acquire(key, tokens)
+
+    async def apeek(self, key: str) -> RateLimitResult:
+        await asyncio.sleep(0)
+        return self.peek(key)
 
 
 class _EvictionMixin:
@@ -147,7 +179,7 @@ class _Bucket:
     last_refill: float
 
 
-class TokenBucketLimiter(_EvictionMixin):
+class TokenBucketLimiter(_AsyncMixin, _EvictionMixin):
     """Token-bucket rate limiter.
 
     Tokens are replenished lazily on each ``acquire`` call.
@@ -252,7 +284,7 @@ class _FixedWindow:
     window_start: float
 
 
-class FixedWindowLimiter(_EvictionMixin):
+class FixedWindowLimiter(_AsyncMixin, _EvictionMixin):
     """Fixed-window rate limiter.
 
     Divides time into non-overlapping windows.  Each key gets at most
@@ -351,7 +383,7 @@ class _SlidingState:
     curr_start: float
 
 
-class SlidingWindowLimiter(_EvictionMixin):
+class SlidingWindowLimiter(_AsyncMixin, _EvictionMixin):
     """Sliding-window counter rate limiter.
 
     Blends the previous window's count with the current window's count
@@ -473,7 +505,7 @@ class SlidingWindowLimiter(_EvictionMixin):
 # ---------------------------------------------------------------------------
 
 
-class GCRALimiter(_EvictionMixin):
+class GCRALimiter(_AsyncMixin, _EvictionMixin):
     """GCRA (Generic Cell Rate Algorithm) rate limiter.
 
     Maintains a single TAT (Theoretical Arrival Time) per key.
@@ -757,7 +789,7 @@ class ratelimit:
         return result
 
     async def _acquire_or_wait_async(self, tokens: int = 1) -> RateLimitResult:
-        result = self._limiter.acquire(self._key, tokens)
+        result = await self._limiter.aacquire(self._key, tokens)
         if result.allowed:
             return result
         if self._timeout is None:
@@ -770,7 +802,7 @@ class ratelimit:
             if remaining_budget <= 0:
                 raise RateLimitExceeded(result)
             await asyncio.sleep(min(wait, remaining_budget))
-            result = self._limiter.acquire(self._key, tokens)
+            result = await self._limiter.aacquire(self._key, tokens)
 
         return result
 
@@ -825,5 +857,15 @@ class ThreadSafeLimiter:
             return self._limiter.acquire(key, tokens)
 
     def peek(self, key: str) -> RateLimitResult:
+        with self._lock:
+            return self._limiter.peek(key)
+
+    async def aacquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        await asyncio.sleep(0)
+        with self._lock:
+            return self._limiter.acquire(key, tokens)
+
+    async def apeek(self, key: str) -> RateLimitResult:
+        await asyncio.sleep(0)
         with self._lock:
             return self._limiter.peek(key)

--- a/ratelimit/ratelimit.py
+++ b/ratelimit/ratelimit.py
@@ -1,0 +1,807 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+"""Multi-algorithm rate limiter with zero dependencies.
+
+Provides four in-memory rate-limiting algorithms behind a common
+``RateLimiter`` protocol, plus convenience wrappers (decorator, context
+manager, async support, string quota notation).
+
+Algorithms:
+
+- **Token bucket** — smooth rate with configurable burst tolerance.
+- **Fixed window** — simplest counter-per-window, lowest overhead.
+- **Sliding window counter** — accurate without boundary-burst artifacts.
+- **GCRA** (Generic Cell Rate Algorithm) — constant-rate shaping via a
+  single TAT (Theoretical Arrival Time) timestamp.
+
+Typical usage::
+
+    limiter = TokenBucketLimiter(rate=10.0, capacity=20)
+    result = limiter.acquire("client-ip")
+    if not result.allowed:
+        return 429, {"Retry-After": str(result.retry_after)}
+
+    # Or with convenience API
+    @ratelimit("10/s", algorithm="sliding_window")
+    def handle_request(): ...
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import re
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Protocol, runtime_checkable
+
+__all__: list[str] = [
+    "RateLimitResult",
+    "RateLimiter",
+    "TokenBucketLimiter",
+    "FixedWindowLimiter",
+    "SlidingWindowLimiter",
+    "GCRALimiter",
+    "ThreadSafeLimiter",
+    "RateLimitExceeded",
+    "ratelimit",
+    "create_limiter",
+    "parse_quota",
+]
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RateLimitResult:
+    """Outcome of a rate-limit check.
+
+    Attributes:
+        allowed: Whether the request is permitted.
+        limit: Total quota (bucket capacity or window limit).
+        remaining: Remaining quota (>= 0).
+        reset_at: Monotonic timestamp when quota fully replenishes or
+            the current window ends.
+        retry_after: Seconds to wait before retrying.  ``None`` when
+            ``allowed`` is ``True``.
+    """
+
+    allowed: bool
+    limit: int
+    remaining: int
+    reset_at: float
+    retry_after: float | None
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RateLimiter(Protocol):
+    """Common interface for all rate-limiter implementations."""
+
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        """Check and consume *tokens* units of quota for *key*."""
+        ...
+
+    def peek(self, key: str) -> RateLimitResult:
+        """Return current quota state for *key* without consuming."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Eviction mixin
+# ---------------------------------------------------------------------------
+
+_EVICT_INTERVAL = 128
+
+
+class _EvictionMixin:
+    """Amortised stale-key eviction for in-memory stores.
+
+    Subclasses must set ``_call_count: int`` and implement
+    ``_evict_stale(now)`` to remove expired entries.
+    """
+
+    _call_count: int
+
+    def _maybe_evict(self, now: float) -> None:
+        self._call_count += 1
+        if self._call_count >= _EVICT_INTERVAL:
+            self._call_count = 0
+            self._evict_stale(now)
+
+    def _evict_stale(self, now: float) -> None:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Token bucket
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Bucket:
+    tokens: float
+    last_refill: float
+
+
+class TokenBucketLimiter(_EvictionMixin):
+    """Token-bucket rate limiter.
+
+    Tokens are replenished lazily on each ``acquire`` call.
+
+    Args:
+        rate: Tokens added per second.
+        capacity: Maximum tokens the bucket can hold (burst size).
+        clock: Callable returning current monotonic time.
+    """
+
+    def __init__(
+        self,
+        rate: float,
+        capacity: int,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if rate <= 0:
+            raise ValueError(f"rate must be positive, got {rate}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be positive, got {capacity}")
+        self.rate = rate
+        self.capacity = capacity
+        self._clock = clock or time.monotonic
+        self._buckets: dict[str, _Bucket] = {}
+        self._call_count = 0
+
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        now = self._clock()
+        self._maybe_evict(now)
+        bucket = self._get_or_create(key, now)
+        self._refill(bucket, now)
+
+        if bucket.tokens >= tokens:
+            bucket.tokens -= tokens
+            return RateLimitResult(
+                allowed=True,
+                limit=self.capacity,
+                remaining=int(bucket.tokens),
+                reset_at=now + (self.capacity - bucket.tokens) / self.rate,
+                retry_after=None,
+            )
+
+        deficit = tokens - bucket.tokens
+        retry_after = deficit / self.rate
+        return RateLimitResult(
+            allowed=False,
+            limit=self.capacity,
+            remaining=int(bucket.tokens),
+            reset_at=now + self.capacity / self.rate,
+            retry_after=round(retry_after, 3),
+        )
+
+    def peek(self, key: str) -> RateLimitResult:
+        now = self._clock()
+        bucket = self._get_or_create(key, now)
+        self._refill(bucket, now)
+        return RateLimitResult(
+            allowed=bucket.tokens >= 1,
+            limit=self.capacity,
+            remaining=int(bucket.tokens),
+            reset_at=now + (self.capacity - bucket.tokens) / self.rate,
+            retry_after=None,
+        )
+
+    def _get_or_create(self, key: str, now: float) -> _Bucket:
+        bucket = self._buckets.get(key)
+        if bucket is None:
+            bucket = _Bucket(tokens=float(self.capacity), last_refill=now)
+            self._buckets[key] = bucket
+        return bucket
+
+    def _refill(self, bucket: _Bucket, now: float) -> None:
+        elapsed = now - bucket.last_refill
+        if elapsed > 0:
+            bucket.tokens = min(self.capacity, bucket.tokens + elapsed * self.rate)
+            bucket.last_refill = now
+
+    def _evict_stale(self, now: float) -> None:
+        stale = [
+            k
+            for k, b in self._buckets.items()
+            if b.tokens + (now - b.last_refill) * self.rate >= self.capacity
+        ]
+        for k in stale:
+            del self._buckets[k]
+
+
+# ---------------------------------------------------------------------------
+# Fixed window
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FixedWindow:
+    count: int
+    window_start: float
+
+
+class FixedWindowLimiter(_EvictionMixin):
+    """Fixed-window rate limiter.
+
+    Divides time into non-overlapping windows.  Each key gets at most
+    ``limit`` requests per window.
+
+    Args:
+        limit: Maximum requests per window.
+        window_seconds: Window duration in seconds.
+        clock: Callable returning current monotonic time.
+    """
+
+    def __init__(
+        self,
+        limit: int,
+        window_seconds: float,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if limit <= 0:
+            raise ValueError(f"limit must be positive, got {limit}")
+        if window_seconds <= 0:
+            raise ValueError(f"window_seconds must be positive, got {window_seconds}")
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._clock = clock or time.monotonic
+        self._windows: dict[str, _FixedWindow] = {}
+        self._call_count = 0
+
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        now = self._clock()
+        self._maybe_evict(now)
+        window = self._get_or_reset(key, now)
+
+        if window.count + tokens <= self.limit:
+            window.count += tokens
+            remaining = self.limit - window.count
+            reset_at = window.window_start + self.window_seconds
+            return RateLimitResult(
+                allowed=True,
+                limit=self.limit,
+                remaining=remaining,
+                reset_at=reset_at,
+                retry_after=None,
+            )
+
+        reset_at = window.window_start + self.window_seconds
+        retry_after = max(0.0, reset_at - now)
+        return RateLimitResult(
+            allowed=False,
+            limit=self.limit,
+            remaining=max(0, self.limit - window.count),
+            reset_at=reset_at,
+            retry_after=round(retry_after, 3),
+        )
+
+    def peek(self, key: str) -> RateLimitResult:
+        now = self._clock()
+        window = self._get_or_reset(key, now)
+        remaining = max(0, self.limit - window.count)
+        reset_at = window.window_start + self.window_seconds
+        return RateLimitResult(
+            allowed=remaining >= 1,
+            limit=self.limit,
+            remaining=remaining,
+            reset_at=reset_at,
+            retry_after=None,
+        )
+
+    def _get_or_reset(self, key: str, now: float) -> _FixedWindow:
+        window = self._windows.get(key)
+        if window is None or now - window.window_start >= self.window_seconds:
+            window = _FixedWindow(count=0, window_start=now)
+            self._windows[key] = window
+        return window
+
+    def _evict_stale(self, now: float) -> None:
+        stale = [
+            k
+            for k, w in self._windows.items()
+            if now - w.window_start >= self.window_seconds * 2
+        ]
+        for k in stale:
+            del self._windows[k]
+
+
+# ---------------------------------------------------------------------------
+# Sliding window counter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SlidingState:
+    prev_count: int
+    prev_start: float
+    curr_count: int
+    curr_start: float
+
+
+class SlidingWindowLimiter(_EvictionMixin):
+    """Sliding-window counter rate limiter.
+
+    Blends the previous window's count with the current window's count
+    weighted by overlap fraction, eliminating boundary-burst artifacts.
+
+    Args:
+        limit: Maximum requests per window.
+        window_seconds: Window duration in seconds.
+        clock: Callable returning current monotonic time.
+    """
+
+    def __init__(
+        self,
+        limit: int,
+        window_seconds: float,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if limit <= 0:
+            raise ValueError(f"limit must be positive, got {limit}")
+        if window_seconds <= 0:
+            raise ValueError(f"window_seconds must be positive, got {window_seconds}")
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._clock = clock or time.monotonic
+        self._states: dict[str, _SlidingState] = {}
+        self._call_count = 0
+
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        now = self._clock()
+        self._maybe_evict(now)
+        state = self._get_or_create(key, now)
+        self._advance(state, now)
+
+        effective = self._effective_count(state, now)
+        if effective + tokens <= self.limit:
+            state.curr_count += tokens
+            new_effective = self._effective_count(state, now)
+            remaining = max(0, self.limit - math.ceil(new_effective))
+            reset_at = state.curr_start + self.window_seconds
+            return RateLimitResult(
+                allowed=True,
+                limit=self.limit,
+                remaining=remaining,
+                reset_at=reset_at,
+                retry_after=None,
+            )
+
+        reset_at = state.curr_start + self.window_seconds
+        retry_after = max(0.0, reset_at - now)
+        remaining = max(0, self.limit - math.ceil(effective))
+        return RateLimitResult(
+            allowed=False,
+            limit=self.limit,
+            remaining=remaining,
+            reset_at=reset_at,
+            retry_after=round(retry_after, 3),
+        )
+
+    def peek(self, key: str) -> RateLimitResult:
+        now = self._clock()
+        state = self._get_or_create(key, now)
+        self._advance(state, now)
+        effective = self._effective_count(state, now)
+        remaining = max(0, self.limit - math.ceil(effective))
+        reset_at = state.curr_start + self.window_seconds
+        return RateLimitResult(
+            allowed=remaining >= 1,
+            limit=self.limit,
+            remaining=remaining,
+            reset_at=reset_at,
+            retry_after=None,
+        )
+
+    def _get_or_create(self, key: str, now: float) -> _SlidingState:
+        state = self._states.get(key)
+        if state is None:
+            state = _SlidingState(
+                prev_count=0,
+                prev_start=now - self.window_seconds,
+                curr_count=0,
+                curr_start=now,
+            )
+            self._states[key] = state
+        return state
+
+    def _advance(self, state: _SlidingState, now: float) -> None:
+        """Roll forward, jumping directly to the correct window."""
+        if now < state.curr_start + self.window_seconds:
+            return
+        elapsed_windows = int((now - state.curr_start) / self.window_seconds)
+        if elapsed_windows == 1:
+            state.prev_count = state.curr_count
+            state.prev_start = state.curr_start
+            state.curr_count = 0
+            state.curr_start = state.prev_start + self.window_seconds
+        else:
+            state.prev_count = 0
+            state.prev_start = (
+                state.curr_start + (elapsed_windows - 1) * self.window_seconds
+            )
+            state.curr_count = 0
+            state.curr_start = state.prev_start + self.window_seconds
+
+    def _effective_count(self, state: _SlidingState, now: float) -> float:
+        elapsed_in_curr = now - state.curr_start
+        overlap = max(0.0, 1.0 - elapsed_in_curr / self.window_seconds)
+        return state.curr_count + state.prev_count * overlap
+
+    def _evict_stale(self, now: float) -> None:
+        cutoff = now - self.window_seconds * 3
+        stale = [k for k, s in self._states.items() if s.curr_start < cutoff]
+        for k in stale:
+            del self._states[k]
+
+
+# ---------------------------------------------------------------------------
+# GCRA (Generic Cell Rate Algorithm)
+# ---------------------------------------------------------------------------
+
+
+class GCRALimiter(_EvictionMixin):
+    """GCRA (Generic Cell Rate Algorithm) rate limiter.
+
+    Maintains a single TAT (Theoretical Arrival Time) per key.
+    Mathematically equivalent to a leaky bucket but with simpler state.
+
+    Args:
+        rate: Requests allowed per second.
+        burst: Maximum burst size above the steady rate.
+        clock: Callable returning current monotonic time.
+    """
+
+    def __init__(
+        self,
+        rate: float,
+        burst: int = 0,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if rate <= 0:
+            raise ValueError(f"rate must be positive, got {rate}")
+        if burst < 0:
+            raise ValueError(f"burst must be non-negative, got {burst}")
+        self.rate = rate
+        self.burst = burst
+        self._emission_interval = 1.0 / rate
+        self._delay_tolerance = burst * self._emission_interval
+        self._limit = burst + 1
+        self._clock = clock or time.monotonic
+        self._tats: dict[str, float] = {}
+        self._call_count = 0
+
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        now = self._clock()
+        self._maybe_evict(now)
+        tat = self._tats.get(key, now)
+        increment = self._emission_interval * tokens
+
+        new_tat = max(tat, now) + increment
+        allow_at = new_tat - self._delay_tolerance - self._emission_interval
+
+        if now < allow_at:
+            retry_after = allow_at - now
+            remaining = max(
+                0,
+                int((self._delay_tolerance - (tat - now)) / self._emission_interval),
+            )
+            return RateLimitResult(
+                allowed=False,
+                limit=self._limit,
+                remaining=remaining,
+                reset_at=tat,
+                retry_after=round(retry_after, 3),
+            )
+
+        self._tats[key] = new_tat
+        remaining = max(
+            0,
+            int((self._delay_tolerance - (new_tat - now)) / self._emission_interval),
+        )
+        return RateLimitResult(
+            allowed=True,
+            limit=self._limit,
+            remaining=remaining,
+            reset_at=new_tat,
+            retry_after=None,
+        )
+
+    def peek(self, key: str) -> RateLimitResult:
+        now = self._clock()
+        tat = self._tats.get(key, now)
+        remaining = max(
+            0,
+            int(
+                (self._delay_tolerance - (max(tat, now) - now))
+                / self._emission_interval
+            ),
+        )
+        return RateLimitResult(
+            allowed=remaining >= 1,
+            limit=self._limit,
+            remaining=remaining,
+            reset_at=max(tat, now),
+            retry_after=None,
+        )
+
+    def _evict_stale(self, now: float) -> None:
+        stale = [k for k, tat in self._tats.items() if tat <= now]
+        for k in stale:
+            del self._tats[k]
+
+
+# ---------------------------------------------------------------------------
+# Quota string parsing
+# ---------------------------------------------------------------------------
+
+_UNIT_MAP: dict[str, float] = {
+    "s": 1.0,
+    "sec": 1.0,
+    "second": 1.0,
+    "m": 60.0,
+    "min": 60.0,
+    "minute": 60.0,
+    "h": 3600.0,
+    "hr": 3600.0,
+    "hour": 3600.0,
+    "d": 86400.0,
+    "day": 86400.0,
+}
+
+_QUOTA_RE = re.compile(
+    r"^\s*(\d+)\s*(?:/|per)\s*([a-z]+)"
+    r"(?:\s+burst\s+(\d+))?\s*$",
+    re.IGNORECASE,
+)
+
+
+def parse_quota(quota: str) -> dict[str, Any]:
+    """Parse a quota string like ``"100/s"`` or ``"10 per minute burst 20"``.
+
+    Returns:
+        Dict with keys ``limit`` (int), ``period`` (float in seconds),
+        and ``burst`` (int or None).
+    """
+    m = _QUOTA_RE.match(quota)
+    if not m:
+        raise ValueError(
+            f"invalid quota string: {quota!r}  "
+            f"(expected: '<N>/<unit>' or '<N> per <unit> [burst <B>]')"
+        )
+    limit = int(m.group(1))
+    unit = m.group(2).lower()
+    # strip trailing "s" for plurals (e.g. "seconds" -> "second") but
+    # not for single-char units like "s" itself
+    if len(unit) > 1 and unit.endswith("s"):
+        unit = unit[:-1]
+    if unit not in _UNIT_MAP:
+        raise ValueError(f"unknown time unit: {m.group(2)!r}")
+    period = _UNIT_MAP[unit]
+    burst = int(m.group(3)) if m.group(3) else None
+    return {"limit": limit, "period": period, "burst": burst}
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+_ALGORITHM_MAP: dict[str, str] = {
+    "token_bucket": "token_bucket",
+    "fixed_window": "fixed_window",
+    "sliding_window": "sliding_window",
+    "gcra": "gcra",
+}
+
+
+def create_limiter(
+    algorithm: str,
+    quota: str,
+    *,
+    clock: Callable[[], float] | None = None,
+) -> RateLimiter:
+    """Create a rate limiter from an algorithm name and quota string.
+
+    Args:
+        algorithm: One of ``"token_bucket"``, ``"fixed_window"``,
+            ``"sliding_window"``, or ``"gcra"``.
+        quota: Quota string like ``"100/s"`` or ``"10/m burst 20"``.
+        clock: Optional clock override for testing.
+
+    Returns:
+        A :class:`RateLimiter` instance.
+    """
+    algo = algorithm.lower()
+    if algo not in _ALGORITHM_MAP:
+        raise ValueError(
+            f"unknown algorithm: {algorithm!r}  (choices: {', '.join(_ALGORITHM_MAP)})"
+        )
+    q = parse_quota(quota)
+    limit, period, burst = q["limit"], q["period"], q["burst"]
+
+    if algo == "token_bucket":
+        rate = limit / period
+        cap = burst if burst is not None else limit
+        return TokenBucketLimiter(rate=rate, capacity=cap, clock=clock)  # type: ignore[return-value]
+    elif algo == "fixed_window":
+        return FixedWindowLimiter(limit=limit, window_seconds=period, clock=clock)  # type: ignore[return-value]
+    elif algo == "sliding_window":
+        return SlidingWindowLimiter(limit=limit, window_seconds=period, clock=clock)  # type: ignore[return-value]
+    else:  # gcra
+        rate = limit / period
+        b = (burst - 1) if burst is not None and burst > 0 else 0
+        return GCRALimiter(rate=rate, burst=b, clock=clock)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Decorator / context manager
+# ---------------------------------------------------------------------------
+
+
+class RateLimitExceeded(Exception):
+    """Raised when a rate limit is exceeded in decorator/context-manager mode."""
+
+    def __init__(self, result: RateLimitResult) -> None:
+        self.result = result
+        super().__init__(
+            f"rate limit exceeded: remaining={result.remaining}, "
+            f"retry_after={result.retry_after}"
+        )
+
+
+class ratelimit:
+    """Rate-limit decorator and context manager.
+
+    Can be used as a decorator::
+
+        @ratelimit("10/s")
+        def handle(): ...
+
+    Or as a sync/async context manager::
+
+        with ratelimit("5/m", key="user-1"):
+            do_work()
+
+        async with ratelimit("5/m", key="user-1"):
+            await do_work()
+
+    Args:
+        quota: Quota string (e.g. ``"10/s"``, ``"100/m burst 200"``).
+        algorithm: Algorithm name (default: ``"token_bucket"``).
+        key: Rate-limit key (default: ``"__default__"``).
+        timeout: If set, wait up to *timeout* seconds for quota
+            instead of raising immediately.
+        limiter: Pre-built limiter instance (overrides *quota*
+            and *algorithm*).
+    """
+
+    def __init__(
+        self,
+        quota: str | None = None,
+        *,
+        algorithm: str = "token_bucket",
+        key: str = "__default__",
+        timeout: float | None = None,
+        limiter: RateLimiter | None = None,
+    ) -> None:
+        if limiter is not None:
+            self._limiter = limiter
+        elif quota is not None:
+            self._limiter = create_limiter(algorithm, quota)
+        else:
+            raise ValueError("either 'quota' or 'limiter' must be provided")
+        self._key = key
+        self._timeout = timeout
+
+    def _acquire_or_wait(self, tokens: int = 1) -> RateLimitResult:
+        result = self._limiter.acquire(self._key, tokens)
+        if result.allowed:
+            return result
+        if self._timeout is None:
+            raise RateLimitExceeded(result)
+
+        deadline = time.monotonic() + self._timeout
+        while not result.allowed:
+            wait = result.retry_after or 0.1
+            remaining_budget = deadline - time.monotonic()
+            if remaining_budget <= 0:
+                raise RateLimitExceeded(result)
+            time.sleep(min(wait, remaining_budget))
+            result = self._limiter.acquire(self._key, tokens)
+
+        return result
+
+    async def _acquire_or_wait_async(self, tokens: int = 1) -> RateLimitResult:
+        result = self._limiter.acquire(self._key, tokens)
+        if result.allowed:
+            return result
+        if self._timeout is None:
+            raise RateLimitExceeded(result)
+
+        deadline = time.monotonic() + self._timeout
+        while not result.allowed:
+            wait = result.retry_after or 0.1
+            remaining_budget = deadline - time.monotonic()
+            if remaining_budget <= 0:
+                raise RateLimitExceeded(result)
+            await asyncio.sleep(min(wait, remaining_budget))
+            result = self._limiter.acquire(self._key, tokens)
+
+        return result
+
+    def __call__(self, func: Any) -> Any:
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                await self._acquire_or_wait_async()
+                return await func(*args, **kwargs)
+
+            return async_wrapper
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            self._acquire_or_wait()
+            return func(*args, **kwargs)
+
+        return sync_wrapper
+
+    def __enter__(self) -> RateLimitResult:
+        return self._acquire_or_wait()
+
+    def __exit__(self, *exc: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> RateLimitResult:
+        return await self._acquire_or_wait_async()
+
+    async def __aexit__(self, *exc: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Thread-safe wrapper
+# ---------------------------------------------------------------------------
+
+
+class ThreadSafeLimiter:
+    """Wraps any :class:`RateLimiter` with a ``threading.Lock``.
+
+    Args:
+        limiter: The underlying rate limiter.
+    """
+
+    def __init__(self, limiter: RateLimiter) -> None:
+        self._limiter = limiter
+        self._lock = threading.Lock()
+
+    def acquire(self, key: str, tokens: int = 1) -> RateLimitResult:
+        with self._lock:
+            return self._limiter.acquire(key, tokens)
+
+    def peek(self, key: str) -> RateLimitResult:
+        with self._lock:
+            return self._limiter.peek(key)

--- a/ratelimit/ratelimit.py
+++ b/ratelimit/ratelimit.py
@@ -30,6 +30,11 @@ Typical usage::
     @ratelimit("10/s", algorithm="sliding_window")
     def handle_request(): ...
 
+Thread safety: individual limiter classes are **not** thread-safe.
+For concurrent access from multiple threads, wrap with
+:class:`ThreadSafeLimiter` or pass a pre-wrapped instance via the
+``limiter`` parameter of :class:`ratelimit`.
+
 Part of zerodep: https://github.com/Oaklight/zerodep
 Copyright (c) 2026 Peng Ding. MIT License.
 """
@@ -109,6 +114,7 @@ class RateLimiter(Protocol):
 # ---------------------------------------------------------------------------
 
 _EVICT_INTERVAL = 128
+_DEFAULT_RETRY_WAIT = 0.1  # fallback wait (seconds) when retry_after is None
 
 
 class _EvictionMixin:
@@ -196,6 +202,11 @@ class TokenBucketLimiter(_EvictionMixin):
         )
 
     def peek(self, key: str) -> RateLimitResult:
+        """Return current quota state without consuming.
+
+        Note: initializes internal state for previously unseen keys
+        (the bucket starts full, so the result is correct).
+        """
         now = self._clock()
         bucket = self._get_or_create(key, now)
         self._refill(bucket, now)
@@ -609,12 +620,7 @@ def parse_quota(quota: str) -> dict[str, Any]:
 # Factory
 # ---------------------------------------------------------------------------
 
-_ALGORITHM_MAP: dict[str, str] = {
-    "token_bucket": "token_bucket",
-    "fixed_window": "fixed_window",
-    "sliding_window": "sliding_window",
-    "gcra": "gcra",
-}
+_ALGORITHMS = {"token_bucket", "fixed_window", "sliding_window", "gcra"}
 
 
 def create_limiter(
@@ -633,11 +639,25 @@ def create_limiter(
 
     Returns:
         A :class:`RateLimiter` instance.
+
+    How ``burst`` maps per algorithm:
+
+    - **token_bucket**: ``burst`` sets bucket capacity directly
+      (default: ``limit``).
+    - **fixed_window** / **sliding_window**: ``burst`` is ignored.
+    - **gcra**: ``burst`` is total capacity, so internal burst
+      parameter = ``burst - 1`` (extra slots above steady rate).
+
+    Note:
+        The ``timeout`` parameter for wait-and-retry always uses
+        wall-clock time (``time.monotonic``), even when the limiter
+        has an injected clock.
     """
     algo = algorithm.lower()
-    if algo not in _ALGORITHM_MAP:
+    if algo not in _ALGORITHMS:
         raise ValueError(
-            f"unknown algorithm: {algorithm!r}  (choices: {', '.join(_ALGORITHM_MAP)})"
+            f"unknown algorithm: {algorithm!r}  "
+            f"(choices: {', '.join(sorted(_ALGORITHMS))})"
         )
     q = parse_quota(quota)
     limit, period, burst = q["limit"], q["period"], q["burst"]
@@ -652,6 +672,8 @@ def create_limiter(
         return SlidingWindowLimiter(limit=limit, window_seconds=period, clock=clock)  # type: ignore[return-value]
     else:  # gcra
         rate = limit / period
+        # GCRA burst = "extra slots above steady rate", so user's
+        # "burst N" (total capacity) maps to burst=N-1 internally.
         b = (burst - 1) if burst is not None and burst > 0 else 0
         return GCRALimiter(rate=rate, burst=b, clock=clock)  # type: ignore[return-value]
 
@@ -725,7 +747,7 @@ class ratelimit:
 
         deadline = time.monotonic() + self._timeout
         while not result.allowed:
-            wait = result.retry_after or 0.1
+            wait = result.retry_after or _DEFAULT_RETRY_WAIT
             remaining_budget = deadline - time.monotonic()
             if remaining_budget <= 0:
                 raise RateLimitExceeded(result)
@@ -743,7 +765,7 @@ class ratelimit:
 
         deadline = time.monotonic() + self._timeout
         while not result.allowed:
-            wait = result.retry_after or 0.1
+            wait = result.retry_after or _DEFAULT_RETRY_WAIT
             remaining_budget = deadline - time.monotonic()
             if remaining_budget <= 0:
                 raise RateLimitExceeded(result)

--- a/ratelimit/ratelimit.py
+++ b/ratelimit/ratelimit.py
@@ -844,6 +844,13 @@ class ratelimit:
 class ThreadSafeLimiter:
     """Wraps any :class:`RateLimiter` with a ``threading.Lock``.
 
+    The async methods (``aacquire``, ``apeek``) use the same
+    ``threading.Lock`` — not ``asyncio.Lock`` — so they are safe for
+    mixed sync+async access to the same limiter.  For pure-async
+    high-contention scenarios, the lock may briefly block the event
+    loop; in practice the hold time is negligible (microseconds of
+    in-memory computation).
+
     Args:
         limiter: The underlying rate limiter.
     """

--- a/ratelimit/test_ratelimit_benchmark.py
+++ b/ratelimit/test_ratelimit_benchmark.py
@@ -1,0 +1,97 @@
+"""Benchmarks for zerodep ratelimit module vs ``limits`` library."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from ratelimit import (
+    FixedWindowLimiter,
+    GCRALimiter,
+    SlidingWindowLimiter,
+    TokenBucketLimiter,
+)
+
+limits = pytest.importorskip("limits")
+from limits import parse as limits_parse  # noqa: E402
+from limits import storage as limits_storage  # noqa: E402
+from limits import strategies as limits_strategies  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def limits_fixed_window():
+    backend = limits_storage.MemoryStorage()
+    return limits_strategies.FixedWindowRateLimiter(backend)
+
+
+@pytest.fixture
+def limits_moving_window():
+    backend = limits_storage.MemoryStorage()
+    return limits_strategies.MovingWindowRateLimiter(backend)
+
+
+@pytest.fixture
+def limits_sliding_window():
+    backend = limits_storage.MemoryStorage()
+    return limits_strategies.SlidingWindowCounterRateLimiter(backend)
+
+
+RATE = limits_parse("10000/second")
+
+
+# ---------------------------------------------------------------------------
+# zerodep benchmarks
+# ---------------------------------------------------------------------------
+
+
+class TestZerodepBenchmarks:
+    def test_token_bucket_acquire(self, benchmark):
+        limiter = TokenBucketLimiter(rate=10000.0, capacity=10000)
+        benchmark(limiter.acquire, "bench-key")
+
+    def test_fixed_window_acquire(self, benchmark):
+        limiter = FixedWindowLimiter(limit=10000, window_seconds=1.0)
+        benchmark(limiter.acquire, "bench-key")
+
+    def test_sliding_window_acquire(self, benchmark):
+        limiter = SlidingWindowLimiter(limit=10000, window_seconds=1.0)
+        benchmark(limiter.acquire, "bench-key")
+
+    def test_gcra_acquire(self, benchmark):
+        limiter = GCRALimiter(rate=10000.0, burst=9999)
+        benchmark(limiter.acquire, "bench-key")
+
+    def test_token_bucket_peek(self, benchmark):
+        limiter = TokenBucketLimiter(rate=10000.0, capacity=10000)
+        benchmark(limiter.peek, "bench-key")
+
+    def test_fixed_window_peek(self, benchmark):
+        limiter = FixedWindowLimiter(limit=10000, window_seconds=1.0)
+        benchmark(limiter.peek, "bench-key")
+
+
+# ---------------------------------------------------------------------------
+# limits library benchmarks
+# ---------------------------------------------------------------------------
+
+
+class TestLimitsBenchmarks:
+    def test_fixed_window_hit(self, benchmark, limits_fixed_window):
+        benchmark(limits_fixed_window.hit, RATE, "bench-key")
+
+    def test_moving_window_hit(self, benchmark, limits_moving_window):
+        benchmark(limits_moving_window.hit, RATE, "bench-key")
+
+    def test_sliding_window_hit(self, benchmark, limits_sliding_window):
+        benchmark(limits_sliding_window.hit, RATE, "bench-key")
+
+    def test_fixed_window_test(self, benchmark, limits_fixed_window):
+        benchmark(limits_fixed_window.test, RATE, "bench-key")

--- a/ratelimit/test_ratelimit_correctness.py
+++ b/ratelimit/test_ratelimit_correctness.py
@@ -719,6 +719,143 @@ class TestThreadSafe:
 
 
 # ---------------------------------------------------------------------------
+# Async API (aacquire / apeek)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncAPI:
+    def test_token_bucket_aacquire(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=3, clock=clock)
+
+        async def run():
+            r = await limiter.aacquire("k")
+            assert r.allowed is True
+            assert r.remaining == 2
+            await limiter.aacquire("k")
+            await limiter.aacquire("k")
+            r = await limiter.aacquire("k")
+            assert r.allowed is False
+
+        asyncio.run(run())
+
+    def test_token_bucket_apeek(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=5, clock=clock)
+
+        async def run():
+            r1 = await limiter.apeek("k")
+            r2 = await limiter.apeek("k")
+            assert r1.remaining == r2.remaining == 5
+
+        asyncio.run(run())
+
+    def test_fixed_window_aacquire(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=2, window_seconds=60.0, clock=clock)
+
+        async def run():
+            r = await limiter.aacquire("k")
+            assert r.allowed is True
+            await limiter.aacquire("k")
+            r = await limiter.aacquire("k")
+            assert r.allowed is False
+
+        asyncio.run(run())
+
+    def test_sliding_window_aacquire(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=2, window_seconds=60.0, clock=clock)
+
+        async def run():
+            r = await limiter.aacquire("k")
+            assert r.allowed is True
+            await limiter.aacquire("k")
+            r = await limiter.aacquire("k")
+            assert r.allowed is False
+
+        asyncio.run(run())
+
+    def test_gcra_aacquire(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=1, clock=clock)
+
+        async def run():
+            r = await limiter.aacquire("k")
+            assert r.allowed is True
+            await limiter.aacquire("k")
+            r = await limiter.aacquire("k")
+            assert r.allowed is False
+
+        asyncio.run(run())
+
+    def test_gcra_apeek(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=2, clock=clock)
+
+        async def run():
+            r1 = await limiter.apeek("k")
+            r2 = await limiter.apeek("k")
+            assert r1.remaining == r2.remaining
+
+        asyncio.run(run())
+
+    def test_thread_safe_aacquire(self):
+        inner = TokenBucketLimiter(rate=1.0, capacity=2)
+        limiter = ThreadSafeLimiter(inner)
+
+        async def run():
+            r = await limiter.aacquire("k")
+            assert r.allowed is True
+            r = await limiter.apeek("k")
+            assert r.remaining == 1
+
+        asyncio.run(run())
+
+    def test_aacquire_matches_acquire(self):
+        """aacquire and acquire produce identical results on same state."""
+        clock = FakeClock()
+        lim_sync = TokenBucketLimiter(rate=5.0, capacity=3, clock=clock)
+        lim_async = TokenBucketLimiter(rate=5.0, capacity=3, clock=clock)
+
+        sync_results = [lim_sync.acquire("k") for _ in range(4)]
+
+        async def run():
+            return [await lim_async.aacquire("k") for _ in range(4)]
+
+        async_results = asyncio.run(run())
+
+        for s, a in zip(sync_results, async_results):
+            assert s.allowed == a.allowed
+            assert s.remaining == a.remaining
+            assert s.limit == a.limit
+
+    def test_aacquire_yields_to_event_loop(self):
+        """aacquire yields control, allowing other tasks to run."""
+        limiter = TokenBucketLimiter(rate=100.0, capacity=100)
+        order: list[str] = []
+
+        async def task_a():
+            order.append("a-start")
+            await limiter.aacquire("k")
+            order.append("a-end")
+
+        async def task_b():
+            order.append("b-start")
+            await limiter.aacquire("k")
+            order.append("b-end")
+
+        async def run():
+            await asyncio.gather(task_a(), task_b())
+
+        asyncio.run(run())
+        assert order[0] == "a-start"
+        assert "b-start" in order
+        assert "a-end" in order
+        assert "b-end" in order
+
+
+# ---------------------------------------------------------------------------
 # RateLimitExceeded
 # ---------------------------------------------------------------------------
 

--- a/ratelimit/test_ratelimit_correctness.py
+++ b/ratelimit/test_ratelimit_correctness.py
@@ -532,6 +532,16 @@ class TestCreateLimiter:
         lim = create_limiter("gcra", "10/s burst 20")
         assert isinstance(lim, GCRALimiter)
 
+    def test_gcra_burst_1_equals_no_burst(self):
+        """'10/s' and '10/s burst 1' should produce identical GCRA limiters."""
+        clock = FakeClock()
+        lim_no_burst = create_limiter("gcra", "10/s", clock=clock)
+        lim_burst_1 = create_limiter("gcra", "10/s burst 1", clock=clock)
+        assert isinstance(lim_no_burst, GCRALimiter)
+        assert isinstance(lim_burst_1, GCRALimiter)
+        assert lim_no_burst.burst == lim_burst_1.burst == 0
+        assert lim_no_burst.rate == lim_burst_1.rate
+
     def test_unknown_algorithm(self):
         with pytest.raises(ValueError, match="unknown algorithm"):
             create_limiter("leaky_bucket", "10/s")

--- a/ratelimit/test_ratelimit_correctness.py
+++ b/ratelimit/test_ratelimit_correctness.py
@@ -1,0 +1,723 @@
+"""Correctness tests for zerodep ratelimit module."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from ratelimit import (
+    FixedWindowLimiter,
+    GCRALimiter,
+    RateLimiter,
+    RateLimitExceeded,
+    RateLimitResult,
+    SlidingWindowLimiter,
+    ThreadSafeLimiter,
+    TokenBucketLimiter,
+    create_limiter,
+    parse_quota,
+    ratelimit,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeClock:
+    """Deterministic clock for testing."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_token_bucket_is_rate_limiter(self):
+        assert isinstance(TokenBucketLimiter(rate=1.0, capacity=1), RateLimiter)
+
+    def test_fixed_window_is_rate_limiter(self):
+        assert isinstance(FixedWindowLimiter(limit=1, window_seconds=1.0), RateLimiter)
+
+    def test_sliding_window_is_rate_limiter(self):
+        assert isinstance(
+            SlidingWindowLimiter(limit=1, window_seconds=1.0), RateLimiter
+        )
+
+    def test_gcra_is_rate_limiter(self):
+        assert isinstance(GCRALimiter(rate=1.0, burst=0), RateLimiter)
+
+    def test_thread_safe_is_rate_limiter(self):
+        inner = TokenBucketLimiter(rate=1.0, capacity=1)
+        assert isinstance(ThreadSafeLimiter(inner), RateLimiter)
+
+
+# ---------------------------------------------------------------------------
+# RateLimitResult
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitResult:
+    def test_allowed_result(self):
+        r = RateLimitResult(
+            allowed=True, limit=10, remaining=9, reset_at=100.0, retry_after=None
+        )
+        assert r.allowed is True
+        assert r.remaining == 9
+        assert r.retry_after is None
+
+    def test_denied_result(self):
+        r = RateLimitResult(
+            allowed=False, limit=10, remaining=0, reset_at=100.0, retry_after=5.0
+        )
+        assert r.allowed is False
+        assert r.retry_after == 5.0
+
+    def test_frozen(self):
+        r = RateLimitResult(
+            allowed=True, limit=10, remaining=9, reset_at=100.0, retry_after=None
+        )
+        with pytest.raises(AttributeError):
+            r.allowed = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_token_bucket_rejects_zero_rate(self):
+        with pytest.raises(ValueError, match="rate must be positive"):
+            TokenBucketLimiter(rate=0, capacity=10)
+
+    def test_token_bucket_rejects_negative_capacity(self):
+        with pytest.raises(ValueError, match="capacity must be positive"):
+            TokenBucketLimiter(rate=1.0, capacity=-1)
+
+    def test_fixed_window_rejects_zero_limit(self):
+        with pytest.raises(ValueError, match="limit must be positive"):
+            FixedWindowLimiter(limit=0, window_seconds=60.0)
+
+    def test_fixed_window_rejects_negative_window(self):
+        with pytest.raises(ValueError, match="window_seconds must be positive"):
+            FixedWindowLimiter(limit=10, window_seconds=-1.0)
+
+    def test_sliding_window_rejects_zero_limit(self):
+        with pytest.raises(ValueError, match="limit must be positive"):
+            SlidingWindowLimiter(limit=0, window_seconds=60.0)
+
+    def test_gcra_rejects_zero_rate(self):
+        with pytest.raises(ValueError, match="rate must be positive"):
+            GCRALimiter(rate=0)
+
+    def test_gcra_rejects_negative_burst(self):
+        with pytest.raises(ValueError, match="burst must be non-negative"):
+            GCRALimiter(rate=1.0, burst=-1)
+
+
+# ---------------------------------------------------------------------------
+# Token Bucket
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBucket:
+    def test_initial_burst(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=5, clock=clock)
+        for i in range(5):
+            r = limiter.acquire("k")
+            assert r.allowed, f"request {i} should be allowed"
+            assert r.remaining == 5 - i - 1
+
+    def test_denied_after_capacity(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=3, clock=clock)
+        for _ in range(3):
+            limiter.acquire("k")
+        r = limiter.acquire("k")
+        assert r.allowed is False
+        assert r.remaining == 0
+        assert r.retry_after is not None and r.retry_after > 0
+
+    def test_refill_over_time(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=2.0, capacity=4, clock=clock)
+        for _ in range(4):
+            limiter.acquire("k")
+        assert limiter.acquire("k").allowed is False
+        clock.advance(1.0)
+        r = limiter.acquire("k")
+        assert r.allowed is True
+        assert r.remaining == 1
+
+    def test_refill_caps_at_capacity(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=10.0, capacity=5, clock=clock)
+        limiter.acquire("k")
+        clock.advance(100.0)
+        r = limiter.peek("k")
+        assert r.remaining == 5
+
+    def test_multi_token_acquire(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=10, clock=clock)
+        r = limiter.acquire("k", tokens=7)
+        assert r.allowed is True
+        assert r.remaining == 3
+        r = limiter.acquire("k", tokens=5)
+        assert r.allowed is False
+
+    def test_key_isolation(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=2, clock=clock)
+        limiter.acquire("a")
+        limiter.acquire("a")
+        assert limiter.acquire("a").allowed is False
+        assert limiter.acquire("b").allowed is True
+
+    def test_peek_does_not_consume(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=3, clock=clock)
+        r1 = limiter.peek("k")
+        r2 = limiter.peek("k")
+        assert r1.remaining == r2.remaining == 3
+
+    def test_retry_after_accuracy(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=2.0, capacity=2, clock=clock)
+        limiter.acquire("k")
+        limiter.acquire("k")
+        r = limiter.acquire("k")
+        assert r.allowed is False
+        assert r.retry_after == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Fixed Window
+# ---------------------------------------------------------------------------
+
+
+class TestFixedWindow:
+    def test_allows_within_limit(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=5, window_seconds=60.0, clock=clock)
+        for i in range(5):
+            r = limiter.acquire("k")
+            assert r.allowed, f"request {i} should be allowed"
+
+    def test_denies_over_limit(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=3, window_seconds=60.0, clock=clock)
+        for _ in range(3):
+            limiter.acquire("k")
+        r = limiter.acquire("k")
+        assert r.allowed is False
+        assert r.retry_after is not None and r.retry_after > 0
+
+    def test_window_reset(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=2, window_seconds=10.0, clock=clock)
+        limiter.acquire("k")
+        limiter.acquire("k")
+        assert limiter.acquire("k").allowed is False
+        clock.advance(10.0)
+        r = limiter.acquire("k")
+        assert r.allowed is True
+        assert r.remaining == 1
+
+    def test_multi_token_acquire(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=10, window_seconds=60.0, clock=clock)
+        r = limiter.acquire("k", tokens=4)
+        assert r.allowed is True
+        assert r.remaining == 6
+        r = limiter.acquire("k", tokens=7)
+        assert r.allowed is False
+
+    def test_key_isolation(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=1, window_seconds=60.0, clock=clock)
+        limiter.acquire("a")
+        assert limiter.acquire("a").allowed is False
+        assert limiter.acquire("b").allowed is True
+
+    def test_peek_does_not_consume(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=3, window_seconds=60.0, clock=clock)
+        limiter.acquire("k")
+        r1 = limiter.peek("k")
+        r2 = limiter.peek("k")
+        assert r1.remaining == r2.remaining == 2
+
+    def test_retry_after_points_to_window_end(self):
+        clock = FakeClock(start=100.0)
+        limiter = FixedWindowLimiter(limit=1, window_seconds=30.0, clock=clock)
+        limiter.acquire("k")
+        clock.advance(5.0)
+        r = limiter.acquire("k")
+        assert r.allowed is False
+        assert r.retry_after == pytest.approx(25.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Sliding Window
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingWindow:
+    def test_allows_within_limit(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=5, window_seconds=60.0, clock=clock)
+        for i in range(5):
+            r = limiter.acquire("k")
+            assert r.allowed, f"request {i} should be allowed"
+
+    def test_denies_over_limit(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=3, window_seconds=60.0, clock=clock)
+        for _ in range(3):
+            limiter.acquire("k")
+        r = limiter.acquire("k")
+        assert r.allowed is False
+
+    def test_window_roll(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=4, window_seconds=10.0, clock=clock)
+        for _ in range(4):
+            limiter.acquire("k")
+        assert limiter.acquire("k").allowed is False
+        clock.advance(10.0)
+        assert limiter.acquire("k").allowed is False
+        clock.advance(5.0)
+        r = limiter.acquire("k")
+        assert r.allowed is True
+
+    def test_boundary_smoothing(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=10, window_seconds=10.0, clock=clock)
+        clock.advance(9.0)
+        for _ in range(8):
+            limiter.acquire("k")
+        clock.advance(1.5)
+        assert limiter.acquire("k").allowed is True
+        assert limiter.acquire("k").allowed is True
+        assert limiter.acquire("k").allowed is False
+
+    def test_multi_token_acquire(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=10, window_seconds=60.0, clock=clock)
+        r = limiter.acquire("k", tokens=6)
+        assert r.allowed is True
+        r = limiter.acquire("k", tokens=5)
+        assert r.allowed is False
+
+    def test_key_isolation(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=1, window_seconds=60.0, clock=clock)
+        limiter.acquire("a")
+        assert limiter.acquire("a").allowed is False
+        assert limiter.acquire("b").allowed is True
+
+    def test_peek_does_not_consume(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=5, window_seconds=60.0, clock=clock)
+        limiter.acquire("k")
+        limiter.acquire("k")
+        r1 = limiter.peek("k")
+        r2 = limiter.peek("k")
+        assert r1.remaining == r2.remaining
+
+
+# ---------------------------------------------------------------------------
+# GCRA
+# ---------------------------------------------------------------------------
+
+
+class TestGCRA:
+    def test_initial_burst(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=4, clock=clock)
+        for i in range(5):
+            r = limiter.acquire("k")
+            assert r.allowed, f"request {i} should be allowed"
+
+    def test_denied_after_burst(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=2, clock=clock)
+        for _ in range(3):
+            limiter.acquire("k")
+        r = limiter.acquire("k")
+        assert r.allowed is False
+        assert r.retry_after is not None and r.retry_after > 0
+
+    def test_recovery_over_time(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=2.0, burst=1, clock=clock)
+        limiter.acquire("k")
+        limiter.acquire("k")
+        assert limiter.acquire("k").allowed is False
+        clock.advance(0.5)
+        assert limiter.acquire("k").allowed is True
+
+    def test_no_burst(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=10.0, burst=0, clock=clock)
+        assert limiter.acquire("k").allowed is True
+        assert limiter.acquire("k").allowed is False
+        clock.advance(0.1)
+        assert limiter.acquire("k").allowed is True
+
+    def test_multi_token(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=10.0, burst=9, clock=clock)
+        r = limiter.acquire("k", tokens=5)
+        assert r.allowed is True
+        r = limiter.acquire("k", tokens=6)
+        assert r.allowed is False
+
+    def test_key_isolation(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=0, clock=clock)
+        limiter.acquire("a")
+        assert limiter.acquire("a").allowed is False
+        assert limiter.acquire("b").allowed is True
+
+    def test_peek_does_not_consume(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=2, clock=clock)
+        r1 = limiter.peek("k")
+        r2 = limiter.peek("k")
+        assert r1.remaining == r2.remaining
+
+
+# ---------------------------------------------------------------------------
+# Eviction
+# ---------------------------------------------------------------------------
+
+
+class TestEviction:
+    def test_token_bucket_evicts_stale_keys(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=2, clock=clock)
+        for i in range(200):
+            limiter.acquire(f"k{i}")
+        assert len(limiter._buckets) == 200
+        clock.advance(100.0)
+        for _ in range(128):
+            limiter.acquire("trigger")
+        assert len(limiter._buckets) < 200
+
+    def test_fixed_window_evicts_stale_keys(self):
+        clock = FakeClock()
+        limiter = FixedWindowLimiter(limit=10, window_seconds=5.0, clock=clock)
+        for i in range(200):
+            limiter.acquire(f"k{i}")
+        assert len(limiter._windows) == 200
+        clock.advance(15.0)
+        for _ in range(128):
+            limiter.acquire("trigger")
+        assert len(limiter._windows) < 200
+
+    def test_sliding_window_evicts_stale_keys(self):
+        clock = FakeClock()
+        limiter = SlidingWindowLimiter(limit=10, window_seconds=5.0, clock=clock)
+        for i in range(200):
+            limiter.acquire(f"k{i}")
+        assert len(limiter._states) == 200
+        clock.advance(20.0)
+        for _ in range(128):
+            limiter.acquire("trigger")
+        assert len(limiter._states) < 200
+
+    def test_gcra_evicts_stale_keys(self):
+        clock = FakeClock()
+        limiter = GCRALimiter(rate=1.0, burst=0, clock=clock)
+        for i in range(200):
+            limiter.acquire(f"k{i}")
+        assert len(limiter._tats) == 200
+        clock.advance(10.0)
+        for _ in range(128):
+            limiter.acquire("trigger")
+        assert len(limiter._tats) < 200
+
+
+# ---------------------------------------------------------------------------
+# Quota string parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseQuota:
+    def test_basic_slash(self):
+        q = parse_quota("100/s")
+        assert q == {"limit": 100, "period": 1.0, "burst": None}
+
+    def test_per_notation(self):
+        q = parse_quota("10 per minute")
+        assert q == {"limit": 10, "period": 60.0, "burst": None}
+
+    def test_with_burst(self):
+        q = parse_quota("50/s burst 100")
+        assert q == {"limit": 50, "period": 1.0, "burst": 100}
+
+    def test_plurals(self):
+        q = parse_quota("5/seconds")
+        assert q["period"] == 1.0
+        q = parse_quota("5/minutes")
+        assert q["period"] == 60.0
+        q = parse_quota("5/hours")
+        assert q["period"] == 3600.0
+
+    def test_all_units(self):
+        for unit, expected in [
+            ("s", 1.0),
+            ("sec", 1.0),
+            ("second", 1.0),
+            ("m", 60.0),
+            ("min", 60.0),
+            ("minute", 60.0),
+            ("h", 3600.0),
+            ("hr", 3600.0),
+            ("hour", 3600.0),
+            ("d", 86400.0),
+            ("day", 86400.0),
+        ]:
+            q = parse_quota(f"1/{unit}")
+            assert q["period"] == expected, f"unit {unit!r} failed"
+
+    def test_invalid_format(self):
+        with pytest.raises(ValueError, match="invalid quota string"):
+            parse_quota("not-a-quota")
+
+    def test_unknown_unit(self):
+        with pytest.raises(ValueError, match="unknown time unit"):
+            parse_quota("10/fortnight")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateLimiter:
+    def test_token_bucket(self):
+        lim = create_limiter("token_bucket", "10/s")
+        assert isinstance(lim, TokenBucketLimiter)
+
+    def test_fixed_window(self):
+        lim = create_limiter("fixed_window", "100/m")
+        assert isinstance(lim, FixedWindowLimiter)
+
+    def test_sliding_window(self):
+        lim = create_limiter("sliding_window", "100/m")
+        assert isinstance(lim, SlidingWindowLimiter)
+
+    def test_gcra(self):
+        lim = create_limiter("gcra", "10/s burst 20")
+        assert isinstance(lim, GCRALimiter)
+
+    def test_unknown_algorithm(self):
+        with pytest.raises(ValueError, match="unknown algorithm"):
+            create_limiter("leaky_bucket", "10/s")
+
+    def test_with_clock(self):
+        clock = FakeClock()
+        lim = create_limiter("token_bucket", "10/s", clock=clock)
+        r = lim.acquire("k")
+        assert r.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Decorator
+# ---------------------------------------------------------------------------
+
+
+class TestDecorator:
+    def test_sync_decorator_allows(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=10.0, capacity=5, clock=clock)
+
+        @ratelimit(limiter=limiter)
+        def func():
+            return 42
+
+        assert func() == 42
+
+    def test_sync_decorator_raises(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=1, clock=clock)
+
+        @ratelimit(limiter=limiter)
+        def func():
+            return 42
+
+        assert func() == 42
+        with pytest.raises(RateLimitExceeded):
+            func()
+
+    def test_async_decorator_allows(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=10.0, capacity=5, clock=clock)
+
+        @ratelimit(limiter=limiter)
+        async def func():
+            return 42
+
+        assert asyncio.run(func()) == 42
+
+    def test_async_decorator_raises(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=1, clock=clock)
+
+        @ratelimit(limiter=limiter)
+        async def func():
+            return 42
+
+        asyncio.run(func())
+        with pytest.raises(RateLimitExceeded):
+            asyncio.run(func())
+
+    def test_decorator_with_quota_string(self):
+        @ratelimit("1000/s")
+        def func():
+            return 42
+
+        assert func() == 42
+
+    def test_no_quota_no_limiter_raises(self):
+        with pytest.raises(ValueError, match="either 'quota' or 'limiter'"):
+            ratelimit()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+class TestContextManager:
+    def test_sync_context_manager(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=10.0, capacity=5, clock=clock)
+        with ratelimit(limiter=limiter) as result:
+            assert result.allowed is True
+
+    def test_sync_context_manager_raises(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=1.0, capacity=1, clock=clock)
+        with ratelimit(limiter=limiter):
+            pass
+        with pytest.raises(RateLimitExceeded):
+            with ratelimit(limiter=limiter):
+                pass
+
+    def test_async_context_manager(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=10.0, capacity=5, clock=clock)
+
+        async def run():
+            async with ratelimit(limiter=limiter) as result:
+                return result.allowed
+
+        assert asyncio.run(run()) is True
+
+
+# ---------------------------------------------------------------------------
+# Wait-and-retry
+# ---------------------------------------------------------------------------
+
+
+class TestWaitAndRetry:
+    def test_sync_wait_succeeds(self):
+        limiter = TokenBucketLimiter(rate=100.0, capacity=1)
+        limiter.acquire("__default__")
+        rl = ratelimit(limiter=limiter, timeout=1.0)
+        with rl:
+            pass
+
+    def test_sync_wait_timeout(self):
+        clock = FakeClock()
+        limiter = TokenBucketLimiter(rate=0.1, capacity=1, clock=clock)
+        limiter.acquire("__default__")
+        rl = ratelimit(limiter=limiter, timeout=0.01)
+        with pytest.raises(RateLimitExceeded):
+            rl._acquire_or_wait()
+
+    def test_async_wait_succeeds(self):
+        limiter = TokenBucketLimiter(rate=100.0, capacity=1)
+        limiter.acquire("__default__")
+
+        async def run():
+            rl = ratelimit(limiter=limiter, timeout=1.0)
+            async with rl:
+                pass
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafe:
+    def test_concurrent_access(self):
+        limiter = ThreadSafeLimiter(TokenBucketLimiter(rate=0.001, capacity=100))
+        lock = threading.Lock()
+        counts = {"allowed": 0, "denied": 0}
+
+        def worker():
+            for _ in range(50):
+                r = limiter.acquire("k")
+                with lock:
+                    if r.allowed:
+                        counts["allowed"] += 1
+                    else:
+                        counts["denied"] += 1
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert counts["allowed"] + counts["denied"] == 200
+        # With rate=0.001/s and capacity=100, essentially no refill
+        # happens during the test, so exactly 100 acquires succeed.
+        assert counts["allowed"] == 100
+
+    def test_peek_is_threadsafe(self):
+        inner = TokenBucketLimiter(rate=10.0, capacity=5)
+        limiter = ThreadSafeLimiter(inner)
+        r = limiter.peek("k")
+        assert r.remaining == 5
+
+
+# ---------------------------------------------------------------------------
+# RateLimitExceeded
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitExceeded:
+    def test_has_result(self):
+        result = RateLimitResult(
+            allowed=False, limit=10, remaining=0, reset_at=100.0, retry_after=5.0
+        )
+        exc = RateLimitExceeded(result)
+        assert exc.result is result
+        assert "retry_after=5.0" in str(exc)


### PR DESCRIPTION
## Summary

- Add `ratelimit` module: zero-dependency, single-file multi-algorithm rate limiter (807 lines, subsystem tier)
- Four algorithms: Token Bucket, Fixed Window, Sliding Window Counter, GCRA — behind a common `RateLimiter` Protocol
- Convenience API: `ratelimit()` decorator/context manager (sync+async), `create_limiter()` factory, `parse_quota()` string parser (`"10/s"`, `"100/m burst 200"`), `ThreadSafeLimiter`, `RateLimitExceeded`, wait-and-retry with timeout
- 76 correctness tests + 10 benchmarks; 2-4x faster than `limits` library

## Context

Extracted from [llm-rosetta#467](https://github.com/Oaklight/llm-rosetta/pull/467) (generic rate limiter for gateway module). The code is entirely stdlib-based and framework-agnostic — a natural fit for zerodep. Design documented in #120.

## Changes

| File | What |
|------|------|
| `ratelimit/ratelimit.py` | Module implementation (4 algorithms + convenience API) |
| `ratelimit/test_ratelimit_correctness.py` | 76 correctness tests |
| `ratelimit/test_ratelimit_benchmark.py` | 10 benchmark tests vs `limits` |
| `pyproject.toml` | Add `bench-ratelimit` extra, testpaths, ty paths |
| `_scripts/module_index_config.yaml` | Add ratelimit to network category + metadata |
| `manifest.json` | Auto-regenerated |

## Benchmark results

```
Name (time in ns)                      Mean
-------------------------------------------
test_fixed_window_acquire           1,430 (zerodep)
test_fixed_window_hit               3,799 (limits)     ← 2.7x slower

test_sliding_window_acquire         1,838 (zerodep)
test_sliding_window_hit             6,401 (limits)     ← 3.5x slower

test_token_bucket_acquire           1,577 (zerodep)
test_gcra_acquire                   1,452 (zerodep)
test_moving_window_hit              6,130 (limits)     ← no zerodep equivalent
```

## Test plan

- [x] `pytest ratelimit/test_ratelimit_correctness.py` — 76 passed
- [x] `pytest ratelimit/test_ratelimit_benchmark.py` — 10 passed
- [x] `ruff check ratelimit/` — clean
- [x] `ty check` — passed via pre-commit
- [x] `make manifest` — regenerated
- [x] `make docs-index` — regenerated

Closes #120