### PR TITLE
feat(httpserver): add background callback to StreamingResponse

### DIFF
--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -309,9 +309,12 @@ class StreamingResponse:
         status_code: HTTP status code.
         headers: Extra response headers.
         content_type: MIME type (default ``application/octet-stream``).
+        background: Optional callable invoked after the stream completes
+            (including client disconnect).  Accepts both sync and async
+            callables.  Exceptions are logged and suppressed.
     """
 
-    __slots__ = ("_generator", "status_code", "headers", "content_type")
+    __slots__ = ("_generator", "status_code", "headers", "content_type", "background")
 
     def __init__(
         self,
@@ -319,11 +322,13 @@ class StreamingResponse:
         status_code: int = 200,
         headers: dict[str, str] | None = None,
         content_type: str = "application/octet-stream",
+        background: Callable[..., Any] | None = None,
     ):
         self._generator = generator
         self.status_code = status_code
         self.headers: dict[str, str] = headers.copy() if headers else {}
         self.content_type = content_type
+        self.background = background
 
     async def _write(self, writer: asyncio.StreamWriter) -> None:
         """Write status line, headers, then stream the body."""
@@ -361,6 +366,13 @@ class StreamingResponse:
             aclose = getattr(self._generator, "aclose", None)
             if aclose is not None:
                 await aclose()
+            if self.background is not None:
+                try:
+                    result = self.background()
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception:
+                    logger.debug("Background callback failed", exc_info=True)
 
 
 class FileResponse(Response):

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -322,7 +322,7 @@ class StreamingResponse:
         status_code: int = 200,
         headers: dict[str, str] | None = None,
         content_type: str = "application/octet-stream",
-        background: Callable[..., Any] | None = None,
+        background: Callable[[], Any] | None = None,
     ):
         self._generator = generator
         self.status_code = status_code
@@ -365,14 +365,17 @@ class StreamingResponse:
         finally:
             aclose = getattr(self._generator, "aclose", None)
             if aclose is not None:
-                await aclose()
+                try:
+                    await aclose()
+                except Exception:
+                    logger.debug("Generator aclose failed", exc_info=True)
             if self.background is not None:
                 try:
                     result = self.background()
                     if inspect.isawaitable(result):
                         await result
                 except Exception:
-                    logger.debug("Background callback failed", exc_info=True)
+                    logger.warning("Background callback failed", exc_info=True)
 
 
 class FileResponse(Response):

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -17,6 +17,7 @@ from httpserver import (
     JSONResponse,
     Request,
     Response,
+    StreamingResponse,
     _coerce_response,
     _compile_route,
     abort,
@@ -362,6 +363,121 @@ class TestStreaming:
         text = r.text
         for i in range(3):
             assert f"chunk-{i}" in text
+
+
+class TestStreamingBackground:
+    """StreamingResponse background callback."""
+
+    def test_sync_background_called(self):
+        called = []
+
+        async def gen():
+            yield "hello"
+
+        resp = StreamingResponse(gen(), background=lambda: called.append("done"))
+
+        class MockWriter:
+            def write(self, data):
+                pass
+
+            async def drain(self):
+                pass
+
+        async def _run():
+            await resp._write(MockWriter())
+            assert called == ["done"]
+
+        asyncio.run(_run())
+
+    def test_async_background_called(self):
+        called = []
+
+        async def gen():
+            yield "hello"
+
+        async def on_complete():
+            called.append("async_done")
+
+        resp = StreamingResponse(gen(), background=on_complete)
+
+        class MockWriter:
+            def write(self, data):
+                pass
+
+            async def drain(self):
+                pass
+
+        async def _run():
+            await resp._write(MockWriter())
+            assert called == ["async_done"]
+
+        asyncio.run(_run())
+
+    def test_background_called_after_generator_completes(self):
+        order = []
+
+        async def gen():
+            for i in range(3):
+                order.append(f"chunk-{i}")
+                yield f"data-{i}"
+
+        def on_complete():
+            order.append("background")
+
+        resp = StreamingResponse(gen(), background=on_complete)
+
+        class MockWriter:
+            def write(self, data):
+                pass
+
+            async def drain(self):
+                pass
+
+        async def _run():
+            await resp._write(MockWriter())
+            assert order == ["chunk-0", "chunk-1", "chunk-2", "background"]
+
+        asyncio.run(_run())
+
+    def test_background_not_called_when_none(self):
+        async def gen():
+            yield "hello"
+
+        resp = StreamingResponse(gen())
+        assert resp.background is None
+
+        class MockWriter:
+            def write(self, data):
+                pass
+
+            async def drain(self):
+                pass
+
+        async def _run():
+            await resp._write(MockWriter())
+
+        asyncio.run(_run())
+
+    def test_background_exception_suppressed(self):
+        async def gen():
+            yield "hello"
+
+        def bad_callback():
+            raise ValueError("boom")
+
+        resp = StreamingResponse(gen(), background=bad_callback)
+
+        class MockWriter:
+            def write(self, data):
+                pass
+
+            async def drain(self):
+                pass
+
+        async def _run():
+            await resp._write(MockWriter())
+
+        asyncio.run(_run())
 
 
 class TestMiddleware:

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -365,6 +365,16 @@ class TestStreaming:
             assert f"chunk-{i}" in text
 
 
+class _MockWriter:
+    """Minimal writer stub for StreamingResponse tests."""
+
+    def write(self, data):
+        pass
+
+    async def drain(self):
+        pass
+
+
 class TestStreamingBackground:
     """StreamingResponse background callback."""
 
@@ -376,15 +386,8 @@ class TestStreamingBackground:
 
         resp = StreamingResponse(gen(), background=lambda: called.append("done"))
 
-        class MockWriter:
-            def write(self, data):
-                pass
-
-            async def drain(self):
-                pass
-
         async def _run():
-            await resp._write(MockWriter())
+            await resp._write(_MockWriter())
             assert called == ["done"]
 
         asyncio.run(_run())
@@ -400,15 +403,8 @@ class TestStreamingBackground:
 
         resp = StreamingResponse(gen(), background=on_complete)
 
-        class MockWriter:
-            def write(self, data):
-                pass
-
-            async def drain(self):
-                pass
-
         async def _run():
-            await resp._write(MockWriter())
+            await resp._write(_MockWriter())
             assert called == ["async_done"]
 
         asyncio.run(_run())
@@ -426,15 +422,8 @@ class TestStreamingBackground:
 
         resp = StreamingResponse(gen(), background=on_complete)
 
-        class MockWriter:
-            def write(self, data):
-                pass
-
-            async def drain(self):
-                pass
-
         async def _run():
-            await resp._write(MockWriter())
+            await resp._write(_MockWriter())
             assert order == ["chunk-0", "chunk-1", "chunk-2", "background"]
 
         asyncio.run(_run())
@@ -446,15 +435,8 @@ class TestStreamingBackground:
         resp = StreamingResponse(gen())
         assert resp.background is None
 
-        class MockWriter:
-            def write(self, data):
-                pass
-
-            async def drain(self):
-                pass
-
         async def _run():
-            await resp._write(MockWriter())
+            await resp._write(_MockWriter())
 
         asyncio.run(_run())
 
@@ -467,15 +449,24 @@ class TestStreamingBackground:
 
         resp = StreamingResponse(gen(), background=bad_callback)
 
-        class MockWriter:
-            def write(self, data):
-                pass
+        async def _run():
+            await resp._write(_MockWriter())
 
-            async def drain(self):
-                pass
+        asyncio.run(_run())
+
+    def test_background_called_after_generator_error(self):
+        called = []
+
+        async def gen():
+            yield "ok"
+            raise RuntimeError("generator error")
+
+        resp = StreamingResponse(gen(), background=lambda: called.append("done"))
 
         async def _run():
-            await resp._write(MockWriter())
+            with pytest.raises(RuntimeError, match="generator error"):
+                await resp._write(_MockWriter())
+            assert called == ["done"]
 
         asyncio.run(_run())
 


### PR DESCRIPTION
## Summary

- Add optional `background` parameter to `StreamingResponse` — a sync or async callable invoked after the stream generator completes (including on client disconnect)
- Follows the same pattern as [Starlette's `BackgroundTask`](https://starlette.dev/background/)
- Callback exceptions are logged and suppressed to avoid disrupting the response

## Motivation

When a handler returns a `StreamingResponse`, the handler's `finally` blocks run **before** the generator is consumed. This makes it impossible to do post-stream cleanup (like stopping a profiler or recording metrics) from the handler level.

Concrete use case: [llm-rosetta-gateway](https://github.com/Oaklight/llm-rosetta) starts a pyinstrument profiler before each request and needs to stop it after streaming completes. Without this feature, the profiler stops immediately when the handler returns the `StreamingResponse`, capturing none of the actual streaming work.

## Test plan

- [x] Sync background callback is called after stream completes
- [x] Async background callback is called after stream completes
- [x] Callback runs after all generator chunks are yielded (ordering)
- [x] No callback when `background=None` (default, backward compatible)
- [x] Callback exceptions are suppressed (no crash)
- [x] All 63 existing tests pass with no regression

Closes #132