### PR TITLE
perf(retry): optimize decorator overhead -60% and retry loop -30%

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-09-06T18:30:38.778326+00:00",
+  "generated": "2026-09-06T18:48:43.674107+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -347,12 +347,12 @@
       "files": [
         "retry/retry.py"
       ],
-      "version": "0.3.1",
+      "version": "0.3.2",
       "deps": [],
       "tier": "simple",
       "category": "process",
-      "last_updated": "2026-09-06T04:44:06-05:00",
-      "content_hash": "b95011242469647a5ec905a92787bba65ebafad8157a75bb2188f91db2060eb7"
+      "last_updated": "2026-09-06T13:33:07-05:00",
+      "content_hash": "b29ca3c9022a2d305ce05e2c5024ce51abf655856b8be3e2ed2fd98130a94a26"
     },
     "runner": {
       "description": "Structured subprocess execution — zero dependencies, stdlib only, Python 3.10+",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-09-04T06:26:06.425647+00:00",
+  "generated": "2026-09-06T09:43:41.383540+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -167,8 +167,8 @@
       "deps": [],
       "tier": "subsystem",
       "category": "network",
-      "last_updated": "2026-08-30T00:18:33-05:00",
-      "content_hash": "90abdb31d116094e9a932297caea3d47bbc03e841c712646f512b48b97368d11"
+      "last_updated": "2026-09-06T01:57:35-05:00",
+      "content_hash": "899dc75942c0a16d534156c695c3d1e74734dde39a13cfa88c8647e6fc13b891"
     },
     "httpserver": {
       "description": "Zero-dependency async HTTP server with decorator-based routing",
@@ -347,12 +347,12 @@
       "files": [
         "retry/retry.py"
       ],
-      "version": "0.3.0",
+      "version": "0.3.1",
       "deps": [],
       "tier": "simple",
       "category": "process",
       "last_updated": "2026-04-27T23:17:36+08:00",
-      "content_hash": "e00d9eed010c2f93ddc51674f7dc4f4f2233e0d619e44b2d01582d09be0684bb"
+      "content_hash": "02f441b9d71f8c1170db10a7c6b185ba9364a922a135b8d42c9401971f7884c6"
     },
     "runner": {
       "description": "Structured subprocess execution — zero dependencies, stdlib only, Python 3.10+",
@@ -524,8 +524,8 @@
       "deps": [],
       "tier": "medium",
       "category": "validation",
-      "last_updated": "2026-07-16T13:03:08+07:00",
-      "content_hash": "9374d94321a73e24dacf93dc090c43495436423ffba7d4c5e1b28e04f9f136ad"
+      "last_updated": "2026-09-06T01:51:29-05:00",
+      "content_hash": "89c8a5579cee4b33825627f09c7c7a867edb7515f2aaca35118dc5900ed8bff7"
     },
     "vcs": {
       "description": "VCS CLI wrapper — zero dependencies, stdlib only, Python 3.10+",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-09-06T09:43:41.383540+00:00",
+  "generated": "2026-09-06T18:30:38.778326+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -351,8 +351,8 @@
       "deps": [],
       "tier": "simple",
       "category": "process",
-      "last_updated": "2026-04-27T23:17:36+08:00",
-      "content_hash": "02f441b9d71f8c1170db10a7c6b185ba9364a922a135b8d42c9401971f7884c6"
+      "last_updated": "2026-09-06T04:44:06-05:00",
+      "content_hash": "b95011242469647a5ec905a92787bba65ebafad8157a75bb2188f91db2060eb7"
     },
     "runner": {
       "description": "Structured subprocess execution — zero dependencies, stdlib only, Python 3.10+",
@@ -524,8 +524,8 @@
       "deps": [],
       "tier": "medium",
       "category": "validation",
-      "last_updated": "2026-09-06T01:51:29-05:00",
-      "content_hash": "89c8a5579cee4b33825627f09c7c7a867edb7515f2aaca35118dc5900ed8bff7"
+      "last_updated": "2026-09-06T03:47:54-05:00",
+      "content_hash": "829cbe78815c22916dd1cd48df6110359ab482a77a0ec87c85f6dcfb2df0c1f5"
     },
     "vcs": {
       "description": "VCS CLI wrapper — zero dependencies, stdlib only, Python 3.10+",

--- a/retry/retry.py
+++ b/retry/retry.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.1"
+# version = "0.3.2"
 # deps = []
 # tier = "simple"
 # category = "process"

--- a/retry/retry.py
+++ b/retry/retry.py
@@ -189,8 +189,6 @@ def _compute_delay(
     backoff_factor: float,
     max_delay: float,
     jitter: str,
-    _random: Callable[[], float] = _random,
-    _min: Callable[..., float] = _min,
 ) -> float:
     """Compute the sleep duration for a given retry attempt.
 
@@ -436,6 +434,8 @@ def retry(
         is_async = inspect.iscoroutinefunction(fn)
 
         if is_async:
+            # Async path is not fast-pathed: coroutine/event-loop overhead
+            # already dwarfs the ns-level savings from skipping monotonic/range.
 
             @functools.wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -462,22 +462,19 @@ def retry(
         _check_result = retry_on_result
         _inner_retry = _retry_sync
 
-        _should_retry = _should_retry_exception
-
         if _check_result is None:
+            _should_retry = _should_retry_exception
+
             # Hot path – no result predicate.  Try the happy path first;
             # only fall into the full retry loop on exception.
             @functools.wraps(fn)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                start = time.monotonic()
                 try:
                     return fn(*args, **kwargs)
                 except BaseException as first_exc:
                     if max_retries == 0 or not _should_retry(first_exc, retry_on):
                         raise
-                    # First call failed and is retryable – handle the
-                    # first retry delay here, then delegate remaining
-                    # retries with correct attempt bookkeeping.
-                    start = time.monotonic()
                     delay = _compute_delay(
                         0, backoff, base_delay, backoff_factor, max_delay, jitter
                     )

--- a/retry/retry.py
+++ b/retry/retry.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.0"
+# version = "0.3.1"
 # deps = []
 # tier = "simple"
 # category = "process"
@@ -176,6 +176,12 @@ def retry_if_status(*status_codes: int) -> Callable[[BaseException], bool]:
 # ── Internal Helpers ──
 
 
+# Cache frequently used functions as module-level references to avoid
+# repeated global/attribute lookups on the hot path.
+_random = random.random
+_min = min
+
+
 def _compute_delay(
     attempt: int,
     backoff: str,
@@ -183,6 +189,8 @@ def _compute_delay(
     backoff_factor: float,
     max_delay: float,
     jitter: str,
+    _random: Callable[[], float] = _random,
+    _min: Callable[..., float] = _min,
 ) -> float:
     """Compute the sleep duration for a given retry attempt.
 
@@ -209,13 +217,13 @@ def _compute_delay(
     else:
         raise ValueError(f"Unknown backoff strategy: {backoff!r}")
 
-    delay = min(delay, max_delay)
+    delay = _min(delay, max_delay)
 
     if jitter == "full":
-        delay = random.uniform(0, delay)
+        delay *= _random()
     elif jitter == "equal":
-        half = delay / 2
-        delay = half + random.uniform(0, half)
+        half = delay * 0.5
+        delay = half + half * _random()
     elif jitter == "none":
         pass
     else:
@@ -251,10 +259,12 @@ def _retry_sync(
     retry_on: tuple[type[BaseException], ...] | Callable[[BaseException], bool],
     retry_on_result: Callable[[Any], bool] | None,
     on_retry: Callable[[RetryState], None] | None,
+    _start_attempt: int = 0,
+    _start_time: float | None = None,
 ) -> Any:
-    start = time.monotonic()
+    start = _start_time if _start_time is not None else time.monotonic()
 
-    for attempt in range(max_retries + 1):  # 0 = initial call
+    for attempt in range(_start_attempt, max_retries + 1):  # 0 = initial call
         try:
             result = fn(*args, **kwargs)
 
@@ -421,7 +431,11 @@ def retry(
     """
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-        if inspect.iscoroutinefunction(fn):
+        # Cache the coroutine check at decoration time so the per-call
+        # wrapper never touches ``inspect``.
+        is_async = inspect.iscoroutinefunction(fn)
+
+        if is_async:
 
             @functools.wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -442,22 +456,76 @@ def retry(
 
             return async_wrapper
 
-        @functools.wraps(fn)
-        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
-            return _retry_sync(
-                fn,
-                args,
-                kwargs,
-                max_retries=max_retries,
-                base_delay=base_delay,
-                max_delay=max_delay,
-                backoff=backoff,
-                backoff_factor=backoff_factor,
-                jitter=jitter,
-                retry_on=retry_on,
-                retry_on_result=retry_on_result,
-                on_retry=on_retry,
-            )
+        # Build a fast-path wrapper: when the first call succeeds and no
+        # result predicate fires, return immediately without entering
+        # the full _retry_sync loop (avoids time.monotonic, range, etc.).
+        _check_result = retry_on_result
+        _inner_retry = _retry_sync
+
+        _should_retry = _should_retry_exception
+
+        if _check_result is None:
+            # Hot path – no result predicate.  Try the happy path first;
+            # only fall into the full retry loop on exception.
+            @functools.wraps(fn)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return fn(*args, **kwargs)
+                except BaseException as first_exc:
+                    if max_retries == 0 or not _should_retry(first_exc, retry_on):
+                        raise
+                    # First call failed and is retryable – handle the
+                    # first retry delay here, then delegate remaining
+                    # retries with correct attempt bookkeeping.
+                    start = time.monotonic()
+                    delay = _compute_delay(
+                        0, backoff, base_delay, backoff_factor, max_delay, jitter
+                    )
+                    if on_retry:
+                        on_retry(
+                            RetryState(
+                                attempt=1,
+                                exception=first_exc,
+                                result=None,
+                                delay=delay,
+                                elapsed=time.monotonic() - start,
+                            )
+                        )
+                    time.sleep(delay)
+                    return _inner_retry(
+                        fn,
+                        args,
+                        kwargs,
+                        max_retries=max_retries,
+                        base_delay=base_delay,
+                        max_delay=max_delay,
+                        backoff=backoff,
+                        backoff_factor=backoff_factor,
+                        jitter=jitter,
+                        retry_on=retry_on,
+                        retry_on_result=None,
+                        on_retry=on_retry,
+                        _start_attempt=1,
+                        _start_time=start,
+                    )
+        else:
+
+            @functools.wraps(fn)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return _inner_retry(
+                    fn,
+                    args,
+                    kwargs,
+                    max_retries=max_retries,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    backoff=backoff,
+                    backoff_factor=backoff_factor,
+                    jitter=jitter,
+                    retry_on=retry_on,
+                    retry_on_result=_check_result,
+                    on_retry=on_retry,
+                )
 
         return sync_wrapper
 


### PR DESCRIPTION
## Summary

Performance optimization of the retry module identified and applied by the
zerodep-genie optimize phase (pi-agent + Claude Opus).

## Changes

Two rounds of focused optimization on `retry/retry.py`:

**Round 1** — hot-path micro-optimizations:
- Cache `random.random` as module-level local (`_random`)
- Replace `random.uniform(0, d)` with `d * _random()` (avoids function call + redundant arithmetic)
- Result: retry-with-failures **-30%** (3,374 → 2,348 ns)

**Round 2** — fast-path for success case:
- Detect success on first call and return immediately, bypassing `_retry_sync`
- Avoids `range()` and `RetryState` construction on the happy path
- `time.monotonic()` captured before the try block to preserve `elapsed` semantics
- Result: decorator overhead **-60%** (430 → 170 ns)

## Benchmark results

| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| Decorator overhead | 430 ns | 170 ns | **-60%** |
| Retry with failures | 3,374 ns | 2,348 ns | **-30%** |
| Backoff calculation | 4,404 ns | 4,455 ns | ~same |

All 36 existing tests pass. No public API changes (`__all__` unchanged).

## Test plan

- [x] All 36 correctness tests pass
- [x] All 6 benchmark tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, ty, complexipy)
- [x] No changes to `__all__` or public function signatures