### PR TITLE
feat(httpserver): add lifespan events (on_startup / on_shutdown)

### DIFF
--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -689,6 +689,7 @@ class App:
         self._error_handlers: dict[int | type, Callable[..., Any]] = {}
         self._server: asyncio.Server | None = None
         self._shutdown_event: asyncio.Event | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
         self.max_body_size = max_body_size
         self.read_timeout = read_timeout
         self.port: int | None = None
@@ -1125,6 +1126,7 @@ class App:
     async def _serve(self, host: str, port: int, *, socket: str | None = None) -> None:
         """Internal async server loop."""
         self._shutdown_event = asyncio.Event()
+        self._loop = asyncio.get_running_loop()
         self._socket_path: str | None = None
 
         try:
@@ -1227,10 +1229,10 @@ class App:
     def shutdown(self) -> None:
         """Request a graceful server shutdown.
 
-        Safe to call from a request handler.
+        Safe to call from any thread or from a request handler.
         """
-        if self._shutdown_event is not None:
-            self._shutdown_event.set()
+        if self._shutdown_event is not None and self._loop is not None:
+            self._loop.call_soon_threadsafe(self._shutdown_event.set)
 
 
 # ── Handler Invocation ───────────────────────────────────────────────────────

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -684,8 +684,8 @@ class App:
         self._static_routes: list[tuple[str, str]] = []
         self._before_request_handlers: list[Callable[..., Any]] = []
         self._after_request_handlers: list[Callable[..., Any]] = []
-        self._startup_handlers: list[Callable[..., Any]] = []
-        self._shutdown_handlers: list[Callable[..., Any]] = []
+        self._startup_handlers: list[Callable[[], Any]] = []
+        self._shutdown_handlers: list[Callable[[], Any]] = []
         self._error_handlers: dict[int | type, Callable[..., Any]] = {}
         self._server: asyncio.Server | None = None
         self._shutdown_event: asyncio.Event | None = None
@@ -805,7 +805,7 @@ class App:
 
     # ── Lifespan Hooks ───────────────────────────────────────────────────
 
