### PR TITLE
feat(httpclient,httpserver): add cookie support

### DIFF
--- a/httpclient/conftest.py
+++ b/httpclient/conftest.py
@@ -137,6 +137,51 @@ class _HttpBinHandler(BaseHTTPRequestHandler):
 
     # ── HTTP methods ──
 
+    def _handle_cookies(self, path, query):
+        """Handle /cookies/* endpoints."""
+        if path == "/cookies/set":
+            params = parse_qs(query)
+            self.send_response(200)
+            for name, values in sorted(params.items()):
+                self.send_header("Set-Cookie", f"{name}={values[0]}; Path=/")
+            body = json.dumps({k: v[0] for k, v in sorted(params.items())}).encode()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+        elif path == "/cookies/delete":
+            params = parse_qs(query, keep_blank_values=True)
+            self.send_response(200)
+            for name in sorted(params.keys()):
+                self.send_header(
+                    "Set-Cookie",
+                    f"{name}=; Path=/; Max-Age=0; "
+                    f"Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+                )
+            body = json.dumps({"deleted": sorted(params.keys())}).encode()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            cookie_header = self.headers.get("Cookie", "")
+            cookies = {}
+            if cookie_header:
+                for pair in cookie_header.split(";"):
+                    pair = pair.strip()
+                    if "=" in pair:
+                        k, v = pair.split("=", 1)
+                        cookies[k.strip()] = v.strip()
+            body = json.dumps({"cookies": cookies}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+
     def do_GET(self):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/")
@@ -293,6 +338,8 @@ class _HttpBinHandler(BaseHTTPRequestHandler):
             seconds = float(path.rsplit("/", 1)[1])
             time.sleep(seconds)
             self._send_json({"delay": seconds})
+        elif path.startswith("/cookies"):
+            self._handle_cookies(path, parsed.query)
         else:
             self.send_response(404)
             self.send_header("Content-Length", "0")

--- a/httpclient/conftest.py
+++ b/httpclient/conftest.py
@@ -150,6 +150,15 @@ class _HttpBinHandler(BaseHTTPRequestHandler):
             self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.write(body)
+        elif path == "/cookies/set-redirect":
+            params = parse_qs(query)
+            self.send_response(302)
+            for name, values in sorted(params.items()):
+                self.send_header("Set-Cookie", f"{name}={values[0]}; Path=/")
+            self.send_header("Location", "/cookies")
+            self.send_header("Content-Length", "0")
+            self.send_header("Connection", "close")
+            self.end_headers()
         elif path == "/cookies/delete":
             params = parse_qs(query, keep_blank_values=True)
             self.send_response(200)

--- a/httpclient/httpclient.py
+++ b/httpclient/httpclient.py
@@ -338,6 +338,7 @@ class Response:
         "_text",
         "_json",
         "_raw_set_cookies",
+        "_cookies",
     )
 
     def __init__(
@@ -355,6 +356,7 @@ class Response:
         self._text: str | None = None
         self._json: Any = None
         self._raw_set_cookies: list[str] = raw_set_cookies or []
+        self._cookies: dict[str, str] | None = None
 
     @property
     def text(self) -> str:
@@ -382,8 +384,10 @@ class Response:
 
     @property
     def cookies(self) -> dict[str, str]:
-        """Parse Set-Cookie headers into a ``{name: value}`` dict."""
-        return _parse_cookies(self._raw_set_cookies)
+        """Parse Set-Cookie headers into a ``{name: value}`` dict (cached)."""
+        if self._cookies is None:
+            self._cookies = _parse_cookies(self._raw_set_cookies)
+        return self._cookies
 
     def _guess_encoding(self) -> str:
         return _guess_encoding_from_headers(self.headers)
@@ -658,6 +662,7 @@ class StreamingResponse:
         "_bytes_remaining",
         "_closed",
         "_raw_set_cookies",
+        "_cookies",
     )
 
     status_code: int
@@ -675,6 +680,7 @@ class StreamingResponse:
     _bytes_remaining: int | None
     _closed: bool
     _raw_set_cookies: list[str]
+    _cookies: dict[str, str] | None
 
     def __init__(self) -> None:
         raise TypeError("Use _from_sync() or _from_async()")
@@ -708,6 +714,7 @@ class StreamingResponse:
         obj._bytes_remaining = None
         obj._closed = False
         obj._raw_set_cookies = raw_set_cookies or []
+        obj._cookies = None
         return obj
 
     @classmethod
@@ -742,6 +749,7 @@ class StreamingResponse:
         obj._bytes_remaining = content_length
         obj._closed = False
         obj._raw_set_cookies = raw_set_cookies or []
+        obj._cookies = None
         return obj
 
     @property
@@ -756,8 +764,10 @@ class StreamingResponse:
 
     @property
     def cookies(self) -> dict[str, str]:
-        """Parse Set-Cookie headers into a ``{name: value}`` dict."""
-        return _parse_cookies(self._raw_set_cookies)
+        """Parse Set-Cookie headers into a ``{name: value}`` dict (cached)."""
+        if self._cookies is None:
+            self._cookies = _parse_cookies(self._raw_set_cookies)
+        return self._cookies
 
     # ── Sync iteration ──
 
@@ -2794,9 +2804,10 @@ class Client:
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
         result = _sync_request(method, url, **kwargs)
-        self._cookies.update(result.cookies)
-        for name in _expired_cookie_names(result._raw_set_cookies):
-            self._cookies.pop(name, None)
+        if result._raw_set_cookies:
+            self._cookies.update(result.cookies)
+            for name in _expired_cookie_names(result._raw_set_cookies):
+                self._cookies.pop(name, None)
         return result
 
     def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
@@ -2896,9 +2907,10 @@ class AsyncClient:
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
         result = await _async_request(method, url, **kwargs)
-        self._cookies.update(result.cookies)
-        for name in _expired_cookie_names(result._raw_set_cookies):
-            self._cookies.pop(name, None)
+        if result._raw_set_cookies:
+            self._cookies.update(result.cookies)
+            for name in _expired_cookie_names(result._raw_set_cookies):
+                self._cookies.pop(name, None)
         return result
 
     async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:

--- a/httpclient/httpclient.py
+++ b/httpclient/httpclient.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.7"
+# version = "0.5.0"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -41,6 +41,7 @@ import asyncio
 import base64
 import hashlib
 import http.client
+import http.cookies
 import json as _json
 import logging
 import os
@@ -329,7 +330,15 @@ class Response:
         url: Final URL after redirects.
     """
 
-    __slots__ = ("status_code", "headers", "content", "url", "_text", "_json")
+    __slots__ = (
+        "status_code",
+        "headers",
+        "content",
+        "url",
+        "_text",
+        "_json",
+        "_raw_set_cookies",
+    )
 
     def __init__(
         self,
@@ -337,6 +346,7 @@ class Response:
         headers: CaseInsensitiveDict,
         content: bytes,
         url: str,
+        raw_set_cookies: list[str] | None = None,
     ) -> None:
         self.status_code = status_code
         self.headers = headers
@@ -344,6 +354,7 @@ class Response:
         self.url = url
         self._text: str | None = None
         self._json: Any = None
+        self._raw_set_cookies: list[str] = raw_set_cookies or []
 
     @property
     def text(self) -> str:
@@ -368,6 +379,20 @@ class Response:
         """Raise HTTPError if status is not 2xx."""
         if not self.ok:
             raise HTTPError(self.status_code, self.text, self.url)
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        """Parse Set-Cookie headers into a ``{name: value}`` dict."""
+        result: dict[str, str] = {}
+        for raw in self._raw_set_cookies:
+            sc = http.cookies.SimpleCookie()
+            try:
+                sc.load(raw)
+            except http.cookies.CookieError:
+                continue
+            for name, morsel in sc.items():
+                result[name] = morsel.value
+        return result
 
     def _guess_encoding(self) -> str:
         return _guess_encoding_from_headers(self.headers)
@@ -612,6 +637,7 @@ class StreamingResponse:
         "_content_length",
         "_bytes_remaining",
         "_closed",
+        "_raw_set_cookies",
     )
 
     status_code: int
@@ -628,6 +654,7 @@ class StreamingResponse:
     _content_length: int | None
     _bytes_remaining: int | None
     _closed: bool
+    _raw_set_cookies: list[str]
 
     def __init__(self) -> None:
         raise TypeError("Use _from_sync() or _from_async()")
@@ -641,6 +668,7 @@ class StreamingResponse:
         resp: http.client.HTTPResponse,
         conn: http.client.HTTPConnection,
         content_encoding: str = "",
+        raw_set_cookies: list[str] | None = None,
     ) -> "StreamingResponse":
         obj = object.__new__(cls)
         obj.status_code = status_code
@@ -659,6 +687,7 @@ class StreamingResponse:
         obj._content_length = None
         obj._bytes_remaining = None
         obj._closed = False
+        obj._raw_set_cookies = raw_set_cookies or []
         return obj
 
     @classmethod
@@ -673,6 +702,7 @@ class StreamingResponse:
         content_length: int | None,
         timeout: float,
         content_encoding: str = "",
+        raw_set_cookies: list[str] | None = None,
     ) -> "StreamingResponse":
         obj = object.__new__(cls)
         obj.status_code = status_code
@@ -691,6 +721,7 @@ class StreamingResponse:
         obj._content_length = content_length
         obj._bytes_remaining = content_length
         obj._closed = False
+        obj._raw_set_cookies = raw_set_cookies or []
         return obj
 
     @property
@@ -702,6 +733,20 @@ class StreamingResponse:
         """Raise HTTPError if status is not 2xx."""
         if not self.ok:
             raise HTTPError(self.status_code, "", self.url)
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        """Parse Set-Cookie headers into a ``{name: value}`` dict."""
+        result: dict[str, str] = {}
+        for raw in self._raw_set_cookies:
+            sc = http.cookies.SimpleCookie()
+            try:
+                sc.load(raw)
+            except http.cookies.CookieError:
+                continue
+            for name, morsel in sc.items():
+                result[name] = morsel.value
+        return result
 
     # ── Sync iteration ──
 
@@ -1463,6 +1508,7 @@ def _prepare_request(
     files: dict[str, Any] | list[tuple[str, Any]] | None,
     params: dict[str, Any] | None,
     auth: tuple[str, str] | Auth | None,
+    cookies: dict[str, str] | None = None,
 ) -> tuple[str, bytes | None, CaseInsensitiveDict, Auth | None]:
     """Build URL, encode body, assemble headers, and normalize auth.
 
@@ -1471,8 +1517,9 @@ def _prepare_request(
     Header precedence (highest → lowest):
       1. auth headers (digest/basic — must override everything)
       2. user-supplied *headers*
-      3. body-derived defaults (Content-Type, Content-Length)
-      4. library defaults (User-Agent, Accept-Encoding)
+      3. cookies (serialised as ``Cookie`` header if not already set)
+      4. body-derived defaults (Content-Type, Content-Length)
+      5. library defaults (User-Agent, Accept-Encoding)
 
     All keys are normalised to lowercase via :class:`CaseInsensitiveDict`;
     no duplicate header names are ever emitted.
@@ -1494,6 +1541,11 @@ def _prepare_request(
         _headers_set_default(req_headers, "Content-Type", content_type)
     if body is not None:
         _headers_set_default(req_headers, "Content-Length", str(len(body)))
+
+    # Cookies — serialised as a single Cookie header (user header wins)
+    if cookies:
+        cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        _headers_set_default(req_headers, "Cookie", cookie_header)
 
     # User headers win over all of the above
     _headers_merge_user(req_headers, headers)
@@ -1746,6 +1798,7 @@ def _build_sync_response(
     resp: http.client.HTTPResponse,
     conn: http.client.HTTPConnection,
     stream: bool,
+    raw_set_cookies: list[str] | None = None,
 ) -> tuple[Response | StreamingResponse, bool]:
     """Build a final sync response (streaming or buffered).
 
@@ -1761,12 +1814,19 @@ def _build_sync_response(
             resp,
             conn,
             content_encoding=content_encoding,
+            raw_set_cookies=raw_set_cookies,
         ), False
 
     resp_body = resp.read()
     if content_encoding:
         resp_body = _decompress_body(resp_body, content_encoding)
-    return Response(status, resp_headers, resp_body, url), True
+    return Response(
+        status,
+        resp_headers,
+        resp_body,
+        url,
+        raw_set_cookies=raw_set_cookies,
+    ), True
 
 
 def _wrap_sync_errors(
@@ -1809,6 +1869,7 @@ def _sync_request(
     stream: bool = False,
     auth: tuple[str, str] | Auth | None = None,
     proxy: str | None = None,
+    cookies: dict[str, str] | None = None,
     _pool: _SyncConnectionPool | None = None,
 ) -> Response | StreamingResponse:
     """Perform a synchronous HTTP request.
@@ -1822,7 +1883,7 @@ def _sync_request(
            d. Connection lifecycle (pool release or close)
     """
     url, body, req_headers, auth_obj = _prepare_request(
-        method, url, headers, data, json, files, params, auth
+        method, url, headers, data, json, files, params, auth, cookies
     )
 
     redirects = 0
@@ -1850,7 +1911,11 @@ def _sync_request(
             try:
                 conn.request(method, request_path, body=body, headers=req_headers)
                 resp = conn.getresponse()
-                resp_headers = CaseInsensitiveDict(resp.getheaders())
+                raw_headers = resp.getheaders()
+                raw_set_cookies = [
+                    v for k, v in raw_headers if k.lower() == "set-cookie"
+                ]
+                resp_headers = CaseInsensitiveDict(raw_headers)
                 status = resp.status
 
                 if _is_redirect(status, resp_headers):
@@ -1890,6 +1955,7 @@ def _sync_request(
                     resp,
                     conn,
                     stream,
+                    raw_set_cookies=raw_set_cookies,
                 )
                 return result
             finally:
@@ -1917,14 +1983,14 @@ def _sync_request(
 async def _async_read_response_headers(
     reader: asyncio.StreamReader,
     timeout: float,
-) -> tuple[int, CaseInsensitiveDict]:
+) -> tuple[int, CaseInsensitiveDict, list[str]]:
     """Read HTTP status line and headers from an asyncio StreamReader.
 
     Does NOT consume the body -- the reader is left positioned at the
     start of the response body.
 
     Returns:
-        (status_code, headers_dict).
+        (status_code, headers_dict, raw_set_cookies).
     """
     # Status line: "HTTP/1.1 200 OK\r\n"
     status_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
@@ -1936,6 +2002,7 @@ async def _async_read_response_headers(
 
     # Headers until empty line
     headers: CaseInsensitiveDict = CaseInsensitiveDict()
+    raw_set_cookies: list[str] = []
     while True:
         line = await asyncio.wait_for(reader.readline(), timeout=timeout)
         decoded = line.decode("latin-1").rstrip("\r\n")
@@ -1943,9 +2010,13 @@ async def _async_read_response_headers(
             break
         if ":" in decoded:
             k, v = decoded.split(":", 1)
-            headers[k.strip()] = v.strip()
+            k_stripped = k.strip()
+            v_stripped = v.strip()
+            if k_stripped.lower() == "set-cookie":
+                raw_set_cookies.append(v_stripped)
+            headers[k_stripped] = v_stripped
 
-    return status_code, headers
+    return status_code, headers, raw_set_cookies
 
 
 async def _async_read_chunked_body(
@@ -2045,7 +2116,7 @@ async def _async_connect_via_proxy_tunnel(
     connect_headers += "\r\n"
     proxy_writer.write((connect_line + connect_headers).encode("latin-1"))
     await asyncio.wait_for(proxy_writer.drain(), timeout=timeout)
-    tunnel_status, _ = await _async_read_response_headers(proxy_reader, timeout)
+    tunnel_status, _, _ = await _async_read_response_headers(proxy_reader, timeout)
     if tunnel_status != 200:
         proxy_writer.close()
         # Tier 3: best-effort silent -- proxy tunnel teardown
@@ -2268,6 +2339,7 @@ def _build_async_streaming_response(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
     timeout: float,
+    raw_set_cookies: list[str] | None = None,
 ) -> StreamingResponse:
     """Build an async StreamingResponse from response metadata."""
     content_encoding = resp_headers.get("content-encoding", "")
@@ -2285,6 +2357,7 @@ def _build_async_streaming_response(
         content_length,
         timeout,
         content_encoding=content_encoding,
+        raw_set_cookies=raw_set_cookies,
     )
 
 
@@ -2306,6 +2379,7 @@ async def _async_request(
     stream: bool = False,
     auth: tuple[str, str] | Auth | None = None,
     proxy: str | None = None,
+    cookies: dict[str, str] | None = None,
     _pool: _AsyncConnectionPool | None = None,
 ) -> Response | StreamingResponse:
     """Perform an asynchronous HTTP request using asyncio streams.
@@ -2319,7 +2393,7 @@ async def _async_request(
            d. Connection lifecycle (pool release or close)
     """
     url, body, req_headers, auth_obj = _prepare_request(
-        method, url, headers, data, json, files, params, auth
+        method, url, headers, data, json, files, params, auth, cookies
     )
 
     redirects = 0
@@ -2349,7 +2423,9 @@ async def _async_request(
                 writer.write(body)
             await asyncio.wait_for(writer.drain(), timeout=timeout)
 
-            status, resp_headers = await _async_read_response_headers(reader, timeout)
+            status, resp_headers, raw_set_cookies = await _async_read_response_headers(
+                reader, timeout
+            )
 
             if _is_redirect(status, resp_headers):
                 await _async_read_body(reader, resp_headers, timeout)
@@ -2391,13 +2467,20 @@ async def _async_request(
                     reader,
                     writer,
                     timeout,
+                    raw_set_cookies=raw_set_cookies,
                 )
 
             content_encoding = resp_headers.get("content-encoding", "")
             resp_body = await _async_read_body(reader, resp_headers, timeout)
             if content_encoding:
                 resp_body = _decompress_body(resp_body, content_encoding)
-            return Response(status, resp_headers, resp_body, url)
+            return Response(
+                status,
+                resp_headers,
+                resp_body,
+                url,
+                raw_set_cookies=raw_set_cookies,
+            )
         except asyncio.TimeoutError:
             raise HttpTimeoutError(
                 f"Request to {url} timed out after {timeout}s",
@@ -2654,6 +2737,7 @@ class Client:
         self,
         *,
         headers: dict[str, str] | None = None,
+        cookies: dict[str, str] | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         verify: bool = True,
@@ -2662,6 +2746,7 @@ class Client:
         pool_size: int = DEFAULT_POOL_SIZE,
     ) -> None:
         self._base_headers = headers or {}
+        self._cookies: dict[str, str] = dict(cookies) if cookies else {}
         self._timeout = timeout
         self._max_redirects = max_redirects
         self._verify = verify
@@ -2676,6 +2761,11 @@ class Client:
         **kwargs: Any,
     ) -> Response | StreamingResponse:
         """Send an HTTP request."""
+        merged_cookies = dict(self._cookies)
+        per_request = kwargs.pop("cookies", None)
+        if per_request:
+            merged_cookies.update(per_request)
+        kwargs["cookies"] = merged_cookies or None
         kwargs.setdefault("timeout", self._timeout)
         kwargs.setdefault("max_redirects", self._max_redirects)
         kwargs.setdefault("verify", self._verify)
@@ -2683,7 +2773,9 @@ class Client:
         kwargs.setdefault("proxy", self._proxy)
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
-        return _sync_request(method, url, **kwargs)
+        result = _sync_request(method, url, **kwargs)
+        self._cookies.update(result.cookies)
+        return result
 
     def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
         return self.request("GET", url, **kwargs)
@@ -2740,6 +2832,7 @@ class AsyncClient:
         self,
         *,
         headers: dict[str, str] | None = None,
+        cookies: dict[str, str] | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         verify: bool = True,
@@ -2748,6 +2841,7 @@ class AsyncClient:
         pool_size: int = DEFAULT_POOL_SIZE,
     ) -> None:
         self._base_headers = headers or {}
+        self._cookies: dict[str, str] = dict(cookies) if cookies else {}
         self._timeout = timeout
         self._max_redirects = max_redirects
         self._verify = verify
@@ -2762,6 +2856,11 @@ class AsyncClient:
         **kwargs: Any,
     ) -> Response | StreamingResponse:
         """Send an async HTTP request."""
+        merged_cookies = dict(self._cookies)
+        per_request = kwargs.pop("cookies", None)
+        if per_request:
+            merged_cookies.update(per_request)
+        kwargs["cookies"] = merged_cookies or None
         kwargs.setdefault("timeout", self._timeout)
         kwargs.setdefault("max_redirects", self._max_redirects)
         kwargs.setdefault("verify", self._verify)
@@ -2769,7 +2868,9 @@ class AsyncClient:
         kwargs.setdefault("proxy", self._proxy)
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
-        return await _async_request(method, url, **kwargs)
+        result = await _async_request(method, url, **kwargs)
+        self._cookies.update(result.cookies)
+        return result
 
     async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
         return await self.request("GET", url, **kwargs)

--- a/httpclient/httpclient.py
+++ b/httpclient/httpclient.py
@@ -383,16 +383,7 @@ class Response:
     @property
     def cookies(self) -> dict[str, str]:
         """Parse Set-Cookie headers into a ``{name: value}`` dict."""
-        result: dict[str, str] = {}
-        for raw in self._raw_set_cookies:
-            sc = http.cookies.SimpleCookie()
-            try:
-                sc.load(raw)
-            except http.cookies.CookieError:
-                continue
-            for name, morsel in sc.items():
-                result[name] = morsel.value
-        return result
+        return _parse_cookies(self._raw_set_cookies)
 
     def _guess_encoding(self) -> str:
         return _guess_encoding_from_headers(self.headers)
@@ -419,6 +410,35 @@ class Response:
 
     def __repr__(self) -> str:
         return f"<Response [{self.status_code}]>"
+
+
+def _parse_cookies(raw_set_cookies: list[str]) -> dict[str, str]:
+    """Parse raw Set-Cookie header values into a ``{name: value}`` dict."""
+    result: dict[str, str] = {}
+    for raw in raw_set_cookies:
+        sc = http.cookies.SimpleCookie()
+        try:
+            sc.load(raw)
+        except http.cookies.CookieError:
+            continue
+        for name, morsel in sc.items():
+            result[name] = morsel.value
+    return result
+
+
+def _expired_cookie_names(raw_set_cookies: list[str]) -> set[str]:
+    """Return names of cookies with Max-Age=0 (deletion markers)."""
+    names: set[str] = set()
+    for raw in raw_set_cookies:
+        sc = http.cookies.SimpleCookie()
+        try:
+            sc.load(raw)
+        except http.cookies.CookieError:
+            continue
+        for name, morsel in sc.items():
+            if morsel.get("max-age") == "0":
+                names.add(name)
+    return names
 
 
 def _guess_encoding_from_headers(headers: CaseInsensitiveDict) -> str:
@@ -737,16 +757,7 @@ class StreamingResponse:
     @property
     def cookies(self) -> dict[str, str]:
         """Parse Set-Cookie headers into a ``{name: value}`` dict."""
-        result: dict[str, str] = {}
-        for raw in self._raw_set_cookies:
-            sc = http.cookies.SimpleCookie()
-            try:
-                sc.load(raw)
-            except http.cookies.CookieError:
-                continue
-            for name, morsel in sc.items():
-                result[name] = morsel.value
-        return result
+        return _parse_cookies(self._raw_set_cookies)
 
     # ── Sync iteration ──
 
@@ -1544,7 +1555,8 @@ def _prepare_request(
 
     # Cookies — serialised as a single Cookie header (user header wins)
     if cookies:
-        cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        sc = http.cookies.SimpleCookie(cookies)
+        cookie_header = sc.output(header="", sep="; ").strip()
         _headers_set_default(req_headers, "Cookie", cookie_header)
 
     # User headers win over all of the above
@@ -1888,6 +1900,7 @@ def _sync_request(
 
     redirects = 0
     _digest_attempted = False
+    accumulated_set_cookies: list[str] = []
     while True:
         scheme, host, port, path, is_https = _parse_url(url)
         close_conn = True
@@ -1912,9 +1925,9 @@ def _sync_request(
                 conn.request(method, request_path, body=body, headers=req_headers)
                 resp = conn.getresponse()
                 raw_headers = resp.getheaders()
-                raw_set_cookies = [
+                accumulated_set_cookies.extend(
                     v for k, v in raw_headers if k.lower() == "set-cookie"
-                ]
+                )
                 resp_headers = CaseInsensitiveDict(raw_headers)
                 status = resp.status
 
@@ -1955,7 +1968,7 @@ def _sync_request(
                     resp,
                     conn,
                     stream,
-                    raw_set_cookies=raw_set_cookies,
+                    raw_set_cookies=accumulated_set_cookies,
                 )
                 return result
             finally:
@@ -2398,6 +2411,7 @@ async def _async_request(
 
     redirects = 0
     _digest_attempted = False
+    accumulated_set_cookies: list[str] = []
     while True:
         scheme, host, port, path, is_https = _parse_url(url)
 
@@ -2423,9 +2437,10 @@ async def _async_request(
                 writer.write(body)
             await asyncio.wait_for(writer.drain(), timeout=timeout)
 
-            status, resp_headers, raw_set_cookies = await _async_read_response_headers(
+            status, resp_headers, iter_set_cookies = await _async_read_response_headers(
                 reader, timeout
             )
+            accumulated_set_cookies.extend(iter_set_cookies)
 
             if _is_redirect(status, resp_headers):
                 await _async_read_body(reader, resp_headers, timeout)
@@ -2467,7 +2482,7 @@ async def _async_request(
                     reader,
                     writer,
                     timeout,
-                    raw_set_cookies=raw_set_cookies,
+                    raw_set_cookies=accumulated_set_cookies,
                 )
 
             content_encoding = resp_headers.get("content-encoding", "")
@@ -2479,7 +2494,7 @@ async def _async_request(
                 resp_headers,
                 resp_body,
                 url,
-                raw_set_cookies=raw_set_cookies,
+                raw_set_cookies=accumulated_set_cookies,
             )
         except asyncio.TimeoutError:
             raise HttpTimeoutError(
@@ -2727,6 +2742,11 @@ class Client:
     Thread-safe: the underlying connection pool uses its own
     ``threading.Lock`` to protect shared state.
 
+    The cookie jar is a flat ``dict[str, str]`` — cookies are **not**
+    scoped by domain or path.  This is suitable for single-origin use
+    (e.g. an API client talking to one service).  For multi-origin
+    scenarios, manage cookies per-domain yourself.
+
     Usage::
 
         with Client(headers={"Authorization": "Bearer token"}) as c:
@@ -2775,6 +2795,8 @@ class Client:
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
         result = _sync_request(method, url, **kwargs)
         self._cookies.update(result.cookies)
+        for name in _expired_cookie_names(result._raw_set_cookies):
+            self._cookies.pop(name, None)
         return result
 
     def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
@@ -2821,6 +2843,11 @@ class AsyncClient:
 
     Safe for concurrent use from multiple asyncio tasks.  The underlying
     connection pool uses its own ``asyncio.Lock`` to protect shared state.
+
+    The cookie jar is a flat ``dict[str, str]`` — cookies are **not**
+    scoped by domain or path.  This is suitable for single-origin use
+    (e.g. an API client talking to one service).  For multi-origin
+    scenarios, manage cookies per-domain yourself.
 
     Usage::
 
@@ -2870,6 +2897,8 @@ class AsyncClient:
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
         result = await _async_request(method, url, **kwargs)
         self._cookies.update(result.cookies)
+        for name in _expired_cookie_names(result._raw_set_cookies):
+            self._cookies.pop(name, None)
         return result
 
     async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:

--- a/httpclient/test_httpclient_correctness.py
+++ b/httpclient/test_httpclient_correctness.py
@@ -1188,3 +1188,175 @@ class TestClientInterfaceParity:
             f"only in Client: {sync_methods - async_methods}\n"
             f"only in AsyncClient: {async_methods - sync_methods}"
         )
+
+
+# ── Cookie support ──
+
+
+class TestSyncCookies:
+    """Sync cookie parsing and sending."""
+
+    def test_response_cookies_single(self, httpbin_url):
+        """Response.cookies parses a single Set-Cookie header."""
+        r = get(f"{httpbin_url}/cookies/set?session=abc123")
+        assert "session" in r.cookies
+        assert r.cookies["session"] == "abc123"
+
+    def test_response_cookies_multiple(self, httpbin_url):
+        """Response.cookies parses multiple Set-Cookie headers."""
+        r = get(f"{httpbin_url}/cookies/set?a=1&b=2")
+        assert r.cookies == {"a": "1", "b": "2"}
+
+    def test_response_cookies_empty(self, httpbin_url):
+        """Response.cookies returns empty dict when no cookies set."""
+        r = get(f"{httpbin_url}/get")
+        assert r.cookies == {}
+
+    def test_send_cookies_kwarg(self, httpbin_url):
+        """cookies= kwarg sends Cookie header."""
+        r = get(f"{httpbin_url}/cookies", cookies={"token": "xyz"})
+        data = r.json()
+        assert data["cookies"]["token"] == "xyz"
+
+    def test_send_cookies_vs_httpx(self, httpbin_url):
+        """Cookie sending matches httpx behavior."""
+        cookies = {"sid": "session1", "lang": "en"}
+        zd = get(f"{httpbin_url}/cookies", cookies=cookies).json()
+        hx = httpx.get(f"{httpbin_url}/cookies", cookies=cookies).json()
+        assert zd["cookies"] == hx["cookies"]
+
+    def test_response_cookies_vs_httpx(self, httpbin_url):
+        """Response.cookies matches httpx cookie parsing."""
+        zd = get(f"{httpbin_url}/cookies/set?theme=dark&lang=en")
+        hx = httpx.get(f"{httpbin_url}/cookies/set?theme=dark&lang=en")
+        assert zd.cookies == dict(hx.cookies)
+
+    def test_delete_cookies(self, httpbin_url):
+        """Server can delete cookies via Max-Age=0."""
+        r = get(f"{httpbin_url}/cookies/delete?old=")
+        assert "old" in r.cookies
+        assert r.cookies["old"] == ""
+
+
+class TestSyncClientCookieJar:
+    """Sync Client session cookie persistence."""
+
+    def test_jar_persistence(self, httpbin_url):
+        """Cookies from server are sent on subsequent requests."""
+        with Client() as c:
+            c.get(f"{httpbin_url}/cookies/set?session=abc")
+            r = c.get(f"{httpbin_url}/cookies")
+            assert r.json()["cookies"]["session"] == "abc"
+
+    def test_jar_multiple_sets(self, httpbin_url):
+        """Multiple cookie sets accumulate in the jar."""
+        with Client() as c:
+            c.get(f"{httpbin_url}/cookies/set?a=1")
+            c.get(f"{httpbin_url}/cookies/set?b=2")
+            r = c.get(f"{httpbin_url}/cookies")
+            cookies = r.json()["cookies"]
+            assert cookies["a"] == "1"
+            assert cookies["b"] == "2"
+
+    def test_jar_per_request_override(self, httpbin_url):
+        """Per-request cookies override session cookies."""
+        with Client(cookies={"x": "session"}) as c:
+            r = c.get(f"{httpbin_url}/cookies", cookies={"x": "override"})
+            assert r.json()["cookies"]["x"] == "override"
+
+    def test_jar_init_cookies(self, httpbin_url):
+        """Cookies passed at init are sent."""
+        with Client(cookies={"init": "val"}) as c:
+            r = c.get(f"{httpbin_url}/cookies")
+            assert r.json()["cookies"]["init"] == "val"
+
+    def test_jar_vs_httpx_session(self, httpbin_url):
+        """Cookie jar behavior matches httpx.Client."""
+        with Client() as zc, httpx.Client() as hc:
+            zc.get(f"{httpbin_url}/cookies/set?token=abc")
+            hc.get(f"{httpbin_url}/cookies/set?token=abc")
+            zd = zc.get(f"{httpbin_url}/cookies").json()
+            hd = hc.get(f"{httpbin_url}/cookies").json()
+            assert zd["cookies"] == hd["cookies"]
+
+
+class TestAsyncCookies:
+    """Async cookie parsing and sending."""
+
+    @pytest.mark.asyncio
+    async def test_response_cookies_single(self, httpbin_url):
+        r = await async_get(f"{httpbin_url}/cookies/set?session=abc123")
+        assert r.cookies["session"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_response_cookies_multiple(self, httpbin_url):
+        r = await async_get(f"{httpbin_url}/cookies/set?a=1&b=2")
+        assert r.cookies == {"a": "1", "b": "2"}
+
+    @pytest.mark.asyncio
+    async def test_send_cookies_kwarg(self, httpbin_url):
+        r = await async_get(f"{httpbin_url}/cookies", cookies={"token": "xyz"})
+        assert r.json()["cookies"]["token"] == "xyz"
+
+    @pytest.mark.asyncio
+    async def test_send_cookies_vs_httpx(self, httpbin_url):
+        cookies = {"sid": "session1"}
+        zd = (await async_get(f"{httpbin_url}/cookies", cookies=cookies)).json()
+        async with httpx.AsyncClient() as hc:
+            hd = (await hc.get(f"{httpbin_url}/cookies", cookies=cookies)).json()
+        assert zd["cookies"] == hd["cookies"]
+
+
+class TestAsyncClientCookieJar:
+    """Async Client session cookie persistence."""
+
+    @pytest.mark.asyncio
+    async def test_jar_persistence(self, httpbin_url):
+        async with AsyncClient() as c:
+            await c.get(f"{httpbin_url}/cookies/set?session=abc")
+            r = await c.get(f"{httpbin_url}/cookies")
+            assert r.json()["cookies"]["session"] == "abc"
+
+    @pytest.mark.asyncio
+    async def test_jar_multiple_sets(self, httpbin_url):
+        async with AsyncClient() as c:
+            await c.get(f"{httpbin_url}/cookies/set?a=1")
+            await c.get(f"{httpbin_url}/cookies/set?b=2")
+            r = await c.get(f"{httpbin_url}/cookies")
+            cookies = r.json()["cookies"]
+            assert cookies["a"] == "1"
+            assert cookies["b"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_jar_init_cookies(self, httpbin_url):
+        async with AsyncClient(cookies={"init": "val"}) as c:
+            r = await c.get(f"{httpbin_url}/cookies")
+            assert r.json()["cookies"]["init"] == "val"
+
+    @pytest.mark.asyncio
+    async def test_jar_vs_httpx_session(self, httpbin_url):
+        async with AsyncClient() as zc, httpx.AsyncClient() as hc:
+            await zc.get(f"{httpbin_url}/cookies/set?token=abc")
+            await hc.get(f"{httpbin_url}/cookies/set?token=abc")
+            zd = (await zc.get(f"{httpbin_url}/cookies")).json()
+            hd = (await hc.get(f"{httpbin_url}/cookies")).json()
+            assert zd["cookies"] == hd["cookies"]
+
+
+class TestStreamingResponseCookies:
+    """Streaming response cookie support."""
+
+    def test_streaming_cookies(self, httpbin_url):
+        """StreamingResponse carries cookies."""
+        with get(f"{httpbin_url}/cookies/set?stream=yes", stream=True) as r:
+            assert r.cookies["stream"] == "yes"
+            r.read()
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_cookies(self, httpbin_url):
+        """Async StreamingResponse carries cookies."""
+        async with await async_get(
+            f"{httpbin_url}/cookies/set?stream=yes", stream=True
+        ) as r:
+            assert r.cookies["stream"] == "yes"
+            await r.aread()

--- a/httpclient/test_httpclient_correctness.py
+++ b/httpclient/test_httpclient_correctness.py
@@ -1238,6 +1238,23 @@ class TestSyncCookies:
         assert r.cookies["old"] == ""
 
 
+class TestSyncCookieRedirect:
+    """Cookies accumulated across redirect chains."""
+
+    def test_redirect_preserves_cookies(self, httpbin_url):
+        """Cookies set during a 302 redirect survive to the final response."""
+        r = get(f"{httpbin_url}/cookies/set-redirect?session=redir123")
+        assert r.cookies["session"] == "redir123"
+
+    def test_redirect_cookies_in_jar(self, httpbin_url):
+        """Client jar captures cookies set during redirects."""
+        with Client() as c:
+            c.get(f"{httpbin_url}/cookies/set-redirect?token=abc")
+            assert c._cookies["token"] == "abc"
+            r = c.get(f"{httpbin_url}/cookies")
+            assert r.json()["cookies"]["token"] == "abc"
+
+
 class TestSyncClientCookieJar:
     """Sync Client session cookie persistence."""
 
@@ -1269,6 +1286,14 @@ class TestSyncClientCookieJar:
         with Client(cookies={"init": "val"}) as c:
             r = c.get(f"{httpbin_url}/cookies")
             assert r.json()["cookies"]["init"] == "val"
+
+    def test_jar_deletion(self, httpbin_url):
+        """Max-Age=0 cookies are removed from the jar."""
+        with Client() as c:
+            c.get(f"{httpbin_url}/cookies/set?temp=val")
+            assert c._cookies["temp"] == "val"
+            c.get(f"{httpbin_url}/cookies/delete?temp=")
+            assert "temp" not in c._cookies
 
     def test_jar_vs_httpx_session(self, httpbin_url):
         """Cookie jar behavior matches httpx.Client."""
@@ -1307,6 +1332,15 @@ class TestAsyncCookies:
         assert zd["cookies"] == hd["cookies"]
 
 
+class TestAsyncCookieRedirect:
+    """Async cookies accumulated across redirect chains."""
+
+    @pytest.mark.asyncio
+    async def test_redirect_preserves_cookies(self, httpbin_url):
+        r = await async_get(f"{httpbin_url}/cookies/set-redirect?session=redir123")
+        assert r.cookies["session"] == "redir123"
+
+
 class TestAsyncClientCookieJar:
     """Async Client session cookie persistence."""
 
@@ -1332,6 +1366,14 @@ class TestAsyncClientCookieJar:
         async with AsyncClient(cookies={"init": "val"}) as c:
             r = await c.get(f"{httpbin_url}/cookies")
             assert r.json()["cookies"]["init"] == "val"
+
+    @pytest.mark.asyncio
+    async def test_jar_deletion(self, httpbin_url):
+        async with AsyncClient() as c:
+            await c.get(f"{httpbin_url}/cookies/set?temp=val")
+            assert c._cookies["temp"] == "val"
+            await c.get(f"{httpbin_url}/cookies/delete?temp=")
+            assert "temp" not in c._cookies
 
     @pytest.mark.asyncio
     async def test_jar_vs_httpx_session(self, httpbin_url):

--- a/httpserver/conftest.py
+++ b/httpserver/conftest.py
@@ -110,6 +110,40 @@ def _build_test_app(static_dir=None):
     async def response_obj(request):
         return Response(body="custom", status_code=200, content_type="text/html")
 
+    @app.get("/cookies/echo")
+    async def cookies_echo(request):
+        return JSONResponse({"cookies": request.cookies})
+
+    @app.get("/cookies/set")
+    async def cookies_set(request):
+        resp = JSONResponse({"set": dict(request.query_params)})
+        for name, values in request.query_params.items():
+            resp.set_cookie(name, values[0], path="/")
+        return resp
+
+    @app.get("/cookies/set-multiple")
+    async def cookies_set_multiple(request):
+        resp = JSONResponse({"set": dict(request.query_params)})
+        for name, values in request.query_params.items():
+            resp.set_cookie(
+                name,
+                values[0],
+                path="/",
+                httponly=True,
+                samesite="Lax",
+            )
+        return resp
+
+    @app.get("/cookies/delete")
+    async def cookies_delete(request):
+        from urllib.parse import parse_qs
+
+        params = parse_qs(request.query_string, keep_blank_values=True)
+        resp = JSONResponse({"deleted": list(params.keys())})
+        for name in params:
+            resp.delete_cookie(name, path="/")
+        return resp
+
     if static_dir:
         app.static("/static", static_dir)
 

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.0"
+# version = "0.4.0"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -48,6 +48,7 @@ import signal
 import sys
 from collections.abc import AsyncIterator, Callable
 from email.utils import formatdate
+from http.cookies import SimpleCookie
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
@@ -217,6 +218,7 @@ class Request:
         "app",
         "state",
         "_json",
+        "_cookies",
     )
 
     def __init__(
@@ -240,6 +242,24 @@ class Request:
         self.app = app
         self.state = State()
         self._json: Any = _SENTINEL
+        self._cookies: Any = _SENTINEL
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        """Parse the Cookie request header into a ``{name: value}`` dict."""
+        if self._cookies is _SENTINEL:
+            raw = self.headers.get("cookie", "")
+            if raw:
+                sc = SimpleCookie()
+                try:
+                    sc.load(raw)
+                except Exception:
+                    self._cookies = {}
+                else:
+                    self._cookies = {k: m.value for k, m in sc.items()}
+            else:
+                self._cookies = {}
+        return self._cookies
 
     def json(self) -> Any:
         """Parse body as JSON (cached)."""
@@ -259,6 +279,39 @@ class Request:
 # ── Response Classes ─────────────────────────────────────────────────────────
 
 
+def _build_set_cookie(
+    name: str,
+    value: str = "",
+    *,
+    max_age: int | None = None,
+    expires: str | None = None,
+    path: str | None = None,
+    domain: str | None = None,
+    secure: bool = False,
+    httponly: bool = False,
+    samesite: str | None = None,
+) -> str:
+    """Build a Set-Cookie header value string."""
+    sc = SimpleCookie()
+    sc[name] = value
+    morsel = sc[name]
+    if max_age is not None:
+        morsel["max-age"] = str(max_age)
+    if expires is not None:
+        morsel["expires"] = expires
+    if path is not None:
+        morsel["path"] = path
+    if domain is not None:
+        morsel["domain"] = domain
+    if secure:
+        morsel["secure"] = True
+    if httponly:
+        morsel["httponly"] = True
+    if samesite is not None:
+        morsel["samesite"] = samesite
+    return morsel.OutputString()
+
+
 class Response:
     """HTTP response with a fixed body.
 
@@ -269,7 +322,7 @@ class Response:
         content_type: Shorthand for ``Content-Type`` header.
     """
 
-    __slots__ = ("status_code", "headers", "body")
+    __slots__ = ("status_code", "headers", "body", "_cookie_headers")
 
     def __init__(
         self,
@@ -286,6 +339,70 @@ class Response:
             self.body = body
         if content_type is not None:
             self.headers["Content-Type"] = content_type
+        self._cookie_headers: list[str] = []
+
+    def set_cookie(
+        self,
+        name: str,
+        value: str = "",
+        *,
+        max_age: int | None = None,
+        expires: str | None = None,
+        path: str | None = None,
+        domain: str | None = None,
+        secure: bool = False,
+        httponly: bool = False,
+        samesite: str | None = None,
+    ) -> None:
+        """Append a Set-Cookie header to the response.
+
+        Args:
+            name: Cookie name.
+            value: Cookie value.
+            max_age: Max age in seconds.
+            expires: Expiry date string (HTTP date format).
+            path: Cookie path scope.
+            domain: Cookie domain scope.
+            secure: Restrict to HTTPS.
+            httponly: Restrict to HTTP (no JavaScript access).
+            samesite: SameSite attribute (``"Strict"``, ``"Lax"``, or ``"None"``).
+        """
+        self._cookie_headers.append(
+            _build_set_cookie(
+                name,
+                value,
+                max_age=max_age,
+                expires=expires,
+                path=path,
+                domain=domain,
+                secure=secure,
+                httponly=httponly,
+                samesite=samesite,
+            )
+        )
+
+    def delete_cookie(
+        self,
+        name: str,
+        *,
+        path: str | None = None,
+        domain: str | None = None,
+    ) -> None:
+        """Append a Set-Cookie header that expires the named cookie.
+
+        Args:
+            name: Cookie name to delete.
+            path: Must match the path used when the cookie was set.
+            domain: Must match the domain used when the cookie was set.
+        """
+        self.set_cookie(
+            name,
+            value="",
+            max_age=0,
+            expires="Thu, 01 Jan 1970 00:00:00 GMT",
+            path=path,
+            domain=domain,
+        )
 
     async def _write(self, writer: asyncio.StreamWriter) -> None:
         """Serialize and write the full HTTP response."""
@@ -299,6 +416,8 @@ class Response:
         buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
         for k, v in self.headers.items():
             buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        for cookie_line in self._cookie_headers:
+            buf.extend(f"Set-Cookie: {cookie_line}\r\n".encode("latin-1"))
         buf.extend(b"\r\n")
         buf.extend(self.body)
         writer.write(bytes(buf))
@@ -347,7 +466,14 @@ class StreamingResponse:
             callables.  Exceptions are logged and suppressed.
     """
 
-    __slots__ = ("_generator", "status_code", "headers", "content_type", "background")
+    __slots__ = (
+        "_generator",
+        "status_code",
+        "headers",
+        "content_type",
+        "background",
+        "_cookie_headers",
+    )
 
     def __init__(
         self,
@@ -362,6 +488,52 @@ class StreamingResponse:
         self.headers: dict[str, str] = headers.copy() if headers else {}
         self.content_type = content_type
         self.background = background
+        self._cookie_headers: list[str] = []
+
+    def set_cookie(
+        self,
+        name: str,
+        value: str = "",
+        *,
+        max_age: int | None = None,
+        expires: str | None = None,
+        path: str | None = None,
+        domain: str | None = None,
+        secure: bool = False,
+        httponly: bool = False,
+        samesite: str | None = None,
+    ) -> None:
+        """Append a Set-Cookie header to the response."""
+        self._cookie_headers.append(
+            _build_set_cookie(
+                name,
+                value,
+                max_age=max_age,
+                expires=expires,
+                path=path,
+                domain=domain,
+                secure=secure,
+                httponly=httponly,
+                samesite=samesite,
+            )
+        )
+
+    def delete_cookie(
+        self,
+        name: str,
+        *,
+        path: str | None = None,
+        domain: str | None = None,
+    ) -> None:
+        """Append a Set-Cookie header that expires the named cookie."""
+        self.set_cookie(
+            name,
+            value="",
+            max_age=0,
+            expires="Thu, 01 Jan 1970 00:00:00 GMT",
+            path=path,
+            domain=domain,
+        )
 
     async def _write(self, writer: asyncio.StreamWriter) -> None:
         """Write status line, headers, then stream the body."""
@@ -379,6 +551,8 @@ class StreamingResponse:
         buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
         for k, v in self.headers.items():
             buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        for cookie_line in self._cookie_headers:
+            buf.extend(f"Set-Cookie: {cookie_line}\r\n".encode("latin-1"))
         buf.extend(b"\r\n")
         writer.write(bytes(buf))
         await writer.drain()

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -48,7 +48,7 @@ import signal
 import sys
 from collections.abc import AsyncIterator, Callable
 from email.utils import formatdate
-from http.cookies import SimpleCookie
+from http.cookies import CookieError, SimpleCookie
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
@@ -253,7 +253,7 @@ class Request:
                 sc = SimpleCookie()
                 try:
                     sc.load(raw)
-                except Exception:
+                except CookieError:
                     self._cookies = {}
                 else:
                     self._cookies = {k: m.value for k, m in sc.items()}

--- a/httpserver/httpserver.py
+++ b/httpserver/httpserver.py
@@ -312,6 +312,54 @@ def _build_set_cookie(
     return morsel.OutputString()
 
 
+def _append_set_cookie(
+    cookie_headers: list[str],
+    name: str,
+    value: str = "",
+    *,
+    max_age: int | None = None,
+    expires: str | None = None,
+    path: str | None = None,
+    domain: str | None = None,
+    secure: bool = False,
+    httponly: bool = False,
+    samesite: str | None = None,
+) -> None:
+    """Append a Set-Cookie header value to the list."""
+    cookie_headers.append(
+        _build_set_cookie(
+            name,
+            value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
+        )
+    )
+
+
+def _append_delete_cookie(
+    cookie_headers: list[str],
+    name: str,
+    *,
+    path: str | None = None,
+    domain: str | None = None,
+) -> None:
+    """Append a Set-Cookie header that expires the named cookie."""
+    _append_set_cookie(
+        cookie_headers,
+        name,
+        value="",
+        max_age=0,
+        expires="Thu, 01 Jan 1970 00:00:00 GMT",
+        path=path,
+        domain=domain,
+    )
+
+
 class Response:
     """HTTP response with a fixed body.
 
@@ -367,18 +415,17 @@ class Response:
             httponly: Restrict to HTTP (no JavaScript access).
             samesite: SameSite attribute (``"Strict"``, ``"Lax"``, or ``"None"``).
         """
-        self._cookie_headers.append(
-            _build_set_cookie(
-                name,
-                value,
-                max_age=max_age,
-                expires=expires,
-                path=path,
-                domain=domain,
-                secure=secure,
-                httponly=httponly,
-                samesite=samesite,
-            )
+        _append_set_cookie(
+            self._cookie_headers,
+            name,
+            value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
         )
 
     def delete_cookie(
@@ -395,11 +442,9 @@ class Response:
             path: Must match the path used when the cookie was set.
             domain: Must match the domain used when the cookie was set.
         """
-        self.set_cookie(
+        _append_delete_cookie(
+            self._cookie_headers,
             name,
-            value="",
-            max_age=0,
-            expires="Thu, 01 Jan 1970 00:00:00 GMT",
             path=path,
             domain=domain,
         )
@@ -504,18 +549,17 @@ class StreamingResponse:
         samesite: str | None = None,
     ) -> None:
         """Append a Set-Cookie header to the response."""
-        self._cookie_headers.append(
-            _build_set_cookie(
-                name,
-                value,
-                max_age=max_age,
-                expires=expires,
-                path=path,
-                domain=domain,
-                secure=secure,
-                httponly=httponly,
-                samesite=samesite,
-            )
+        _append_set_cookie(
+            self._cookie_headers,
+            name,
+            value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
         )
 
     def delete_cookie(
@@ -526,11 +570,9 @@ class StreamingResponse:
         domain: str | None = None,
     ) -> None:
         """Append a Set-Cookie header that expires the named cookie."""
-        self.set_cookie(
+        _append_delete_cookie(
+            self._cookie_headers,
             name,
-            value="",
-            max_age=0,
-            expires="Thu, 01 Jan 1970 00:00:00 GMT",
             path=path,
             domain=domain,
         )

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -875,3 +875,112 @@ class TestLifespan:
             await app._run_shutdown_hooks()
 
         asyncio.run(_test())  # Should not raise
+
+
+# ── Cookie support ──
+
+
+class TestRequestCookies:
+    """Request.cookies property."""
+
+    def test_parse_cookies(self, server_url):
+        """Request.cookies parses Cookie header correctly."""
+        r = get(
+            f"{server_url}/cookies/echo",
+            headers={"Cookie": "a=1; b=hello"},
+        )
+        data = r.json()
+        assert data["cookies"] == {"a": "1", "b": "hello"}
+
+    def test_empty_cookies(self, server_url):
+        """Request.cookies returns empty dict when no Cookie header."""
+        r = get(f"{server_url}/cookies/echo")
+        assert r.json()["cookies"] == {}
+
+    def test_cookies_single(self, server_url):
+        """Single cookie is parsed."""
+        r = get(
+            f"{server_url}/cookies/echo",
+            headers={"Cookie": "session=abc123"},
+        )
+        assert r.json()["cookies"]["session"] == "abc123"
+
+
+class TestResponseSetCookie:
+    """Response.set_cookie() and delete_cookie()."""
+
+    def test_set_single_cookie(self, server_url):
+        """set_cookie sets a single Set-Cookie header."""
+        r = get(f"{server_url}/cookies/set?token=xyz")
+        assert "set-cookie" in r.headers or "Set-Cookie" in r.headers
+        assert r.cookies["token"] == "xyz"
+
+    def test_set_multiple_cookies(self, server_url):
+        """Multiple set_cookie calls produce multiple Set-Cookie headers."""
+        r = get(f"{server_url}/cookies/set?a=1&b=2")
+        cookies = r.cookies
+        assert cookies["a"] == "1"
+        assert cookies["b"] == "2"
+
+    def test_set_cookie_attributes(self, server_url):
+        """set_cookie with httponly and samesite."""
+        import http.client as hc
+
+        url_parts = server_url.replace("http://", "").split(":")
+        host, port = url_parts[0], int(url_parts[1])
+        conn = hc.HTTPConnection(host, port)
+        conn.request("GET", "/cookies/set-multiple?secure_test=val")
+        resp = conn.getresponse()
+        raw_headers = resp.getheaders()
+        set_cookie_headers = [v for k, v in raw_headers if k.lower() == "set-cookie"]
+        resp.read()
+        conn.close()
+        assert len(set_cookie_headers) >= 1
+        header = set_cookie_headers[0].lower()
+        assert "httponly" in header
+        assert "samesite=lax" in header
+
+    def test_delete_cookie(self, server_url):
+        """delete_cookie sets Max-Age=0 and epoch expires."""
+        import http.client as hc
+
+        url_parts = server_url.replace("http://", "").split(":")
+        host, port = url_parts[0], int(url_parts[1])
+        conn = hc.HTTPConnection(host, port)
+        conn.request("GET", "/cookies/delete?old=")
+        resp = conn.getresponse()
+        raw_headers = resp.getheaders()
+        set_cookie_headers = [v for k, v in raw_headers if k.lower() == "set-cookie"]
+        resp.read()
+        conn.close()
+        assert len(set_cookie_headers) >= 1
+        header = set_cookie_headers[0].lower()
+        assert "max-age=0" in header
+
+
+class TestCookieRoundTrip:
+    """Full cookie round-trip through the server."""
+
+    def test_set_then_echo(self, server_url):
+        """Set cookies, then verify they echo back."""
+        from httpclient import Client
+
+        with Client() as c:
+            c.get(f"{server_url}/cookies/set?session=test123")
+            r = c.get(f"{server_url}/cookies/echo")
+            assert r.json()["cookies"]["session"] == "test123"
+
+    def test_set_delete_echo(self, server_url):
+        """Set a cookie, delete it, verify it's gone."""
+        from httpclient import Client
+
+        with Client() as c:
+            c.get(f"{server_url}/cookies/set?temp=value")
+            r1 = c.get(f"{server_url}/cookies/echo")
+            assert "temp" in r1.json()["cookies"]
+
+            c.get(f"{server_url}/cookies/delete?temp=")
+            r2 = c.get(f"{server_url}/cookies/echo")
+            # After deletion, the cookie value should be empty
+            cookies = r2.json()["cookies"]
+            assert cookies.get("temp", "") == ""

--- a/httpserver/test_httpserver_correctness.py
+++ b/httpserver/test_httpserver_correctness.py
@@ -971,7 +971,7 @@ class TestCookieRoundTrip:
             assert r.json()["cookies"]["session"] == "test123"
 
     def test_set_delete_echo(self, server_url):
-        """Set a cookie, delete it, verify it's gone."""
+        """Set a cookie, delete it, verify jar removes it."""
         from httpclient import Client
 
         with Client() as c:
@@ -980,7 +980,6 @@ class TestCookieRoundTrip:
             assert "temp" in r1.json()["cookies"]
 
             c.get(f"{server_url}/cookies/delete?temp=")
+            assert "temp" not in c._cookies
             r2 = c.get(f"{server_url}/cookies/echo")
-            # After deletion, the cookie value should be empty
-            cookies = r2.json()["cookies"]
-            assert cookies.get("temp", "") == ""
+            assert "temp" not in r2.json()["cookies"]

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated": "2026-09-07T18:45:39.400062+00:00",
+  "generated": "2026-09-09T00:35:39.056157+00:00",
   "modules": {
     "a2a": {
       "description": "A2A (Agent-to-Agent Protocol) - Zero-dependency Python implementation",
@@ -163,24 +163,24 @@
       "files": [
         "httpclient/httpclient.py"
       ],
-      "version": "0.4.7",
+      "version": "0.5.0",
       "deps": [],
       "tier": "subsystem",
       "category": "network",
       "last_updated": "2026-09-06T14:22:58-05:00",
-      "content_hash": "899dc75942c0a16d534156c695c3d1e74734dde39a13cfa88c8647e6fc13b891"
+      "content_hash": "649521cc54a6bbbe6ca508dcc2ee9aa24a3599e98152459f0a837e0f2f05fe17"
     },
     "httpserver": {
       "description": "Zero-dependency async HTTP server with decorator-based routing",
       "files": [
         "httpserver/httpserver.py"
       ],
-      "version": "0.3.0",
+      "version": "0.4.0",
       "deps": [],
       "tier": "subsystem",
       "category": "network",
       "last_updated": "2026-09-04T00:55:25-05:00",
-      "content_hash": "6158246a65da53d2406a612aa58b5c7c4baca244344caaad38ff42d33283655e"
+      "content_hash": "60ba267559f842c6a7bf0ef52aa7afb7151db82acf614fc0e525aebbc96f3334"
     },
     "jsonrpc": {
       "description": "JSON-RPC 2.0 -- Zero-dependency Python implementation",


### PR DESCRIPTION
## Summary

- Add cookie support to both `httpclient` and `httpserver` modules
- Fix multi-`Set-Cookie` header loss in httpclient (previously `CaseInsensitiveDict` kept only the last value)
- Add session-level cookie jar to `Client` / `AsyncClient` with automatic persistence
- Add `Request.cookies`, `Response.set_cookie()`, and `Response.delete_cookie()` to httpserver
- All cookie parsing/building uses stdlib `http.cookies.SimpleCookie` (zero external deps)
- Tests compare against `httpx` for client-side cookie behavior

## Changes

### httpclient (0.4.7 → 0.5.0)
- `Response.cookies` / `StreamingResponse.cookies` property → `dict[str, str]`
- `cookies=` kwarg on all request functions (`get`, `post`, etc.)
- `Client` / `AsyncClient` session cookie jar (init + per-request override)
- Raw `Set-Cookie` values captured in `_raw_set_cookies` before `CaseInsensitiveDict` collapses them

### httpserver (0.3.0 → 0.4.0)
- `Request.cookies` property (lazy-parsed from `Cookie:` header)
- `Response.set_cookie(name, value, *, max_age, expires, path, domain, secure, httponly, samesite)`
- `Response.delete_cookie(name, *, path, domain)`
- Same methods on `StreamingResponse`; `FileResponse` / `JSONResponse` inherit

## Test plan

- [x] 22 new httpclient cookie tests (sync/async, bare API, Client jar, streaming, vs httpx)
- [x] 9 new httpserver cookie tests (request parsing, set/delete, round-trip)
- [x] All 299 existing + new tests pass
- [x] Lint (ruff), format (ruff-format), type check (ty), complexity (complexipy) all pass

Closes #150