### PR TITLE
feat: CI-friendly CLI flags for automated vendor updates

### DIFF
--- a/skill/zerodep/SKILL.md
+++ b/skill/zerodep/SKILL.md
@@ -136,6 +136,8 @@ zerodep update --all           # update all outdated modules in one command
 
 These can be combined: `zerodep outdated --json --exit-code`.
 
+Note: `outdated_count` and `--exit-code` include renamed modules (status `renamed → <name>`), not just version-outdated ones. Renames require manual migration — `update --all` skips them.
+
 ### Deploying the workflow
 
 Copy the `zerodep-update.yml` workflow template from [dev-playbook](https://github.com/Oaklight/dev-playbook/tree/main/ci/templates/workflows/zerodep-update.yml) into your project's `.github/workflows/`. The workflow:

--- a/skill/zerodep/SKILL.md
+++ b/skill/zerodep/SKILL.md
@@ -49,10 +49,13 @@ zerodep info sse                    # Show module details and deps
 zerodep add sse retry -d lib/       # Copy sse + httpclient + retry to lib/
 zerodep add sse --nested            # Copy into sse/ and httpclient/ subdirs
 zerodep update sse -d lib/          # Update existing modules in lib/
+zerodep update --all                # Update all outdated modules
 zerodep outdated -d lib/            # Check for upstream changes in lib/
+zerodep outdated --json             # Machine-readable JSON output
+zerodep outdated --exit-code        # Exit 1 if any module is outdated
 ```
 
-The `-d`/`--dir` flag is shared by `add`, `update`, and `outdated` — it specifies the target directory (defaults to `.`).
+The `-d`/`--dir` flag is shared by `add`, `update`, and `outdated` — it specifies the target directory. If omitted, it reads `vendor-dir` from `[tool.zerodep]` in `pyproject.toml`, falling back to `.`.
 
 ## What zerodep modules are
 
@@ -107,6 +110,43 @@ exclude = ["*/_vendor"]
 ```
 
 The vendored file is plain Python — no magic, no runtime hooks. Read it, modify it, vendor it into wherever your project needs it.
+
+## CI Automation — keeping vendored modules up to date
+
+Projects that vendor zerodep modules can use a scheduled GitHub Actions workflow to detect outdated modules and auto-create PRs with updates.
+
+### Project configuration
+
+Add `[tool.zerodep]` to your project's `pyproject.toml` so the CLI knows where vendored modules live:
+
+```toml
+[tool.zerodep]
+vendor-dir = "src/mypackage/_vendor"
+```
+
+With this set, `zerodep outdated` and `zerodep update --all` work without `-d`.
+
+### CI-friendly CLI flags
+
+```bash
+zerodep outdated --json        # JSON output: {"modules": [...], "outdated_count": N}
+zerodep outdated --exit-code   # exit 1 if any module is outdated
+zerodep update --all           # update all outdated modules in one command
+```
+
+These can be combined: `zerodep outdated --json --exit-code`.
+
+### Deploying the workflow
+
+Copy the `zerodep-update.yml` workflow template from [dev-playbook](https://github.com/Oaklight/dev-playbook/tree/main/ci/templates/workflows/zerodep-update.yml) into your project's `.github/workflows/`. The workflow:
+
+1. Runs weekly (Monday) and on manual dispatch
+2. Installs the `zerodep` CLI
+3. Runs `zerodep outdated --json` to check for updates
+4. If outdated modules found, runs `zerodep update --all`
+5. Creates a PR with the changes via `peter-evans/create-pull-request`
+
+The workflow reads `vendor-dir` from `[tool.zerodep]` in `pyproject.toml` — no per-workflow configuration needed.
 
 ## Contributing
 

--- a/test_cli.py
+++ b/test_cli.py
@@ -1,0 +1,146 @@
+"""Tests for CLI enhancements: --json, --exit-code, update --all, config."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CLI = str(Path(__file__).parent / "zerodep.py")
+
+
+def run_cli(*args: str, cwd: str | Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, CLI, "--local", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+# ── _read_config ──
+
+
+def test_read_config_from_pyproject(tmp_path: Path):
+    vendor = tmp_path / "_vendor"
+    vendor.mkdir()
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.zerodep]\nvendor-dir = "_vendor"\n', encoding="utf-8")
+    r = run_cli("outdated", "--json", cwd=tmp_path)
+    assert r.returncode == 0
+    data = json.loads(r.stdout)
+    assert "modules" in data
+    assert "outdated_count" in data
+
+
+def test_read_config_no_pyproject(tmp_path: Path):
+    r = run_cli("outdated", "--json", cwd=tmp_path)
+    assert r.returncode == 0
+    data = json.loads(r.stdout)
+    assert data["modules"] == []
+
+
+def test_read_config_malformed_toml(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("this is not valid toml {{{\n", encoding="utf-8")
+    r = run_cli("outdated", "--json", cwd=tmp_path)
+    assert r.returncode == 0
+    data = json.loads(r.stdout)
+    assert data["modules"] == []
+
+
+def test_read_config_no_zerodep_section(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.ruff]\ntarget-version = "py310"\n', encoding="utf-8")
+    r = run_cli("outdated", "--json", cwd=tmp_path)
+    assert r.returncode == 0
+    data = json.loads(r.stdout)
+    assert data["modules"] == []
+
+
+# ── outdated --json ──
+
+
+def test_outdated_json_structure(tmp_path: Path):
+    vendor = tmp_path / "_vendor"
+    vendor.mkdir()
+    r = run_cli("outdated", "--json", "-d", str(vendor))
+    assert r.returncode == 0
+    data = json.loads(r.stdout)
+    assert isinstance(data["modules"], list)
+    assert isinstance(data["outdated_count"], int)
+
+
+def test_outdated_json_module_fields(tmp_path: Path):
+    vendor = tmp_path / "_vendor"
+    vendor.mkdir()
+    # Copy a real vendored file to test with
+    src = Path(__file__).parent / "yaml" / "yaml.py"
+    if src.exists():
+        (vendor / "yaml.py").write_text(
+            src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        r = run_cli("outdated", "--json", "-d", str(vendor))
+        data = json.loads(r.stdout)
+        if data["modules"]:
+            mod = data["modules"][0]
+            assert "name" in mod
+            assert "local_version" in mod
+            assert "latest_version" in mod
+            assert "status" in mod
+
+
+# ── outdated --exit-code ──
+
+
+def test_exit_code_zero_when_up_to_date(tmp_path: Path):
+    vendor = tmp_path / "_vendor"
+    vendor.mkdir()
+    src = Path(__file__).parent / "yaml" / "yaml.py"
+    if src.exists():
+        (vendor / "yaml.py").write_text(
+            src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        r = run_cli("outdated", "--exit-code", "-d", str(vendor))
+        assert r.returncode == 0
+
+
+def test_exit_code_one_when_outdated(tmp_path: Path):
+    vendor = tmp_path / "_vendor"
+    vendor.mkdir()
+    # Write a fake yaml.py with old version and different content
+    (vendor / "yaml.py").write_text(
+        '# /// zerodep\n# version = "0.0.1"\n# deps = []\n# ///\npass\n',
+        encoding="utf-8",
+    )
+    r = run_cli("outdated", "--exit-code", "-d", str(vendor))
+    assert r.returncode == 1
+
+
+# ── update --all ──
+
+
+def test_update_all_nothing_outdated(tmp_path: Path):
+    vendor = tmp_path / "_vendor"
+    vendor.mkdir()
+    src = Path(__file__).parent / "yaml" / "yaml.py"
+    if src.exists():
+        (vendor / "yaml.py").write_text(
+            src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        r = run_cli("update", "--all", "-d", str(vendor))
+        assert r.returncode == 0
+        assert "up-to-date" in r.stdout.lower()
+
+
+def test_update_no_args_errors():
+    r = run_cli("update")
+    assert r.returncode == 1
+    assert "--all" in r.stderr
+
+
+def test_update_all_with_modules_errors():
+    r = run_cli("update", "--all", "yaml")
+    assert r.returncode == 1
+    assert "cannot use --all" in r.stderr

--- a/zerodep.py
+++ b/zerodep.py
@@ -5,7 +5,9 @@ Usage::
     python zerodep.py list                  # list available modules
     python zerodep.py info <module>         # module details + deps
     python zerodep.py add <module> [...]    # copy modules to cwd
+    python zerodep.py update --all          # update all outdated modules
     python zerodep.py outdated              # check local files for updates
+    python zerodep.py outdated --json       # machine-readable output
     python zerodep.py manifest              # regenerate manifest.json
 
 Requires Python 3.10+, zero external dependencies.
@@ -28,6 +30,11 @@ import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None  # type: ignore[assignment]
 
 # ── Constants ──
 
@@ -525,6 +532,35 @@ _REPLACED_BY: dict[str, str] = {
 }
 
 
+# ── Config ──
+
+
+def _read_config() -> dict:
+    """Read ``[tool.zerodep]`` from ``pyproject.toml`` in CWD, if available."""
+    pyproject = Path("pyproject.toml")
+    if not pyproject.exists() or tomllib is None:
+        return {}
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        return data.get("tool", {}).get("zerodep", {})
+    except Exception:
+        return {}
+
+
+def _resolve_dir(args: argparse.Namespace) -> str:
+    """Return the target directory, falling back to ``[tool.zerodep]`` config.
+
+    Parser defaults for ``-d/--dir`` should use ``default=None`` so this
+    function can distinguish "user passed -d" from "default".
+    """
+    if args.dir is not None:
+        return args.dir
+    vendor_dir = _read_config().get("vendor-dir")
+    if vendor_dir:
+        return vendor_dir
+    return "."
+
+
 # ── Commands ──
 
 
@@ -664,7 +700,7 @@ def cmd_add(args: argparse.Namespace) -> None:
     to_copy = _resolve_deps(args.modules, manifest, no_deps=args.no_deps)
 
     # Determine target directory
-    target = Path(args.dir).resolve()
+    target = Path(_resolve_dir(args)).resolve()
 
     # Build file list
     file_plan: list[tuple[str, Path]] = []  # (remote_path, local_dest)
@@ -737,6 +773,20 @@ def cmd_add(args: argparse.Namespace) -> None:
 
 def cmd_update(args: argparse.Namespace) -> None:
     """Update existing module files (alias for add --force --yes)."""
+    if getattr(args, "all", False):
+        if args.modules:
+            _die("cannot use --all together with explicit module names")
+        manifest = _load_manifest(local=args.local, offline=args.offline)
+        scan_dir = Path(_resolve_dir(args)).resolve()
+        rows = _scan_outdated(manifest, scan_dir)
+        outdated = [r[0] for r in rows if r[3] == "outdated"]
+        if not outdated:
+            _ok("All modules are up-to-date.")
+            return
+        args.modules = outdated
+    elif not args.modules:
+        _die("provide module names or use --all")
+    args.dir = _resolve_dir(args)
     args.force = True
     args.yes = True
     cmd_add(args)
@@ -869,12 +919,14 @@ def cmd_bump(args: argparse.Namespace) -> None:
     cmd_manifest(args)
 
 
-def cmd_outdated(args: argparse.Namespace) -> None:
-    """Check local zerodep files against the upstream manifest for changes."""
-    manifest = _load_manifest(local=args.local, offline=args.offline)
-    modules_data = manifest.get("modules", {})
+def _scan_outdated(manifest: dict, scan_dir: Path) -> list[tuple[str, str, str, str]]:
+    """Scan *scan_dir* for vendored zerodep modules and return status rows.
 
-    scan_dir = Path(args.dir).resolve()
+    Each row is ``(module_name, local_version, latest_version, status)``
+    where *status* is ``"up-to-date"``, ``"outdated"``, or
+    ``"renamed → <new_name>"``.
+    """
+    modules_data = manifest.get("modules", {})
     rows: list[tuple[str, str, str, str]] = []
 
     for mod_name, mod in sorted(modules_data.items()):
@@ -896,9 +948,7 @@ def cmd_outdated(args: argparse.Namespace) -> None:
                 status = "outdated"
             rows.append((mod_name, local_ver, upstream_ver, status))
 
-    # Detect locally installed modules that have been replaced upstream
     for old_name, new_name in sorted(_REPLACED_BY.items()):
-        # Check for old module files in scan_dir
         old_mod = modules_data.get(old_name)
         fallback = [f"{old_name}/{old_name}.py"]
         old_files = old_mod.get("files", fallback) if old_mod else fallback
@@ -909,27 +959,55 @@ def cmd_outdated(args: argparse.Namespace) -> None:
                 rows.append((old_name, "—", "—", f"renamed → {new_name}"))
                 break
 
+    return rows
+
+
+def cmd_outdated(args: argparse.Namespace) -> None:
+    """Check local zerodep files against the upstream manifest for changes."""
+    manifest = _load_manifest(local=args.local, offline=args.offline)
+    scan_dir = Path(_resolve_dir(args)).resolve()
+    rows = _scan_outdated(manifest, scan_dir)
+
     if not rows:
-        _ok(f"No zerodep modules found in {scan_dir}.")
+        if getattr(args, "json", False):
+            print(json.dumps({"modules": [], "outdated_count": 0}))
+        else:
+            _ok(f"No zerodep modules found in {scan_dir}.")
         return
 
-    # Print table
-    headers = ("Module", "Local Ver", "Latest Ver", "Status")
-    widths = [max(len(headers[i]), *(len(r[i]) for r in rows)) for i in range(4)]
-    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
-    print(fmt.format(*headers))
-    print(fmt.format(*("-" * w for w in widths)))
-    for row in rows:
-        print(fmt.format(*row))
+    has_outdated = any(r[3] != "up-to-date" for r in rows)
 
-    # Print migration hints for renamed modules
-    for row in rows:
-        if row[3].startswith("renamed"):
-            new_name = row[3].split("→ ")[1].strip()
-            _warn(
-                f"'{row[0]}' has been renamed to '{new_name}'. "
-                f"Run `zerodep add {new_name}` and remove the old file."
-            )
+    if getattr(args, "json", False):
+        modules = [
+            {
+                "name": r[0],
+                "local_version": r[1],
+                "latest_version": r[2],
+                "status": r[3],
+            }
+            for r in rows
+        ]
+        outdated_count = sum(1 for r in rows if r[3] != "up-to-date")
+        print(json.dumps({"modules": modules, "outdated_count": outdated_count}))
+    else:
+        headers = ("Module", "Local Ver", "Latest Ver", "Status")
+        widths = [max(len(headers[i]), *(len(r[i]) for r in rows)) for i in range(4)]
+        fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+        print(fmt.format(*headers))
+        print(fmt.format(*("-" * w for w in widths)))
+        for row in rows:
+            print(fmt.format(*row))
+
+        for row in rows:
+            if row[3].startswith("renamed"):
+                new_name = row[3].split("→ ")[1].strip()
+                _warn(
+                    f"'{row[0]}' has been renamed to '{new_name}'. "
+                    f"Run `zerodep add {new_name}` and remove the old file."
+                )
+
+    if getattr(args, "exit_code", False) and has_outdated:
+        sys.exit(1)
 
 
 def _normalized_hash(source: str) -> str:
@@ -1419,7 +1497,12 @@ def main(argv: list[str] | None = None) -> None:
     # add
     p_add = sub.add_parser("add", help="copy modules to your project")
     p_add.add_argument("modules", nargs="+", help="module names to copy")
-    p_add.add_argument("-d", "--dir", default=".", help="target directory (default: .)")
+    p_add.add_argument(
+        "-d",
+        "--dir",
+        default=None,
+        help="target directory (default: from pyproject.toml or .)",
+    )
     p_add.add_argument(
         "--nested", action="store_true", help="use subdirectories per module"
     )
@@ -1431,14 +1514,22 @@ def main(argv: list[str] | None = None) -> None:
 
     # update
     p_update = sub.add_parser("update", help="update existing modules")
-    p_update.add_argument("modules", nargs="+", help="module names to update")
     p_update.add_argument(
-        "-d", "--dir", default=".", help="target directory (default: .)"
+        "modules", nargs="*", default=[], help="module names to update"
+    )
+    p_update.add_argument(
+        "-d",
+        "--dir",
+        default=None,
+        help="target directory (default: from pyproject.toml or .)",
     )
     p_update.add_argument(
         "--nested", action="store_true", help="use subdirectories per module"
     )
     p_update.add_argument("--no-deps", action="store_true", help="skip dependencies")
+    p_update.add_argument(
+        "--all", action="store_true", help="update all outdated modules"
+    )
 
     # new
     p_new = sub.add_parser("new", help="scaffold a new module")
@@ -1484,7 +1575,16 @@ def main(argv: list[str] | None = None) -> None:
         "outdated", help="check local files for upstream changes"
     )
     p_outdated.add_argument(
-        "-d", "--dir", default=".", help="target directory (default: .)"
+        "-d",
+        "--dir",
+        default=None,
+        help="target directory (default: from pyproject.toml or .)",
+    )
+    p_outdated.add_argument(
+        "--json", action="store_true", help="output JSON instead of table"
+    )
+    p_outdated.add_argument(
+        "--exit-code", action="store_true", help="exit 1 if outdated modules found"
     )
 
     # manifest

--- a/zerodep.py
+++ b/zerodep.py
@@ -31,11 +31,6 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    tomllib = None  # type: ignore[assignment]
-
 # ── Constants ──
 
 REPO_OWNER = "Oaklight"
@@ -535,16 +530,33 @@ _REPLACED_BY: dict[str, str] = {
 # ── Config ──
 
 
+_TOOL_ZERODEP_RE = re.compile(
+    r"^\[tool\.zerodep\]\s*$"
+    r"(.*?)"
+    r"(?=^\[|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_KV_RE = re.compile(r'^([\w-]+)\s*=\s*"([^"]*)"', re.MULTILINE)
+
+
 def _read_config() -> dict:
-    """Read ``[tool.zerodep]`` from ``pyproject.toml`` in CWD, if available."""
+    """Read ``[tool.zerodep]`` from ``pyproject.toml`` in CWD, if available.
+
+    Uses a lightweight regex parser instead of ``tomllib`` so the CLI
+    stays zero-dependency and works on Python 3.10+.
+    """
     pyproject = Path("pyproject.toml")
-    if not pyproject.exists() or tomllib is None:
+    if not pyproject.exists():
         return {}
     try:
-        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-        return data.get("tool", {}).get("zerodep", {})
-    except Exception:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError as exc:
+        _warn(f"cannot read pyproject.toml: {exc}")
         return {}
+    m = _TOOL_ZERODEP_RE.search(text)
+    if not m:
+        return {}
+    return dict(_KV_RE.findall(m.group(1)))
 
 
 def _resolve_dir(args: argparse.Namespace) -> str:
@@ -773,11 +785,12 @@ def cmd_add(args: argparse.Namespace) -> None:
 
 def cmd_update(args: argparse.Namespace) -> None:
     """Update existing module files (alias for add --force --yes)."""
-    if getattr(args, "all", False):
+    resolved = _resolve_dir(args)
+    if args.update_all:
         if args.modules:
             _die("cannot use --all together with explicit module names")
         manifest = _load_manifest(local=args.local, offline=args.offline)
-        scan_dir = Path(_resolve_dir(args)).resolve()
+        scan_dir = Path(resolved).resolve()
         rows = _scan_outdated(manifest, scan_dir)
         outdated = [r[0] for r in rows if r[3] == "outdated"]
         if not outdated:
@@ -786,7 +799,7 @@ def cmd_update(args: argparse.Namespace) -> None:
         args.modules = outdated
     elif not args.modules:
         _die("provide module names or use --all")
-    args.dir = _resolve_dir(args)
+    args.dir = resolved
     args.force = True
     args.yes = True
     cmd_add(args)
@@ -969,7 +982,7 @@ def cmd_outdated(args: argparse.Namespace) -> None:
     rows = _scan_outdated(manifest, scan_dir)
 
     if not rows:
-        if getattr(args, "json", False):
+        if args.json_output:
             print(json.dumps({"modules": [], "outdated_count": 0}))
         else:
             _ok(f"No zerodep modules found in {scan_dir}.")
@@ -977,12 +990,12 @@ def cmd_outdated(args: argparse.Namespace) -> None:
 
     has_outdated = any(r[3] != "up-to-date" for r in rows)
 
-    if getattr(args, "json", False):
+    if args.json_output:
         modules = [
             {
                 "name": r[0],
-                "local_version": r[1],
-                "latest_version": r[2],
+                "local_version": r[1] if r[1] != "—" else None,
+                "latest_version": r[2] if r[2] != "—" else None,
                 "status": r[3],
             }
             for r in rows
@@ -1006,7 +1019,7 @@ def cmd_outdated(args: argparse.Namespace) -> None:
                     f"Run `zerodep add {new_name}` and remove the old file."
                 )
 
-    if getattr(args, "exit_code", False) and has_outdated:
+    if args.exit_code and has_outdated:
         sys.exit(1)
 
 
@@ -1528,7 +1541,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     p_update.add_argument("--no-deps", action="store_true", help="skip dependencies")
     p_update.add_argument(
-        "--all", action="store_true", help="update all outdated modules"
+        "--all",
+        dest="update_all",
+        action="store_true",
+        help="update all outdated modules",
     )
 
     # new
@@ -1581,10 +1597,15 @@ def main(argv: list[str] | None = None) -> None:
         help="target directory (default: from pyproject.toml or .)",
     )
     p_outdated.add_argument(
-        "--json", action="store_true", help="output JSON instead of table"
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="output JSON instead of table",
     )
     p_outdated.add_argument(
-        "--exit-code", action="store_true", help="exit 1 if outdated modules found"
+        "--exit-code",
+        action="store_true",
+        help="exit 1 if outdated or renamed modules found",
     )
 
     # manifest


### PR DESCRIPTION
## Summary

- Add `outdated --json` for machine-readable output (modules list + outdated_count)
- Add `outdated --exit-code` to exit 1 when outdated modules found (like `git diff --exit-code`)
- Add `update --all` to discover and update all outdated modules without listing them explicitly
- Add `[tool.zerodep]` config reading from `pyproject.toml` — `vendor-dir` key so `-d` can be omitted
- Extract `_scan_outdated()` helper shared by `cmd_outdated` and `cmd_update --all`
- Update skill file with CI automation documentation

These enhancements enable a scheduled GitHub Actions workflow pattern where consumer projects can auto-detect drift in vendored modules and create PRs with updates. The workflow template lives in dev-playbook.

## Test plan

- [x] `zerodep outdated --json -d <vendor_dir>` outputs valid JSON with correct structure
- [x] `zerodep outdated --exit-code` exits 0 when all up-to-date, exits 1 when outdated
- [x] `zerodep update --all -d <vendor_dir>` reports "All modules are up-to-date" when nothing to update
- [x] `zerodep update` with no args and no `--all` exits with error message
- [x] `[tool.zerodep] vendor-dir` in pyproject.toml is read when `-d` is not explicitly passed
- [x] Existing commands (`list`, `info`, `outdated` without flags) still work unchanged
- [x] Pre-commit hooks pass (ruff, ruff-format, ty, complexipy)