-    def on_startup(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+    def on_startup(self, handler: Callable[[], Any]) -> Callable[[], Any]:
         """Register a startup hook.
 
         The hook is called (with no arguments) before the server starts
@@ -819,12 +819,12 @@ class App:
 
             @app.on_startup
             async def init_pool():
-                app.state["pool"] = await create_pool()
+                app.pool = await create_pool()
         """
         self._startup_handlers.append(handler)
         return handler
 
-    def on_shutdown(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+    def on_shutdown(self, handler: Callable[[], Any]) -> Callable[[], Any]:
         """Register a shutdown hook.
 
         The hook is called (with no arguments) after the server stops
@@ -838,7 +838,7 @@ class App:
 
             @app.on_shutdown
             async def close_pool():
-                await app.state["pool"].close()
+                await app.pool.close()
         """
         self._shutdown_handlers.append(handler)
         return handler
@@ -1127,30 +1127,32 @@ class App:
         self._shutdown_event = asyncio.Event()
         self._socket_path: str | None = None
 
-        # Run startup hooks before accepting connections
-        await self._run_startup_hooks()
-
-        if socket:
-            server = await self._start_unix_socket(socket)
-        else:
-            server = await asyncio.start_server(
-                self._handle_connection,
-                host,
-                port,
-            )
-            addrs = server.sockets[0].getsockname() if server.sockets else (host, port)
-            self.host = addrs[0]
-            self.port = addrs[1]
-            logger.info("Serving on %s:%d", self.host, self.port)
-
-        self._server = server
-
-        loop = asyncio.get_running_loop()
-        if sys.platform != "win32":
-            for sig in (signal.SIGINT, signal.SIGTERM):
-                loop.add_signal_handler(sig, self._shutdown_event.set)
-
         try:
+            # Run startup hooks before accepting connections
+            await self._run_startup_hooks()
+
+            if socket:
+                server = await self._start_unix_socket(socket)
+            else:
+                server = await asyncio.start_server(
+                    self._handle_connection,
+                    host,
+                    port,
+                )
+                addrs = (
+                    server.sockets[0].getsockname() if server.sockets else (host, port)
+                )
+                self.host = addrs[0]
+                self.port = addrs[1]
+                logger.info("Serving on %s:%d", self.host, self.port)
+
+            self._server = server
+
+            loop = asyncio.get_running_loop()
+            if sys.platform != "win32":
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.add_signal_handler(sig, self._shutdown_event.set)
+
             async with server:
                 await self._shutdown_event.wait()
                 logger.info("Shutting down server")

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -684,6 +684,8 @@ class App:
         self._static_routes: list[tuple[str, str]] = []
         self._before_request_handlers: list[Callable[..., Any]] = []
         self._after_request_handlers: list[Callable[..., Any]] = []
+        self._startup_handlers: list[Callable[..., Any]] = []
+        self._shutdown_handlers: list[Callable[..., Any]] = []
         self._error_handlers: dict[int | type, Callable[..., Any]] = {}
         self._server: asyncio.Server | None = None
         self._shutdown_event: asyncio.Event | None = None
@@ -800,6 +802,46 @@ class App:
             return handler
 
         return decorator
+
+    # ── Lifespan Hooks ───────────────────────────────────────────────────
+
+    def on_startup(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register a startup hook.
+
+        The hook is called (with no arguments) before the server starts
+        accepting connections.  Both sync and async callables are supported.
+        Hooks run in registration order.
+
+        If a startup hook raises, the error is logged and re-raised so the
+        server does not start with failed initialization.
+
+        Example::
+
+            @app.on_startup
+            async def init_pool():
+                app.state["pool"] = await create_pool()
+        """
+        self._startup_handlers.append(handler)
+        return handler
+
+    def on_shutdown(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register a shutdown hook.
+
+        The hook is called (with no arguments) after the server stops
+        accepting connections.  Both sync and async callables are supported.
+        Hooks run in **reverse** registration order (LIFO).
+
+        If a shutdown hook raises, the error is logged and the remaining
+        hooks still execute (best-effort cleanup).
+
+        Example::
+
+            @app.on_shutdown
+            async def close_pool():
+                await app.state["pool"].close()
+        """
+        self._shutdown_handlers.append(handler)
+        return handler
 
     # ── Request Dispatch ─────────────────────────────────────────────────
 
@@ -1020,6 +1062,43 @@ class App:
 
     # ── Server Lifecycle ─────────────────────────────────────────────────
 
+    async def _run_startup_hooks(self) -> None:
+        """Run all registered startup hooks in registration order.
+
+        If any hook raises, the exception is logged and re-raised so the
+        server does not start with failed initialization.
+        """
+        for hook in self._startup_handlers:
+            try:
+                result = hook()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.error(
+                    "Startup hook %r failed",
+                    getattr(hook, "__name__", repr(hook)),
+                    exc_info=True,
+                )
+                raise
+
+    async def _run_shutdown_hooks(self) -> None:
+        """Run all registered shutdown hooks in reverse registration order.
+
+        Errors are logged and suppressed so that remaining hooks still
+        execute (best-effort cleanup).
+        """
+        for hook in reversed(self._shutdown_handlers):
+            try:
+                result = hook()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.warning(
+                    "Shutdown hook %r failed",
+                    getattr(hook, "__name__", repr(hook)),
+                    exc_info=True,
+                )
+
     def run(
         self,
         host: str = DEFAULT_HOST,
@@ -1048,6 +1127,9 @@ class App:
         self._shutdown_event = asyncio.Event()
         self._socket_path: str | None = None
 
+        # Run startup hooks before accepting connections
+        await self._run_startup_hooks()
+
         if socket:
             server = await self._start_unix_socket(socket)
         else:
@@ -1068,11 +1150,15 @@ class App:
             for sig in (signal.SIGINT, signal.SIGTERM):
                 loop.add_signal_handler(sig, self._shutdown_event.set)
 
-        async with server:
-            await self._shutdown_event.wait()
-            logger.info("Shutting down server")
-            if self._socket_path:
-                self._cleanup_socket()
+        try:
+            async with server:
+                await self._shutdown_event.wait()
+                logger.info("Shutting down server")
+                if self._socket_path:
+                    self._cleanup_socket()
+        finally:
+            # Run shutdown hooks after server stops accepting connections
+            await self._run_shutdown_hooks()
 
     async def _start_unix_socket(self, socket_path: str) -> asyncio.Server:
         """Start listening on a Unix domain socket.

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -655,3 +655,220 @@ class TestRequestState:
             assert log == ["before", "handler", "after"]
 
         asyncio.run(_test())
+class TestLifespan:
+    """Lifespan event hooks (on_startup / on_shutdown)."""
+
+    def test_sync_startup(self):
+        """Sync startup hook is called."""
+        app = App()
+        called = []
+
+        @app.on_startup
+        def init():
+            called.append("started")
+
+        asyncio.run(app._run_startup_hooks())
+        assert called == ["started"]
+
+    def test_async_startup(self):
+        """Async startup hook is called."""
+        app = App()
+        called = []
+
+        @app.on_startup
+        async def init():
+            called.append("async_started")
+
+        asyncio.run(app._run_startup_hooks())
+        assert called == ["async_started"]
+
+    def test_sync_shutdown(self):
+        """Sync shutdown hook is called."""
+        app = App()
+        called = []
+
+        @app.on_shutdown
+        def cleanup():
+            called.append("stopped")
+
+        asyncio.run(app._run_shutdown_hooks())
+        assert called == ["stopped"]
+
+    def test_async_shutdown(self):
+        """Async shutdown hook is called."""
+        app = App()
+        called = []
+
+        @app.on_shutdown
+        async def cleanup():
+            called.append("async_stopped")
+
+        asyncio.run(app._run_shutdown_hooks())
+        assert called == ["async_stopped"]
+
+    def test_startup_order(self):
+        """Startup hooks run in registration order."""
+        app = App()
+        order = []
+
+        @app.on_startup
+        def first():
+            order.append(1)
+
+        @app.on_startup
+        async def second():
+            order.append(2)
+
+        @app.on_startup
+        def third():
+            order.append(3)
+
+        asyncio.run(app._run_startup_hooks())
+        assert order == [1, 2, 3]
+
+    def test_shutdown_reverse_order(self):
+        """Shutdown hooks run in reverse registration order (LIFO)."""
+        app = App()
+        order = []
+
+        @app.on_shutdown
+        def first():
+            order.append(1)
+
+        @app.on_shutdown
+        async def second():
+            order.append(2)
+
+        @app.on_shutdown
+        def third():
+            order.append(3)
+
+        asyncio.run(app._run_shutdown_hooks())
+        assert order == [3, 2, 1]
+
+    def test_startup_failure_reraises(self):
+        """Startup hook failure is re-raised to prevent server start."""
+        app = App()
+        called = []
+
+        @app.on_startup
+        def good():
+            called.append("good")
+
+        @app.on_startup
+        async def bad():
+            raise RuntimeError("init failed")
+
+        @app.on_startup
+        def after_bad():
+            called.append("should_not_run")
+
+        with pytest.raises(RuntimeError, match="init failed"):
+            asyncio.run(app._run_startup_hooks())
+
+        # First hook ran, third did not
+        assert called == ["good"]
+
+    def test_shutdown_failure_continues(self):
+        """Shutdown hook failure does not prevent remaining hooks."""
+        app = App()
+        called = []
+
+        @app.on_shutdown
+        def first():
+            called.append("first")
+
+        @app.on_shutdown
+        async def bad():
+            raise RuntimeError("cleanup failed")
+
+        @app.on_shutdown
+        def third():
+            called.append("third")
+
+        # No exception raised despite the failing hook
+        asyncio.run(app._run_shutdown_hooks())
+
+        # Reverse order: third, bad (fails), first — both non-failing hooks ran
+        assert called == ["third", "first"]
+
+    def test_decorators_return_original(self):
+        """on_startup / on_shutdown return the original callable."""
+        app = App()
+
+        @app.on_startup
+        def my_startup():
+            pass
+
+        @app.on_shutdown
+        async def my_shutdown():
+            pass
+
+        assert my_startup.__name__ == "my_startup"
+        assert my_shutdown.__name__ == "my_shutdown"
+
+    def test_lifespan_integration_with_serve(self):
+        """Startup and shutdown hooks fire during a full server lifecycle."""
+        import threading
+
+        app = App()
+        events = []
+
+        @app.on_startup
+        async def on_start():
+            events.append("startup")
+
+        @app.on_shutdown
+        async def on_stop():
+            events.append("shutdown")
+
+        @app.get("/ping")
+        async def ping(request):
+            return {"pong": True}
+
+        ready = threading.Event()
+
+        def _run():
+            async def _start():
+                app._shutdown_event = asyncio.Event()
+                # Startup hooks
+                await app._run_startup_hooks()
+                server = await asyncio.start_server(
+                    app._handle_connection, "127.0.0.1", 0
+                )
+                app._server = server
+                addrs = server.sockets[0].getsockname()
+                app.host = addrs[0]
+                app.port = addrs[1]
+                ready.set()
+                try:
+                    async with server:
+                        await app._shutdown_event.wait()
+                finally:
+                    await app._run_shutdown_hooks()
+
+            asyncio.run(_start())
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        ready.wait(timeout=5)
+
+        from httpclient import get as http_get
+
+        r = http_get(f"http://127.0.0.1:{app.port}/ping")
+        assert r.status_code == 200
+
+        app.shutdown()
+        thread.join(timeout=2)
+
+        assert events == ["startup", "shutdown"]
+
+    def test_no_hooks_is_noop(self):
+        """Server works fine with no lifespan hooks registered."""
+        app = App()
+
+        async def _test():
+            await app._run_startup_hooks()
+            await app._run_shutdown_hooks()
+
+        asyncio.run(_test())  # Should not raise

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -655,6 +655,8 @@ class TestRequestState:
             assert log == ["before", "handler", "after"]
 
         asyncio.run(_test())
+
+
 class TestLifespan:
     """Lifespan event hooks (on_startup / on_shutdown)."""
 

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -859,7 +859,8 @@ class TestLifespan:
         assert r.status_code == 200
 
         app.shutdown()
-        thread.join(timeout=2)
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "Server thread did not exit in time"
 
         assert events == ["startup", "shutdown"]
 

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -831,7 +831,7 @@ class TestLifespan:
         def _run():
             async def _start():
                 app._shutdown_event = asyncio.Event()
-                # Startup hooks
+                app._loop = asyncio.get_running_loop()
                 await app._run_startup_hooks()
                 server = await asyncio.start_server(
                     app._handle_connection, "127.0.0.1", 0

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-09-03T23:33:43.053319+00:00",
+  "generated": "2026-09-04T06:03:32.165430+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -179,8 +179,8 @@
       "deps": [],
       "tier": "subsystem",
       "category": "network",
-      "last_updated": "2026-09-03T18:10:53-05:00",
-      "content_hash": "edd19faf629c59160cc3fe90068563dd11c4231a8bac2264107ed7f4af18c9c8"
+      "last_updated": "2026-09-04T00:40:55-05:00",
+      "content_hash": "7262797f4fb0d295d5257c3fc2c22582b3e6a18d697c9ac14b4aa020426175d6"
     },
     "jsonrpc": {
       "description": "JSON-RPC 2.0 -- Zero-dependency Python implementation",


### PR DESCRIPTION
## Summary

- Add `on_startup` and `on_shutdown` decorator hooks to `App` for server lifecycle management
- Startup hooks run in registration order before `asyncio.start_server`
- Shutdown hooks run in reverse order (LIFO) after server stops, in a `finally` block
- Both sync and async callables supported
- Startup failure re-raises (prevents server start); shutdown failure is suppressed (best-effort cleanup)

## Motivation

No way to run initialization or cleanup logic tied to the server lifecycle. Users need to manage connection pools, caches, background workers etc. externally. This follows the Starlette/FastAPI pattern.

## Test plan

- [x] Sync/async startup hooks called
- [x] Sync/async shutdown hooks called
- [x] Startup hooks run in registration order
- [x] Shutdown hooks run in reverse order (LIFO)
- [x] Startup failure re-raises, stops subsequent hooks
- [x] Shutdown failure suppressed, remaining hooks still run
- [x] Decorators return original callable
- [x] Full integration test with live server lifecycle
- [x] No-hooks case is a no-op
- [x] All existing tests pass (75 total)

Closes #134