### PR TITLE
fix: position-aware walkers to preserve parameter names matching schema keywords

### DIFF
--- a/jsonschema/jsonschema.py
+++ b/jsonschema/jsonschema.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.2.0"
+# version = "0.3.0"
 # deps = []
 # tier = "medium"
 # category = "validation"
@@ -57,6 +57,12 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 _DEFS_KEYS: set[str] = {"$defs", "definitions"}
+
+# Keys whose *values* are property-name maps (not schema nodes).
+# When a walker enters one of these, it must NOT treat the map's keys as
+# schema keywords — they are user-defined parameter names.  The map's
+# *values* are sub-schemas and should still be processed.
+_PROPERTY_MAP_KEYS: set[str] = {"properties", "patternProperties"}
 
 UNSUPPORTED_SCHEMA_KEYS: set[str] = {
     # JSON Schema meta
@@ -300,22 +306,30 @@ def _merge_allof_node(schema: dict[str, Any]) -> dict[str, Any]:
     return base
 
 
-def _walk_merge_allof(schema: dict[str, Any]) -> dict[str, Any]:
+def _walk_merge_allof(
+    schema: dict[str, Any],
+    *,
+    _in_property_map: bool = False,
+) -> dict[str, Any]:
     """Recursively merge all ``allOf`` nodes in *schema*."""
     # First recurse into children so nested allOf are resolved bottom-up.
     result: dict[str, Any] = {}
     for key, value in schema.items():
         if isinstance(value, dict):
-            result[key] = _walk_merge_allof(value)
+            result[key] = _walk_merge_allof(
+                value, _in_property_map=key in _PROPERTY_MAP_KEYS
+            )
         elif isinstance(value, list):
             result[key] = [
-                _walk_merge_allof(item) if isinstance(item, dict) else item
+                _walk_merge_allof(item, _in_property_map=False)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:
             result[key] = value
 
-    if "allOf" in result and isinstance(result["allOf"], list):
+    if not _in_property_map and "allOf" in result and isinstance(result["allOf"], list):
         result = _merge_allof_node(result)
     return result
 
@@ -367,21 +381,29 @@ def _simplify_node(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
-def _walk_simplify(schema: dict[str, Any]) -> dict[str, Any]:
+def _walk_simplify(
+    schema: dict[str, Any],
+    *,
+    _in_property_map: bool = False,
+) -> dict[str, Any]:
     """Recursively simplify all ``anyOf``/``oneOf`` nodes."""
     result: dict[str, Any] = {}
     for key, value in schema.items():
         if isinstance(value, dict):
-            result[key] = _walk_simplify(value)
+            result[key] = _walk_simplify(
+                value, _in_property_map=key in _PROPERTY_MAP_KEYS
+            )
         elif isinstance(value, list):
             result[key] = [
-                _walk_simplify(item) if isinstance(item, dict) else item
+                _walk_simplify(item, _in_property_map=False)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:
             result[key] = value
 
-    if result.keys() & {"anyOf", "oneOf"}:
+    if not _in_property_map and result.keys() & {"anyOf", "oneOf"}:
         result = _simplify_node(result)
     return result
 
@@ -411,17 +433,23 @@ def simplify_unions(schema: dict[str, Any]) -> dict[str, Any]:
 def _walk_sanitize(
     schema: dict[str, Any],
     strip: set[str],
+    *,
+    _in_property_map: bool = False,
 ) -> dict[str, Any]:
     """Recursively strip unsupported keys and prune orphaned ``required``."""
     result: dict[str, Any] = {}
     for key, value in schema.items():
-        if key in strip:
+        if not _in_property_map and key in strip:
             continue
         if isinstance(value, dict):
-            result[key] = _walk_sanitize(value, strip)
+            result[key] = _walk_sanitize(
+                value, strip, _in_property_map=key in _PROPERTY_MAP_KEYS
+            )
         elif isinstance(value, list):
             result[key] = [
-                _walk_sanitize(item, strip) if isinstance(item, dict) else item
+                _walk_sanitize(item, strip, _in_property_map=False)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:

--- a/jsonschema/jsonschema.py
+++ b/jsonschema/jsonschema.py
@@ -62,7 +62,7 @@ _DEFS_KEYS: set[str] = {"$defs", "definitions"}
 # When a walker enters one of these, it must NOT treat the map's keys as
 # schema keywords — they are user-defined parameter names.  The map's
 # *values* are sub-schemas and should still be processed.
-_PROPERTY_MAP_KEYS: set[str] = {"properties", "patternProperties"}
+_PROPERTY_MAP_KEYS: set[str] = {"properties", "patternProperties", "dependentSchemas"}
 
 UNSUPPORTED_SCHEMA_KEYS: set[str] = {
     # JSON Schema meta

--- a/jsonschema/test_jsonschema_correctness.py
+++ b/jsonschema/test_jsonschema_correctness.py
@@ -1103,6 +1103,30 @@ class TestPropertyNameCollisions:
         result = sanitize(schema)
         assert "const" in result["properties"]
 
+    def test_pattern_property_key_survives_sanitize(self):
+        schema = {
+            "type": "object",
+            "patternProperties": {
+                "title": {"type": "string"},
+                "^x-": {"type": "string"},
+            },
+        }
+        result = sanitize(schema, strip_keys={"title"})
+        assert "title" in result["patternProperties"]
+
+    def test_dependent_schemas_key_survives_sanitize(self):
+        schema = {
+            "type": "object",
+            "properties": {"mode": {"type": "string"}},
+            "dependentSchemas": {
+                "title": {
+                    "properties": {"subtitle": {"type": "string"}},
+                },
+            },
+        }
+        result = sanitize(schema, strip_keys={"title"})
+        assert "title" in result["dependentSchemas"]
+
     def test_schema_keyword_title_still_stripped(self):
         """title as a schema keyword (not a param name) should still be stripped."""
         schema = {
@@ -1225,9 +1249,7 @@ class TestPropertyNameCollisions:
         }
         result = flatten_schema(schema, strip_keys={"title", "nullable"})
         # Schema-level keywords stripped
-        assert "title" not in {
-            k for k in result if k != "properties" and k != "required" and k != "type"
-        }
+        assert "title" not in result
         assert "deprecated" not in result
         # Param "title" survives
         assert "title" in result["properties"]

--- a/jsonschema/test_jsonschema_correctness.py
+++ b/jsonschema/test_jsonschema_correctness.py
@@ -1043,3 +1043,214 @@ class TestEdgeCases:
             "const",
         }
         assert UNSUPPORTED_SCHEMA_KEYS == expected
+
+
+# ---------------------------------------------------------------------------
+# Regression: position-aware walkers (issue #153)
+# ---------------------------------------------------------------------------
+
+
+class TestPropertyNameCollisions:
+    """Parameter names that collide with schema keywords must survive."""
+
+    def _tool_schema(self, **props):
+        """Build a minimal tool-parameter schema."""
+        return {
+            "type": "object",
+            "properties": props,
+            "required": list(props),
+        }
+
+    # -- sanitize ----------------------------------------------------------
+
+    def test_param_named_title_survives_sanitize(self):
+        schema = self._tool_schema(
+            title={"type": "string"},
+            name={"type": "string"},
+        )
+        result = sanitize(schema, strip_keys={"title"})
+        assert "title" in result["properties"]
+        assert "title" in result["required"]
+
+    def test_param_named_deprecated_survives_sanitize(self):
+        schema = self._tool_schema(
+            deprecated={"type": "boolean"},
+            name={"type": "string"},
+        )
+        result = sanitize(schema)
+        assert "deprecated" in result["properties"]
+
+    def test_param_named_examples_survives_sanitize(self):
+        schema = self._tool_schema(
+            examples={"type": "array", "items": {"type": "string"}},
+            query={"type": "string"},
+        )
+        result = sanitize(schema)
+        assert "examples" in result["properties"]
+
+    def test_param_named_nullable_survives_sanitize(self):
+        schema = self._tool_schema(
+            nullable={"type": "boolean"},
+            value={"type": "integer"},
+        )
+        result = sanitize(schema, strip_keys={"nullable"})
+        assert "nullable" in result["properties"]
+
+    def test_param_named_const_survives_sanitize(self):
+        schema = self._tool_schema(
+            const={"type": "string"},
+        )
+        result = sanitize(schema)
+        assert "const" in result["properties"]
+
+    def test_schema_keyword_title_still_stripped(self):
+        """title as a schema keyword (not a param name) should still be stripped."""
+        schema = {
+            "type": "object",
+            "title": "MyModel",
+            "properties": {
+                "name": {"type": "string", "title": "Name Field"},
+            },
+        }
+        result = sanitize(schema, strip_keys={"title"})
+        assert "title" not in result
+        assert "title" not in result["properties"]["name"]
+        assert "name" in result["properties"]
+
+    def test_nested_object_param_named_title_survives(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "size": {"type": "integer"},
+                    },
+                    "required": ["title"],
+                },
+            },
+        }
+        result = sanitize(schema, strip_keys={"title"})
+        inner = result["properties"]["config"]["properties"]
+        assert "title" in inner
+        assert "title" in result["properties"]["config"]["required"]
+
+    def test_required_preserved_when_param_name_collides(self):
+        schema = self._tool_schema(
+            data_path={"type": "string"},
+            title={"type": "string"},
+            width={"type": "integer"},
+        )
+        result = sanitize(schema, strip_keys={"title"})
+        assert sorted(result["required"]) == ["data_path", "title", "width"]
+        assert sorted(result["properties"]) == ["data_path", "title", "width"]
+
+    # -- simplify_unions ---------------------------------------------------
+
+    def test_param_named_anyOf_survives_simplify(self):
+        """A parameter literally named 'anyOf' should not trigger simplification."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "anyOf": {"type": "string", "description": "filter expression"},
+                "name": {"type": "string"},
+            },
+        }
+        result = simplify_unions(schema)
+        assert "anyOf" in result["properties"]
+        assert result["properties"]["anyOf"]["type"] == "string"
+
+    # -- merge_allof -------------------------------------------------------
+
+    def test_param_named_allOf_survives_merge(self):
+        """A parameter literally named 'allOf' should not trigger merging."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "allOf": {"type": "string", "description": "merge strategy"},
+                "name": {"type": "string"},
+            },
+        }
+        result = merge_allof(schema)
+        assert "allOf" in result["properties"]
+        assert result["properties"]["allOf"]["type"] == "string"
+
+    # -- flatten_schema (full pipeline) ------------------------------------
+
+    def test_flatten_preserves_title_param(self):
+        """The exact scenario from toolregistry#265."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "data_path": {"type": "string", "description": "input file"},
+                "title": {"type": "string", "description": "figure title"},
+                "width": {"type": "integer", "default": 800},
+            },
+            "required": ["data_path", "title"],
+        }
+        result = flatten_schema(schema, strip_keys={"title", "nullable"})
+        assert sorted(result["properties"]) == ["data_path", "title", "width"]
+        assert sorted(result["required"]) == ["data_path", "title"]
+
+    def test_flatten_preserves_multiple_colliding_params(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "deprecated": {"type": "boolean", "default": False},
+                "examples": {"type": "array", "items": {"type": "string"}},
+                "name": {"type": "string"},
+            },
+            "required": ["title", "name"],
+        }
+        result = flatten_schema(schema, strip_keys={"title", "nullable"})
+        props = result["properties"]
+        assert "title" in props
+        assert "deprecated" in props
+        assert "examples" in props
+        assert "name" in props
+
+    def test_flatten_strips_schema_keywords_but_keeps_param_names(self):
+        """Schema-level title stripped, param-level title kept."""
+        schema = {
+            "type": "object",
+            "title": "PlotParams",
+            "deprecated": True,
+            "properties": {
+                "title": {"type": "string", "title": "Title", "deprecated": True},
+                "size": {"type": "integer", "examples": [100, 200]},
+            },
+            "required": ["title"],
+        }
+        result = flatten_schema(schema, strip_keys={"title", "nullable"})
+        # Schema-level keywords stripped
+        assert "title" not in {
+            k for k in result if k != "properties" and k != "required" and k != "type"
+        }
+        assert "deprecated" not in result
+        # Param "title" survives
+        assert "title" in result["properties"]
+        assert result["required"] == ["title"]
+        # Schema keywords inside param sub-schemas are stripped
+        assert "title" not in result["properties"]["title"]
+        assert "deprecated" not in result["properties"]["title"]
+        assert "examples" not in result["properties"]["size"]
+
+    def test_flatten_with_ref_and_colliding_param(self):
+        """$ref resolution + sanitization should not eat param named 'title'."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "title": {"$ref": "#/$defs/Title"},
+                "count": {"type": "integer"},
+            },
+            "required": ["title"],
+            "$defs": {
+                "Title": {"type": "string", "minLength": 1},
+            },
+        }
+        result = flatten_schema(schema, strip_keys={"title", "nullable"})
+        assert "title" in result["properties"]
+        assert result["properties"]["title"] == {"type": "string", "minLength": 1}
+        assert "title" in result["required"]


