### PR TITLE
fix: _ensure_sibling_path supports flat vendor layouts

### DIFF
--- a/a2a/a2a.py
+++ b/a2a/a2a.py
@@ -62,7 +62,7 @@ from typing import (
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)

--- a/a2a/a2a.py
+++ b/a2a/a2a.py
@@ -61,11 +61,12 @@ from typing import (
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 _ensure_sibling_path("jsonrpc")

--- a/acp/acp.py
+++ b/acp/acp.py
@@ -91,11 +91,12 @@ from typing import (
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 _ensure_sibling_path("jsonrpc")

--- a/acp/acp.py
+++ b/acp/acp.py
@@ -92,7 +92,7 @@ from typing import (
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -72,11 +72,12 @@ logger = logging.getLogger(__name__)
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 try:

--- a/cdp/cdp.py
+++ b/cdp/cdp.py
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)
@@ -81,7 +81,7 @@ def _ensure_sibling_path(name: str) -> str:
 
 
 try:
-    _websocket_dir = _ensure_sibling_path("websocket")
+    _ensure_sibling_path("websocket")
     from websocket import AsyncWebSocketClient as _AsyncWebSocketClient
     from websocket import WebSocketClient as _WebSocketClient
     from websocket import WebSocketConnectionError as _WebSocketConnectionError

--- a/config/config.py
+++ b/config/config.py
@@ -58,7 +58,7 @@ __all__ = [
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)

--- a/config/config.py
+++ b/config/config.py
@@ -57,11 +57,12 @@ __all__ = [
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 # ── Sibling module loaders (lazy) ───────────────────────────────────────────

--- a/qr/qr.py
+++ b/qr/qr.py
@@ -1691,7 +1691,7 @@ def print_qr_terminal(text: str) -> None:
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)

--- a/qr/qr.py
+++ b/qr/qr.py
@@ -1690,11 +1690,12 @@ def print_qr_terminal(text: str) -> None:
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 def _load_png_encoder():

--- a/readability/readability.py
+++ b/readability/readability.py
@@ -68,7 +68,7 @@ log = logging.getLogger(__name__)
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)

--- a/readability/readability.py
+++ b/readability/readability.py
@@ -67,11 +67,12 @@ log = logging.getLogger(__name__)
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Add a sibling module directory to ``sys.path`` if not present."""
-    sibling_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", name))
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 def _load_soup():

--- a/skills/skills.py
+++ b/skills/skills.py
@@ -86,11 +86,12 @@ __all__ = [
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 def _load_frontmatter():

--- a/skills/skills.py
+++ b/skills/skills.py
@@ -87,7 +87,7 @@ __all__ = [
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)

--- a/sse/sse.py
+++ b/sse/sse.py
@@ -78,11 +78,12 @@ __all__ = [
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 # ── Sibling httpclient import (guarded) ──

--- a/sse/sse.py
+++ b/sse/sse.py
@@ -79,7 +79,7 @@ __all__ = [
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)
@@ -89,7 +89,7 @@ def _ensure_sibling_path(name: str) -> str:
 # ── Sibling httpclient import (guarded) ──
 
 try:
-    _httpclient_dir = _ensure_sibling_path("httpclient")
+    _ensure_sibling_path("httpclient")
     from httpclient import HttpConnectionError as _HttpConnectionError
     from httpclient import HttpTimeoutError as _HttpTimeoutError
     from httpclient import async_get as _http_async_get

--- a/vcs/vcs.py
+++ b/vcs/vcs.py
@@ -81,11 +81,12 @@ _UNSET = _Unset()
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(__file__)
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 # ── Sibling diff module import (lazy) ───────────────────────────────────────

--- a/vcs/vcs.py
+++ b/vcs/vcs.py
@@ -82,7 +82,7 @@ _UNSET = _Unset()
 
 def _ensure_sibling_path(name: str) -> str:
     """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
-    base = os.path.dirname(__file__)
+    base = os.path.dirname(os.path.abspath(__file__))
     for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
         if candidate not in sys.path:
             sys.path.insert(0, candidate)


### PR DESCRIPTION
## Summary

Fixes #124. `_ensure_sibling_path()` only added the nested sibling directory (`../name/`) to `sys.path`, which fails when modules are vendored in a flat layout (all `.py` files in the same directory).

Now adds both the module's own directory **and** the nested path, supporting both layouts:
- Flat: `_vendor/soup.py` + `_vendor/readability.py` ✅
- Nested: `soup/soup.py` + `readability/readability.py` ✅

## Changed files

All 9 modules with sibling dependencies: `readability`, `qr`, `vcs`, `skills`, `sse`, `config`, `a2a`, `acp`, `cdp`.

## Discovered in

Oaklight/veilrender — `readability` always returned `null` because `from soup import Soup` silently failed in flat vendor layout.

## Test plan
- [x] `ruff check` + `ruff format` + `ty check` pass
- [ ] `zerodep add readability -d /tmp/flat/ -y && python -c "import sys; sys.path.insert(0, '/tmp/flat'); from readability import extract; print(extract('<html><body><article><p>test text long enough</p></article></body></html>').text)"` succeeds