### PR TITLE
feat(httpserver): add request-scoped state (request.state)

### DIFF
--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -173,6 +173,9 @@ class State:
     the same pattern as Starlette's ``State``.
     """
 
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, State):
             return NotImplemented

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.2.1"
+# version = "0.3.0"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -61,6 +61,7 @@ __all__ = [
     "JSONResponse",
     "StreamingResponse",
     "FileResponse",
+    "State",
     # Exceptions
     "HTTPException",
     # Utilities
@@ -156,6 +157,32 @@ def abort(status_code: int, message: str | None = None) -> None:
     raise HTTPException(status_code, message)
 
 
+# ── Request State ────────────────────────────────────────────────────────────
+
+
+class State:
+    """Mutable namespace for storing arbitrary per-request data.
+
+    Middleware and handlers can attach attributes freely::
+
+        @app.before_request
+        async def start_timer(req):
+            req.state.start_time = time.monotonic()
+
+    Uses ``__dict__``-based attribute access (no ``__slots__``), following
+    the same pattern as Starlette's ``State``.
+    """
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, State):
+            return NotImplemented
+        return self.__dict__ == other.__dict__
+
+    def __repr__(self) -> str:
+        items = ", ".join(f"{k}={v!r}" for k, v in self.__dict__.items())
+        return f"State({items})"
+
+
 # ── Request ──────────────────────────────────────────────────────────────────
 
 
@@ -172,6 +199,7 @@ class Request:
         path_params: Parameters extracted from the route pattern.
         client_addr: Client ``(host, port)`` tuple.
         app: Reference to the :class:`App` instance handling this request.
+        state: Per-request :class:`State` namespace for arbitrary data.
     """
 
     __slots__ = (
@@ -184,6 +212,7 @@ class Request:
         "path_params",
         "client_addr",
         "app",
+        "state",
         "_json",
     )
 
@@ -206,6 +235,7 @@ class Request:
         self.path_params: dict[str, Any] = {}
         self.client_addr = client_addr
         self.app = app
+        self.state = State()
         self._json: Any = _SENTINEL
 
     def json(self) -> Any:

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -17,6 +17,7 @@ from httpserver import (
     JSONResponse,
     Request,
     Response,
+    State,
     StreamingResponse,
     _coerce_response,
     _compile_route,
@@ -536,5 +537,121 @@ class TestMiddleware:
             resp = await app._dispatch(req)
             assert resp.status_code == 404
             assert json.loads(resp.body)["custom"] == "not found"
+
+        asyncio.run(_test())
+
+
+class TestRequestState:
+    """Per-request State namespace."""
+
+    def test_set_and_get_attribute(self):
+        """State allows arbitrary attribute set/get."""
+        state = State()
+        state.foo = "bar"
+        state.count = 42
+        assert state.foo == "bar"
+        assert state.count == 42
+
+    def test_missing_attribute_raises(self):
+        """Accessing an unset attribute raises AttributeError."""
+        state = State()
+        with pytest.raises(AttributeError):
+            _ = state.no_such_attr
+
+    def test_repr_empty(self):
+        """Empty State has a clean repr."""
+        state = State()
+        assert repr(state) == "State()"
+
+    def test_repr_with_attrs(self):
+        """State repr shows stored attributes."""
+        state = State()
+        state.x = 1
+        r = repr(state)
+        assert r.startswith("State(")
+        assert "x=1" in r
+
+    def test_equality(self):
+        """Two State objects with the same attributes are equal."""
+        a = State()
+        a.x = 1
+        a.y = "hello"
+        b = State()
+        b.x = 1
+        b.y = "hello"
+        assert a == b
+
+    def test_inequality(self):
+        """State objects with different attributes are not equal."""
+        a = State()
+        a.x = 1
+        b = State()
+        b.x = 2
+        assert a != b
+
+    def test_equality_not_implemented_for_other_types(self):
+        """State.__eq__ returns NotImplemented for non-State objects."""
+        state = State()
+        assert state != "not a state"
+        assert state.__eq__("not a state") is NotImplemented
+
+    def test_request_has_fresh_state(self):
+        """Each Request gets its own fresh State instance."""
+        req = Request("GET", "/", "", {}, b"", ("127.0.0.1", 0))
+        assert isinstance(req.state, State)
+        assert repr(req.state) == "State()"
+
+    def test_each_request_gets_independent_state(self):
+        """Two requests do not share state."""
+        req1 = Request("GET", "/", "", {}, b"", ("127.0.0.1", 0))
+        req2 = Request("GET", "/", "", {}, b"", ("127.0.0.1", 0))
+        req1.state.marker = "req1"
+        assert not hasattr(req2.state, "marker")
+
+    def test_state_in_before_request_middleware(self):
+        """State set in before_request is visible in the handler."""
+        app = App()
+        observed = {}
+
+        @app.before_request
+        async def inject(request):
+            request.state.injected = "hello"
+
+        @app.get("/check")
+        async def handler(request):
+            observed["value"] = request.state.injected
+            return {"ok": True}
+
+        async def _test():
+            req = Request("GET", "/check", "", {}, b"", ("127.0.0.1", 0), app=app)
+            await app._dispatch(req)
+            assert observed["value"] == "hello"
+
+        asyncio.run(_test())
+
+    def test_state_persists_across_middleware_and_handler(self):
+        """State survives from before_request through handler to after_request."""
+        app = App()
+        log = []
+
+        @app.before_request
+        async def before(request):
+            request.state.trace = ["before"]
+
+        @app.get("/traced")
+        async def handler(request):
+            request.state.trace.append("handler")
+            return {"ok": True}
+
+        @app.after_request
+        async def after(request, response):
+            request.state.trace.append("after")
+            log.extend(request.state.trace)
+            return response
+
+        async def _test():
+            req = Request("GET", "/traced", "", {}, b"", ("127.0.0.1", 0), app=app)
+            await app._dispatch(req)
+            assert log == ["before", "handler", "after"]
 
         asyncio.run(_test())

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-08-30T05:22:56.487702+00:00",
+  "generated": "2026-09-03T23:33:43.053319+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -175,12 +175,12 @@
       "files": [
         "httpserver/httpserver.py"
       ],
-      "version": "0.2.1",
+      "version": "0.3.0",
       "deps": [],
       "tier": "subsystem",
       "category": "network",
-      "last_updated": "2026-06-26T15:01:23-05:00",
-      "content_hash": "33e7f4f0032b96e919a1e7641acc3456423a57a6a13b7ea35f7317e80025e1c8"
+      "last_updated": "2026-09-03T18:10:53-05:00",
+      "content_hash": "edd19faf629c59160cc3fe90068563dd11c4231a8bac2264107ed7f4af18c9c8"
     },
     "jsonrpc": {
       "description": "JSON-RPC 2.0 -- Zero-dependency Python implementation",


### PR DESCRIPTION
## Summary

- Add `State` class — a `__dict__`-based namespace for arbitrary attribute access
- Add `state` attribute to `Request`, initialized as a fresh `State()` per request
- Export `State` in `__all__`

## Motivation

No built-in way to share data between middleware (`before_request`/`after_request`) and handlers within a single request. Users resort to thread-locals or global dicts keyed by request ID. The `request.state` pattern (from Starlette/FastAPI) is the standard solution.

## Test plan

- [x] Attribute set/get on State
- [x] AttributeError on missing attribute
- [x] `__repr__` for empty and non-empty State
- [x] Equality/inequality
- [x] Fresh state per request
- [x] Independent state across requests
- [x] State accessible in `before_request` middleware
- [x] State persists across before_request → handler → after_request
- [x] All existing tests pass (75 total)

Closes #135