### PR DESCRIPTION
## Summary

Fixes #153. Upstream fix for [toolregistry#265](https://github.com/Oaklight/toolregistry/issues/265).

- `_walk_sanitize`, `_walk_simplify`, and `_walk_merge_allof` now track whether they are inside a `properties` (or `patternProperties`) map via an `_in_property_map` flag
- When inside a property map, key-level operations (strip, simplify, merge) are skipped — the keys are user-defined parameter names, not schema keywords
- Values inside property maps are still recursed into as sub-schemas
- Adds `_PROPERTY_MAP_KEYS` constant for the set of keys whose values are property-name maps
- Version bump to 0.3.0

Affected parameter names that were previously deleted: `title`, `deprecated`, `examples`, `nullable`, `const`, `readOnly`, `writeOnly`, and 10 others in `UNSUPPORTED_SCHEMA_KEYS`.

## Test plan

- [x] All 62 existing tests pass unchanged
- [x] 14 new regression tests in `TestPropertyNameCollisions` covering:
  - `sanitize()`: params named `title`, `deprecated`, `examples`, `nullable`, `const`
  - Schema-keyword `title` still stripped at schema level
  - Nested object with colliding param names
  - `required` array preservation
  - `simplify_unions()`: param named `anyOf` survives
  - `merge_allof()`: param named `allOf` survives
  - `flatten_schema()`: full pipeline with colliding params, `$ref` + collision, mixed schema-keyword vs param-name stripping