### PR TITLE
feat(validate): add Doc, create_struct, and schema defaults

### DIFF
--- a/validate/test_validate_correctness.py
+++ b/validate/test_validate_correctness.py
@@ -10,6 +10,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(__file__))
 
 from validate import (
+    Doc,
     ErrorDetail,
     FieldValidator,
     Ge,
@@ -21,6 +22,7 @@ from validate import (
     MinLen,
     Predicate,
     ValidationError,
+    create_struct,
     json_schema,
     model_validator,
     validate,
@@ -889,6 +891,156 @@ def _type_to_schema_import(tp: Any) -> dict[str, Any]:
     from validate import _type_to_schema
 
     return _type_to_schema(tp)
+
+
+# ── Doc ──
+
+
+class TestDoc:
+    def test_schema_description(self):
+        """Doc adds description to JSON Schema."""
+        schema = json_schema(Annotated[str, Doc("A name")])
+        assert schema == {"type": "string", "description": "A name"}
+
+    def test_with_constraints(self):
+        """Doc and constraints can be combined."""
+        tp = Annotated[int, Doc("User age"), Ge(0)]
+        schema = json_schema(tp)
+        assert schema["type"] == "integer"
+        assert schema["description"] == "User age"
+        assert schema["minimum"] == 0
+
+    def test_no_validation_effect(self):
+        """Doc does not affect validation."""
+        tp = Annotated[str, Doc("just a label")]
+        assert validate("hello", tp) == "hello"
+        with pytest.raises(ValidationError):
+            validate(123, tp)
+
+    def test_in_typeddict_schema(self):
+        """Doc descriptions appear in struct property schemas."""
+
+        class Params(TypedDict):
+            name: Annotated[str, Doc("The user's name")]
+            age: Annotated[int, Doc("Years old")]
+
+        schema = json_schema(Params)
+        assert schema["properties"]["name"]["description"] == "The user's name"
+        assert schema["properties"]["age"]["description"] == "Years old"
+
+    def test_str(self):
+        assert str(Doc("hello")) == "hello"
+
+
+# ── create_struct ──
+
+
+class TestCreateStruct:
+    def test_required_fields(self):
+        """Fields with Ellipsis default are required."""
+        T = create_struct("T", {"x": (int, ...), "y": (str, ...)})
+        assert validate({"x": 1, "y": "a"}, T) == {"x": 1, "y": "a"}
+        with pytest.raises(ValidationError):
+            validate({"x": 1}, T)
+
+    def test_optional_with_default(self):
+        """Fields with non-Ellipsis default are optional."""
+        T = create_struct("T", {"x": (int, ...), "y": (str, "hello")})
+        assert validate({"x": 1}, T) == {"x": 1}
+        assert validate({"x": 1, "y": "world"}, T) == {"x": 1, "y": "world"}
+
+    def test_is_typeddict(self):
+        """Returned type behaves as a TypedDict."""
+        T = create_struct("T", {"x": (int, ...)})
+        assert hasattr(T, "__required_keys__")
+        assert hasattr(T, "__optional_keys__")
+
+    def test_field_defaults_stored(self):
+        """Default values are stored in __field_defaults__."""
+        T = create_struct("T", {"x": (int, ...), "y": (str, "hi"), "z": (int, 0)})
+        assert T.__field_defaults__ == {"y": "hi", "z": 0}
+
+    def test_all_required_empty_defaults(self):
+        """All-required struct has empty __field_defaults__."""
+        T = create_struct("T", {"x": (int, ...), "y": (str, ...)})
+        assert T.__field_defaults__ == {}
+
+    def test_with_doc(self):
+        """Doc annotations work inside create_struct fields."""
+        T = create_struct(
+            "T",
+            {
+                "name": (Annotated[str, Doc("The name")], ...),
+            },
+        )
+        schema = json_schema(T)
+        assert schema["properties"]["name"]["description"] == "The name"
+
+    def test_with_constraints(self):
+        """Constraint annotations work inside create_struct fields."""
+        T = create_struct("T", {"age": (Annotated[int, Ge(0)], ...)})
+        validate({"age": 5}, T)
+        with pytest.raises(ValidationError):
+            validate({"age": -1}, T)
+        schema = json_schema(T)
+        assert schema["properties"]["age"]["minimum"] == 0
+
+    def test_schema_includes_defaults(self):
+        """json_schema emits default values for optional fields."""
+        T = create_struct(
+            "T",
+            {
+                "x": (int, ...),
+                "y": (str, "hello"),
+                "z": (int, 42),
+            },
+        )
+        schema = json_schema(T)
+        assert "default" not in schema["properties"]["x"]
+        assert schema["properties"]["y"]["default"] == "hello"
+        assert schema["properties"]["z"]["default"] == 42
+
+    def test_nested_struct(self):
+        """create_struct types can be nested."""
+        Inner = create_struct("Inner", {"v": (int, ...)})
+        Outer = create_struct("Outer", {"inner": (Inner, ...), "tag": (str, "x")})
+        data = {"inner": {"v": 1}}
+        assert validate(data, Outer) == data
+        schema = json_schema(Outer)
+        assert schema["properties"]["inner"]["type"] == "object"
+        assert schema["properties"]["tag"]["default"] == "x"
+
+    def test_schema_title(self):
+        """create_struct type name becomes schema title."""
+        T = create_struct("MyParams", {"x": (int, ...)})
+        schema = json_schema(T)
+        assert schema["title"] == "MyParams"
+
+    def test_none_default(self):
+        """None as default value is emitted in schema."""
+        T = create_struct("T", {"tag": (str | None, None)})
+        schema = json_schema(T)
+        assert schema["properties"]["tag"]["default"] is None
+
+    def test_dataclass_defaults_in_schema(self):
+        """Dataclass static defaults appear in json_schema output."""
+        schema = json_schema(PointWithDefault)
+        assert schema["properties"]["z"]["default"] == 0.0
+        assert "default" not in schema["properties"]["x"]
+        assert "default" not in schema["properties"]["y"]
+
+    def test_doc_and_default_combined(self):
+        """Doc description and default coexist in schema."""
+        T = create_struct(
+            "T",
+            {
+                "limit": (Annotated[int, Doc("Max results")], 10),
+            },
+        )
+        schema = json_schema(T)
+        prop = schema["properties"]["limit"]
+        assert prop["description"] == "Max results"
+        assert prop["default"] == 10
 
 
 # ── FieldValidator ──

--- a/validate/test_validate_correctness.py
+++ b/validate/test_validate_correctness.py
@@ -476,6 +476,20 @@ class TestUnion:
         with pytest.raises(ValidationError):
             validate([], Union[str, int])
 
+    def test_pep604_optional(self):
+        """PEP 604 ``X | None`` works like ``Optional[X]``."""
+        assert validate("hello", str | None) == "hello"
+        assert validate(None, str | None) is None
+        with pytest.raises(ValidationError):
+            validate(42, str | None)
+
+    def test_pep604_union(self):
+        """PEP 604 ``X | Y`` works like ``Union[X, Y]``."""
+        assert validate("hello", str | int) == "hello"
+        assert validate(42, str | int) == 42
+        with pytest.raises(ValidationError):
+            validate([], str | int)
+
     def test_discriminated_union(self):
         DiscUnion = Union[TypeA, TypeB]
         data_a = {"kind": "a", "value_a": "hello"}
@@ -842,6 +856,21 @@ class TestJsonSchema:
         schema = json_schema(HasOptional)
         val = schema["properties"]["value"]
         assert val["type"] == ["string", "null"]
+
+    def test_pep604_optional_schema(self):
+        """PEP 604 ``X | None`` produces same schema as ``Optional[X]``."""
+        schema = _type_to_schema_import(str | None)
+        assert schema == {"type": ["string", "null"]}
+
+    def test_pep604_union_schema(self):
+        """PEP 604 ``X | Y`` produces same schema as ``Union[X, Y]``."""
+        schema = _type_to_schema_import(str | int)
+        assert "oneOf" in schema
+
+    def test_pep604_double_optional_no_duplicate_null(self):
+        """``Optional[X | None]`` does not produce double null in schema."""
+        schema = _type_to_schema_import(Optional[str | None])
+        assert schema == {"type": ["string", "null"]}
 
     def test_dict_schema(self):
         schema = _type_to_schema_import(dict[str, int])

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -70,9 +70,12 @@ from __future__ import annotations
 import dataclasses
 import functools
 import re
+import types
 import typing
 from collections.abc import Callable
 from typing import Any, Union, get_type_hints
+
+_UNION_ORIGINS = (Union, types.UnionType)
 
 __all__ = [
     # Constraint annotations
@@ -535,7 +538,7 @@ def _type_name(tp: Any) -> str:
     if origin is typing.Annotated:
         base = typing.get_args(tp)[0]
         return _type_name(base)
-    if origin is Union:
+    if origin in _UNION_ORIGINS:
         args = typing.get_args(tp)
         return " | ".join(_type_name(a) for a in args)
     if origin is typing.Literal:
@@ -1116,7 +1119,7 @@ def _validate(
         return _validate_annotated(value, tp, path, errors, coerce)
     if origin is typing.Literal:
         return _validate_literal(value, path, errors, args)
-    if origin is Union:
+    if origin in _UNION_ORIGINS:
         return _validate_union(value, tp, path, errors, coerce, args)
     if origin is list:
         return _validate_list(value, tp, path, errors, coerce, args)
@@ -1174,7 +1177,12 @@ def _schema_union(args: tuple[Any, ...]) -> dict[str, Any]:
     if len(non_none) == 1 and none_args:
         schema = _type_to_schema(non_none[0])
         if "type" in schema:
-            schema["type"] = [schema["type"], "null"]
+            current = schema["type"]
+            if isinstance(current, list):
+                if "null" not in current:
+                    schema["type"] = [*current, "null"]
+            else:
+                schema["type"] = [current, "null"]
         else:
             schema = {"oneOf": [schema, {"type": "null"}]}
         return schema
@@ -1262,7 +1270,7 @@ def _type_to_schema(tp: Any) -> dict[str, Any]:
         return _schema_annotated(tp)
     if origin is typing.Literal:
         return {"enum": list(args)}
-    if origin is Union:
+    if origin in _UNION_ORIGINS:
         return _schema_union(args)
     if origin is list:
         return _schema_list(args)

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -509,7 +509,12 @@ def _dataclass_fields(dc: type) -> dict[str, tuple[Any, bool]]:
 
 
 def _dataclass_defaults(dc: type) -> dict[str, Any] | None:
-    """Extract static default values from a dataclass type."""
+    """Extract static default values from a dataclass type.
+
+    Fields using ``default_factory`` are intentionally excluded — factory
+    return values are not statically known and calling them would risk
+    side effects.
+    """
     result: dict[str, Any] = {}
     for f in dataclasses.fields(dc):
         if f.default is not dataclasses.MISSING:
@@ -1190,6 +1195,7 @@ def _schema_struct(
             required.append(name)
         if defaults and name in defaults:
             default_val = defaults[name]
+            # Shallow check — list/dict contents are not inspected.
             if isinstance(default_val, (str, int, float, bool, type(None), list, dict)):
                 properties[name]["default"] = default_val
     schema: dict[str, Any] = {
@@ -1356,7 +1362,7 @@ def create_struct(name: str, fields: dict[str, tuple[Any, ...]]) -> type:
     annotations: dict[str, Any] = {}
     defaults: dict[str, Any] = {}
     for field_name, spec in fields.items():
-        field_type, default = spec[0], spec[1]
+        field_type, default = spec
         if default is ...:
             annotations[field_name] = field_type
         else:

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -85,6 +85,7 @@ __all__ = [
     "Match",
     "Predicate",
     "FieldValidator",
+    "Doc",
     # Error types
     "ErrorDetail",
     "ValidationError",
@@ -92,6 +93,7 @@ __all__ = [
     "validate",
     "json_schema",
     "model_validator",
+    "create_struct",
 ]
 
 # ── Constraint Annotations ──
@@ -265,8 +267,44 @@ class FieldValidator:
         return self.description
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class Doc:
+    """Field description marker for ``Annotated`` types.
+
+    Attaches a human-readable description to a type annotation.  The
+    description is emitted as ``{"description": ...}`` in JSON Schema
+    and has no effect on validation.
+
+    Example::
+
+        Annotated[str, Doc("The user's full name")]
+    """
+
+    description: str
+
+    def check(self, value: Any) -> bool:
+        return True
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"description": self.description}
+
+    def __str__(self) -> str:
+        return self.description
+
+
 # Constraint base types for isinstance checks
-_CONSTRAINT_TYPES = (Gt, Ge, Lt, Le, MinLen, MaxLen, Match, Predicate, FieldValidator)
+_CONSTRAINT_TYPES = (
+    Gt,
+    Ge,
+    Lt,
+    Le,
+    MinLen,
+    MaxLen,
+    Match,
+    Predicate,
+    FieldValidator,
+    Doc,
+)
 
 
 # ── Model Validator Registry ──
@@ -468,6 +506,15 @@ def _dataclass_fields(dc: type) -> dict[str, tuple[Any, bool]]:
         )
         result[f.name] = (tp, not has_default)
     return result
+
+
+def _dataclass_defaults(dc: type) -> dict[str, Any] | None:
+    """Extract static default values from a dataclass type."""
+    result: dict[str, Any] = {}
+    for f in dataclasses.fields(dc):
+        if f.default is not dataclasses.MISSING:
+            result[f.name] = f.default
+    return result or None
 
 
 def _join_path(base: str, key: str | int) -> str:
@@ -1130,7 +1177,10 @@ def _schema_union(args: tuple[Any, ...]) -> dict[str, Any]:
     return {"oneOf": [_type_to_schema(a) for a in args]}
 
 
-def _schema_struct(fields: dict[str, tuple[Any, bool]]) -> dict[str, Any]:
+def _schema_struct(
+    fields: dict[str, tuple[Any, bool]],
+    defaults: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Generate JSON Schema for a struct-like type (TypedDict or dataclass)."""
     properties: dict[str, Any] = {}
     required: list[str] = []
@@ -1138,6 +1188,10 @@ def _schema_struct(fields: dict[str, tuple[Any, bool]]) -> dict[str, Any]:
         properties[name] = _type_to_schema(field_tp)
         if is_required:
             required.append(name)
+        if defaults and name in defaults:
+            default_val = defaults[name]
+            if isinstance(default_val, (str, int, float, bool, type(None), list, dict)):
+                properties[name]["default"] = default_val
     schema: dict[str, Any] = {
         "type": "object",
         "properties": properties,
@@ -1213,9 +1267,11 @@ def _type_to_schema(tp: Any) -> dict[str, Any]:
     if origin in (set, frozenset):
         return _schema_set(args)
     if _is_typeddict(tp):
-        return _schema_struct(_typeddict_fields(tp))
+        return _schema_struct(
+            _typeddict_fields(tp), getattr(tp, "__field_defaults__", None)
+        )
     if _is_dataclass_type(tp):
-        return _schema_struct(_dataclass_fields(tp))
+        return _schema_struct(_dataclass_fields(tp), _dataclass_defaults(tp))
     if isinstance(tp, type) and tp in _PY_TO_JSON_TYPE:
         return {"type": _PY_TO_JSON_TYPE[tp]}
     return {}
@@ -1261,3 +1317,52 @@ def json_schema(tp: Any, *, title: str | None = None) -> dict[str, Any]:
     elif isinstance(tp, type) and hasattr(tp, "__name__"):
         schema["title"] = tp.__name__
     return schema
+
+
+def create_struct(name: str, fields: dict[str, tuple[Any, ...]]) -> type:
+    """Dynamically create a TypedDict type from a field specification.
+
+    Each field is specified as ``(type, default)`` where ``...`` (Ellipsis)
+    marks the field as required.  Fields with any other default value are
+    optional (``NotRequired``).
+
+    The returned type works with :func:`validate` and :func:`json_schema`
+    just like a hand-written ``TypedDict``.  Default values are stored in
+    a ``__field_defaults__`` class attribute and emitted by
+    :func:`json_schema`.
+
+    Args:
+        name: The name of the new type.
+        fields: Mapping of field names to ``(type, default)`` tuples.
+
+    Returns:
+        A new TypedDict class.
+
+    Example::
+
+        Params = create_struct("Params", {
+            "query": (str, ...),            # required
+            "limit": (int, 10),             # optional, default 10
+            "tag": (str | None, None),      # optional, default None
+        })
+    """
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from typing import NotRequired, TypedDict
+    else:
+        from typing_extensions import NotRequired, TypedDict
+
+    annotations: dict[str, Any] = {}
+    defaults: dict[str, Any] = {}
+    for field_name, spec in fields.items():
+        field_type, default = spec[0], spec[1]
+        if default is ...:
+            annotations[field_name] = field_type
+        else:
+            annotations[field_name] = NotRequired[field_type]
+            defaults[field_name] = default
+
+    td = TypedDict(name, annotations)  # type: ignore[operator]  # ty: ignore[invalid-argument-type, mismatched-type-name]
+    td.__field_defaults__ = defaults  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    return td


### PR DESCRIPTION
## Summary

Closes #142.

- **`Doc`** — `Annotated` marker that emits `{"description": ...}` in JSON Schema with no validation effect. Works on static TypedDict/dataclass fields and `create_struct` fields.
- **`create_struct(name, fields)`** — dynamically builds a TypedDict from `{name: (type, default)}` tuples where `...` = required. Returns a real TypedDict compatible with `validate()`, `json_schema()`, and `model_validator()`.
- **`json_schema()` enhancements** — now emits `"default"` per property from `create_struct` defaults and dataclass static defaults.

Design choice: `Doc` follows the existing constraint protocol (`check()` returns `True`, `schema_kw()` returns `{"description": ...}`) so it flows through `_unwrap_annotated` / `_schema_annotated` with zero changes to dispatch logic. Option A from the issue — composable with static types, not just `create_struct`.

## Test plan

- [x] 18 new tests covering `TestDoc` (5) and `TestCreateStruct` (13)
- [x] All 147 tests pass (`make test-validate`)
- [x] Pre-commit hooks pass (ruff, ruff-format, ty, complexipy)
- [ ] CI lint + test green