### PR TITLE
fix(cli): add -d/--dir flag to outdated subcommand

### DIFF
--- a/skill/zerodep/SKILL.md
+++ b/skill/zerodep/SKILL.md
@@ -39,9 +39,20 @@ dev = ["zerodep", ...]
 
 The CLI is self-documenting. Run `zerodep --help` to see all available subcommands, and `zerodep <subcommand> --help` for details on any specific command.
 
-The typical workflow is: browse modules, pick what you need, vendor them into your project directory.
+The typical workflow is: browse modules, pick what you need, vendor them into your project directory. Dependencies between modules are resolved automatically — if module A depends on module B, both are copied.
 
-Dependencies between modules are resolved automatically — if module A depends on module B, both are copied.
+Quick reference:
+
+```bash
+zerodep list                        # Browse all modules by category
+zerodep info sse                    # Show module details and deps
+zerodep add sse retry -d lib/       # Copy sse + httpclient + retry to lib/
+zerodep add sse --nested            # Copy into sse/ and httpclient/ subdirs
+zerodep update sse -d lib/          # Update existing modules in lib/
+zerodep outdated -d lib/            # Check for upstream changes in lib/
+```
+
+The `-d`/`--dir` flag is shared by `add`, `update`, and `outdated` — it specifies the target directory (defaults to `.`).
 
 ## What zerodep modules are
 

--- a/zerodep.py
+++ b/zerodep.py
@@ -870,7 +870,7 @@ def cmd_outdated(args: argparse.Namespace) -> None:
     manifest = _load_manifest(local=args.local, offline=args.offline)
     modules_data = manifest.get("modules", {})
 
-    scan_dir = Path.cwd()
+    scan_dir = Path(args.dir).resolve()
     rows: list[tuple[str, str, str, str]] = []
 
     for mod_name, mod in sorted(modules_data.items()):
@@ -906,7 +906,7 @@ def cmd_outdated(args: argparse.Namespace) -> None:
                 break
 
     if not rows:
-        _ok("No zerodep modules found in current directory.")
+        _ok(f"No zerodep modules found in {scan_dir}.")
         return
 
     # Print table
@@ -1476,7 +1476,12 @@ def main(argv: list[str] | None = None) -> None:
     bump_level.add_argument("--major", action="store_true", help="major bump")
 
     # outdated
-    sub.add_parser("outdated", help="check local files for upstream changes")
+    p_outdated = sub.add_parser(
+        "outdated", help="check local files for upstream changes"
+    )
+    p_outdated.add_argument(
+        "-d", "--dir", default=".", help="target directory (default: .)"
+    )
 
     # manifest
     sub.add_parser("manifest", help="regenerate manifest.json from source")


### PR DESCRIPTION
## Summary

- Add `-d`/`--dir` flag to `outdated` subcommand, matching `add` and `update` for consistency. Previously `outdated` hardcoded `Path.cwd()`, requiring users to `cd` into the target directory.
- Update "no modules found" message to show the actual scanned path instead of "current directory".
- Add CLI quick-reference with examples to the zerodep skill file.

## Test plan

- [x] `zerodep outdated --help` shows `-d`/`--dir` flag
- [x] `zerodep outdated -d /tmp` scans `/tmp` and shows path in output
- [x] `zerodep outdated` (no flag) still defaults to `.`
- [x] Pre-commit hooks pass